### PR TITLE
Add sorting and deletion for queue and local playlists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,20 @@ jobs:
     - name: Build Debug APK
       run: ./gradlew assembleDebug
 
-    - name: Upload Debug APK
+    - name: Upload ABI Split Debug APKs
       uses: actions/upload-artifact@v4
       with:
-        name: app-debug
-        path: app/build/outputs/apk/debug/*.apk
+        name: app-debug-splits
+        path: |
+          app/build/outputs/apk/debug/*-arm64-v8a-debug.apk
+          app/build/outputs/apk/debug/*-armeabi-v7a-debug.apk
+        if-no-files-found: error
+        retention-days: 14
+
+    - name: Upload Universal Debug APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: app-debug-universal
+        path: app/build/outputs/apk/debug/*-universal-debug.apk
+        if-no-files-found: error
         retention-days: 14

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
             isEnable = true
             reset()
             include("arm64-v8a", "armeabi-v7a")
-            isUniversalApk = false
+            isUniversalApk = true
         }
     }
     //Only for Release apk that is why I hardcoded cause if you want to make as a maintainer release apk you can change here in future we will make it the correct way

--- a/app/src/main/java/com/ivor/ivormusic/data/PlaylistRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/PlaylistRepository.kt
@@ -111,6 +111,21 @@ class PlaylistRepository(private val context: Context) {
         val updatedPlaylist = playlist.copy(songs = sortedSongs)
         savePlaylist(updatedPlaylist)
     }
+
+    suspend fun moveSongInPlaylist(playlistId: String, fromIndex: Int, toIndex: Int) = withContext(Dispatchers.IO) {
+        val currentList = _userPlaylists.value
+        val playlist = currentList.find { it.id == playlistId } ?: return@withContext
+        if (fromIndex == toIndex) return@withContext
+        if (fromIndex !in playlist.songs.indices || toIndex !in playlist.songs.indices) return@withContext
+
+        val reorderedSongs = playlist.songs.toMutableList().apply {
+            val movedSong = removeAt(fromIndex)
+            add(toIndex, movedSong)
+        }
+
+        val updatedPlaylist = playlist.copy(songs = reorderedSongs)
+        savePlaylist(updatedPlaylist)
+    }
     
     suspend fun deletePlaylist(playlistId: String) = withContext(Dispatchers.IO) {
         val file = File(playlistDir, "$playlistId.json")

--- a/app/src/main/java/com/ivor/ivormusic/data/PlaylistRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/PlaylistRepository.kt
@@ -97,6 +97,20 @@ class PlaylistRepository(private val context: Context) {
         )
         savePlaylist(updatedPlaylist)
     }
+
+    suspend fun sortPlaylistSongs(playlistId: String, ascending: Boolean = true) = withContext(Dispatchers.IO) {
+        val currentList = _userPlaylists.value
+        val playlist = currentList.find { it.id == playlistId } ?: return@withContext
+
+        val sortedSongs = if (ascending) {
+            playlist.songs.sortedBy { it.title.lowercase() }
+        } else {
+            playlist.songs.sortedByDescending { it.title.lowercase() }
+        }
+
+        val updatedPlaylist = playlist.copy(songs = sortedSongs)
+        savePlaylist(updatedPlaylist)
+    }
     
     suspend fun deletePlaylist(playlistId: String) = withContext(Dispatchers.IO) {
         val file = File(playlistDir, "$playlistId.json")

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
@@ -219,6 +219,22 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         }
 
     }
+
+    fun isLocalPlaylist(playlistId: String): Boolean {
+        return playlistRepository.userPlaylists.value.any { it.id == playlistId }
+    }
+
+    fun removeSongFromLocalPlaylist(playlistId: String, songId: String) {
+        viewModelScope.launch {
+            playlistRepository.removeSongFromPlaylist(playlistId, songId)
+        }
+    }
+
+    fun sortLocalPlaylist(playlistId: String, ascending: Boolean) {
+        viewModelScope.launch {
+            playlistRepository.sortPlaylistSongs(playlistId, ascending)
+        }
+    }
     
 
     

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
@@ -224,16 +224,12 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         return playlistRepository.userPlaylists.value.any { it.id == playlistId }
     }
 
-    fun removeSongFromLocalPlaylist(playlistId: String, songId: String) {
-        viewModelScope.launch {
-            playlistRepository.removeSongFromPlaylist(playlistId, songId)
-        }
+    suspend fun removeSongFromLocalPlaylist(playlistId: String, songId: String) {
+        playlistRepository.removeSongFromPlaylist(playlistId, songId)
     }
 
-    fun sortLocalPlaylist(playlistId: String, ascending: Boolean) {
-        viewModelScope.launch {
-            playlistRepository.sortPlaylistSongs(playlistId, ascending)
-        }
+    suspend fun sortLocalPlaylist(playlistId: String, ascending: Boolean) {
+        playlistRepository.sortPlaylistSongs(playlistId, ascending)
     }
     
 

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
@@ -231,6 +231,10 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     suspend fun sortLocalPlaylist(playlistId: String, ascending: Boolean) {
         playlistRepository.sortPlaylistSongs(playlistId, ascending)
     }
+
+    suspend fun moveSongInLocalPlaylist(playlistId: String, fromIndex: Int, toIndex: Int) {
+        playlistRepository.moveSongInPlaylist(playlistId, fromIndex, toIndex)
+    }
     
 
     

--- a/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
@@ -642,7 +642,11 @@ fun ExpressivePlaylistCard(
 }
 
 @Composable
-fun SongListItem(song: Song, onClick: () -> Unit) {
+fun SongListItem(
+    song: Song,
+    onClick: () -> Unit,
+    trailingContent: (@Composable () -> Unit)? = null
+) {
     ListItem(
         headlineContent = { Text(song.title, maxLines = 1, overflow = TextOverflow.Ellipsis, fontWeight = FontWeight.SemiBold) },
         supportingContent = { Text(song.artist, maxLines = 1, overflow = TextOverflow.Ellipsis) },
@@ -658,6 +662,7 @@ fun SongListItem(song: Song, onClick: () -> Unit) {
                     Box(contentAlignment = Alignment.Center) { Icon(Icons.Rounded.MusicNote, null, tint = MaterialTheme.colorScheme.onSurfaceVariant) }
             }
         },
+        trailingContent = trailingContent,
         modifier = Modifier.clickable(onClick = onClick),
         colors = ListItemDefaults.colors(containerColor = Color.Transparent)
     )
@@ -693,10 +698,12 @@ fun PlaylistDetailScreen(
     var songs by remember { mutableStateOf(preloadedSongs ?: emptyList()) }
     val isLoading by viewModel.isLoading.collectAsState()
     val isFetching = remember { mutableStateOf(songs.isEmpty()) }
+    val isLocalPlaylist = remember(playlist.id) { viewModel.isLocalPlaylist(playlist.id) }
     
     // Search State
     var searchQuery by remember { mutableStateOf("") }
     var isSearchActive by remember { mutableStateOf(false) }
+    var showSortMenu by remember { mutableStateOf(false) }
 
     // Scroll State for FAB and App Bar
     val listState = androidx.compose.foundation.lazy.rememberLazyListState()
@@ -716,6 +723,12 @@ fun PlaylistDetailScreen(
             isFetching.value = true
             songs = viewModel.fetchPlaylistSongs(playlist.id)
             isFetching.value = false
+        }
+    }
+
+    LaunchedEffect(playlist.id, isLocalPlaylist, isLoading) {
+        if (isLocalPlaylist) {
+            songs = viewModel.fetchPlaylistSongs(playlist.id)
         }
     }
 
@@ -742,6 +755,36 @@ fun PlaylistDetailScreen(
                     }
                 },
                 actions = {
+                    if (isLocalPlaylist) {
+                        Box {
+                            IconButton(onClick = { showSortMenu = true }) {
+                                Icon(
+                                    imageVector = Icons.Rounded.SortByAlpha,
+                                    contentDescription = "Sort playlist"
+                                )
+                            }
+                            DropdownMenu(
+                                expanded = showSortMenu,
+                                onDismissRequest = { showSortMenu = false }
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text("Title A-Z") },
+                                    onClick = {
+                                        viewModel.sortLocalPlaylist(playlist.id, ascending = true)
+                                        showSortMenu = false
+                                    }
+                                )
+                                DropdownMenuItem(
+                                    text = { Text("Title Z-A") },
+                                    onClick = {
+                                        viewModel.sortLocalPlaylist(playlist.id, ascending = false)
+                                        showSortMenu = false
+                                    }
+                                )
+                            }
+                        }
+                    }
+
                     IconButton(onClick = { isSearchActive = !isSearchActive }) {
                         Icon(
                             imageVector = if (isSearchActive) Icons.Rounded.Close else Icons.Rounded.Search,
@@ -887,7 +930,19 @@ fun PlaylistDetailScreen(
                     items(filteredSongs) { song ->
                         SongListItem(
                             song = song, 
-                            onClick = { onPlayQueue(filteredSongs, song) }
+                            onClick = { onPlayQueue(filteredSongs, song) },
+                            trailingContent = if (isLocalPlaylist) {
+                                {
+                                    IconButton(
+                                        onClick = { viewModel.removeSongFromLocalPlaylist(playlist.id, song.id) }
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Rounded.Delete,
+                                            contentDescription = "Remove from playlist"
+                                        )
+                                    }
+                                }
+                            } else null
                         )
                     }
                 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
@@ -44,6 +44,7 @@ import com.ivor.ivormusic.ui.artist.ArtistScreen
 import com.ivor.ivormusic.ui.components.ExpressivePullToRefresh
 import androidx.compose.foundation.ExperimentalFoundationApi
 import com.ivor.ivormusic.ui.home.HomeViewModel
+import kotlinx.coroutines.launch
 
 /**
  * The Main Library Navigation Hub.
@@ -696,9 +697,9 @@ fun PlaylistDetailScreen(
     isAlbum: Boolean = false
 ) {
     var songs by remember { mutableStateOf(preloadedSongs ?: emptyList()) }
-    val isLoading by viewModel.isLoading.collectAsState()
     val isFetching = remember { mutableStateOf(songs.isEmpty()) }
     val isLocalPlaylist = remember(playlist.id) { viewModel.isLocalPlaylist(playlist.id) }
+    val coroutineScope = rememberCoroutineScope()
     
     // Search State
     var searchQuery by remember { mutableStateOf("") }
@@ -726,7 +727,7 @@ fun PlaylistDetailScreen(
         }
     }
 
-    LaunchedEffect(playlist.id, isLocalPlaylist, isLoading) {
+    LaunchedEffect(playlist.id, isLocalPlaylist) {
         if (isLocalPlaylist) {
             songs = viewModel.fetchPlaylistSongs(playlist.id)
         }
@@ -770,14 +771,20 @@ fun PlaylistDetailScreen(
                                 DropdownMenuItem(
                                     text = { Text("Title A-Z") },
                                     onClick = {
-                                        viewModel.sortLocalPlaylist(playlist.id, ascending = true)
+                                        coroutineScope.launch {
+                                            viewModel.sortLocalPlaylist(playlist.id, ascending = true)
+                                            songs = viewModel.fetchPlaylistSongs(playlist.id)
+                                        }
                                         showSortMenu = false
                                     }
                                 )
                                 DropdownMenuItem(
                                     text = { Text("Title Z-A") },
                                     onClick = {
-                                        viewModel.sortLocalPlaylist(playlist.id, ascending = false)
+                                        coroutineScope.launch {
+                                            viewModel.sortLocalPlaylist(playlist.id, ascending = false)
+                                            songs = viewModel.fetchPlaylistSongs(playlist.id)
+                                        }
                                         showSortMenu = false
                                     }
                                 )
@@ -934,7 +941,12 @@ fun PlaylistDetailScreen(
                             trailingContent = if (isLocalPlaylist) {
                                 {
                                     IconButton(
-                                        onClick = { viewModel.removeSongFromLocalPlaylist(playlist.id, song.id) }
+                                        onClick = {
+                                            coroutineScope.launch {
+                                                viewModel.removeSongFromLocalPlaylist(playlist.id, song.id)
+                                                songs = viewModel.fetchPlaylistSongs(playlist.id)
+                                            }
+                                        }
                                     ) {
                                         Icon(
                                             imageVector = Icons.Rounded.Delete,

--- a/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
@@ -6,9 +6,11 @@ import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -36,6 +38,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.PlaylistDisplayItem
@@ -705,6 +708,8 @@ fun PlaylistDetailScreen(
     var searchQuery by remember { mutableStateOf("") }
     var isSearchActive by remember { mutableStateOf(false) }
     var showSortMenu by remember { mutableStateOf(false) }
+    var draggingSongId by remember { mutableStateOf<String?>(null) }
+    var dragOffsetY by remember { mutableFloatStateOf(0f) }
 
     // Scroll State for FAB and App Bar
     val listState = androidx.compose.foundation.lazy.rememberLazyListState()
@@ -934,7 +939,7 @@ fun PlaylistDetailScreen(
                         }
                     }
                 } else {
-                    items(filteredSongs) { song ->
+                    itemsIndexed(filteredSongs, key = { _, song -> "playlist_${song.id}" }) { _, song ->
                         SongListItem(
                             song = song, 
                             onClick = { onPlayQueue(filteredSongs, song) },
@@ -953,6 +958,52 @@ fun PlaylistDetailScreen(
                                             contentDescription = "Remove from playlist"
                                         )
                                     }
+                                    Icon(
+                                        imageVector = Icons.Rounded.DragHandle,
+                                        contentDescription = "Reorder playlist item",
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        modifier = Modifier.pointerInput(songs, searchQuery) {
+                                            detectDragGesturesAfterLongPress(
+                                                onDragStart = {
+                                                    draggingSongId = song.id
+                                                    dragOffsetY = 0f
+                                                },
+                                                onDragEnd = {
+                                                    draggingSongId = null
+                                                    dragOffsetY = 0f
+                                                },
+                                                onDragCancel = {
+                                                    draggingSongId = null
+                                                    dragOffsetY = 0f
+                                                }
+                                            ) { change, dragAmount ->
+                                                change.consume()
+                                                if (searchQuery.isNotBlank()) return@detectDragGesturesAfterLongPress
+
+                                                val activeSongId = draggingSongId ?: return@detectDragGesturesAfterLongPress
+                                                val fromIndex = songs.indexOfFirst { it.id == activeSongId }
+                                                if (fromIndex == -1) return@detectDragGesturesAfterLongPress
+
+                                                val dragStepPx = 72.dp.toPx()
+                                                dragOffsetY += dragAmount.y
+                                                if (dragOffsetY > dragStepPx && fromIndex < songs.lastIndex) {
+                                                    coroutineScope.launch {
+                                                        viewModel.moveSongInLocalPlaylist(playlist.id, fromIndex, fromIndex + 1)
+                                                        songs = viewModel.fetchPlaylistSongs(playlist.id)
+                                                        draggingSongId = songs.getOrNull(fromIndex + 1)?.id
+                                                    }
+                                                    dragOffsetY = 0f
+                                                } else if (dragOffsetY < -dragStepPx && fromIndex > 0) {
+                                                    coroutineScope.launch {
+                                                        viewModel.moveSongInLocalPlaylist(playlist.id, fromIndex, fromIndex - 1)
+                                                        songs = viewModel.fetchPlaylistSongs(playlist.id)
+                                                        draggingSongId = songs.getOrNull(fromIndex - 1)?.id
+                                                    }
+                                                    dragOffsetY = 0f
+                                                }
+                                            }
+                                        }
+                                    )
                                 }
                             } else null
                         )

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/GesturePlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/GesturePlayerContent.kt
@@ -12,6 +12,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
@@ -122,6 +123,7 @@ fun GesturePlayerSheetContent(
                     currentSong = currentSong,
                     onSongClick = { song -> viewModel.playQueue(currentQueue, song) },
                     onRemoveSong = { song -> viewModel.removeFromQueue(song.id) },
+                    onMoveSong = { fromIndex, toIndex -> viewModel.moveSongInQueue(fromIndex, toIndex) },
                     onSortQueue = { ascending -> viewModel.sortQueue(ascending) },
                     onCollapse = onCollapse,
                     onBackToPlayer = { showQueue = false },
@@ -1014,6 +1016,7 @@ private fun GestureQueueView(
     currentSong: Song?,
     onSongClick: (Song) -> Unit,
     onRemoveSong: (Song) -> Unit,
+    onMoveSong: (Int, Int) -> Unit,
     onSortQueue: (Boolean) -> Unit,
     onCollapse: () -> Unit,
     onBackToPlayer: () -> Unit,
@@ -1027,6 +1030,9 @@ private fun GestureQueueView(
     onSurfaceVariantColor: Color
 ) {
     var showSortMenu by remember { mutableStateOf(false) }
+    var draggingIndex by remember { mutableIntStateOf(-1) }
+    var dragOffsetY by remember { mutableFloatStateOf(0f) }
+    val dragStepPx = with(LocalDensity.current) { 72.dp.toPx() }
     // Guard against invalid dimensions during transitions
     BoxWithConstraints(
         modifier = Modifier
@@ -1384,6 +1390,42 @@ private fun GestureQueueView(
                                         tint = onSurfaceVariantColor
                                     )
                                 }
+
+                                Icon(
+                                    imageVector = Icons.Default.DragHandle,
+                                    contentDescription = "Reorder queue item",
+                                    tint = onSurfaceVariantColor,
+                                    modifier = Modifier.pointerInput(queue.size) {
+                                        detectDragGesturesAfterLongPress(
+                                            onDragStart = {
+                                                draggingIndex = index
+                                                dragOffsetY = 0f
+                                            },
+                                            onDragEnd = {
+                                                draggingIndex = -1
+                                                dragOffsetY = 0f
+                                            },
+                                            onDragCancel = {
+                                                draggingIndex = -1
+                                                dragOffsetY = 0f
+                                            }
+                                        ) { change, dragAmount ->
+                                            change.consume()
+                                            if (draggingIndex !in queue.indices) return@detectDragGesturesAfterLongPress
+
+                                            dragOffsetY += dragAmount.y
+                                            if (dragOffsetY > dragStepPx && draggingIndex < queue.lastIndex) {
+                                                onMoveSong(draggingIndex, draggingIndex + 1)
+                                                draggingIndex += 1
+                                                dragOffsetY = 0f
+                                            } else if (dragOffsetY < -dragStepPx && draggingIndex > 0) {
+                                                onMoveSong(draggingIndex, draggingIndex - 1)
+                                                draggingIndex -= 1
+                                                dragOffsetY = 0f
+                                            }
+                                        }
+                                    }
+                                )
                             }
                         }
                     }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/GesturePlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/GesturePlayerContent.kt
@@ -121,6 +121,8 @@ fun GesturePlayerSheetContent(
                     queue = currentQueue,
                     currentSong = currentSong,
                     onSongClick = { song -> viewModel.playQueue(currentQueue, song) },
+                    onRemoveSong = { song -> viewModel.removeFromQueue(song.id) },
+                    onSortQueue = { ascending -> viewModel.sortQueue(ascending) },
                     onCollapse = onCollapse,
                     onBackToPlayer = { showQueue = false },
                     onLoadMore = onLoadMore,
@@ -1011,6 +1013,8 @@ private fun GestureQueueView(
     queue: List<Song>,
     currentSong: Song?,
     onSongClick: (Song) -> Unit,
+    onRemoveSong: (Song) -> Unit,
+    onSortQueue: (Boolean) -> Unit,
     onCollapse: () -> Unit,
     onBackToPlayer: () -> Unit,
     onLoadMore: () -> Unit,
@@ -1022,6 +1026,7 @@ private fun GestureQueueView(
     onSurfaceColor: Color,
     onSurfaceVariantColor: Color
 ) {
+    var showSortMenu by remember { mutableStateOf(false) }
     // Guard against invalid dimensions during transitions
     BoxWithConstraints(
         modifier = Modifier
@@ -1078,16 +1083,51 @@ private fun GestureQueueView(
                     }
                 }
                 
-                FilledIconButton(
-                    onClick = onBackToPlayer,
-                    shape = CircleShape,
-                    colors = IconButtonDefaults.filledIconButtonColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                        contentColor = MaterialTheme.colorScheme.onSurface
-                    ),
-                    modifier = Modifier.size(48.dp)
-                ) {
-                    Icon(Icons.Rounded.MusicNote, "Now Playing", modifier = Modifier.size(24.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box {
+                        FilledIconButton(
+                            onClick = { showSortMenu = true },
+                            shape = CircleShape,
+                            colors = IconButtonDefaults.filledIconButtonColors(
+                                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                                contentColor = MaterialTheme.colorScheme.onSurface
+                            ),
+                            modifier = Modifier.size(48.dp)
+                        ) {
+                            Icon(Icons.Default.SortByAlpha, "Sort queue", modifier = Modifier.size(22.dp))
+                        }
+                        DropdownMenu(
+                            expanded = showSortMenu,
+                            onDismissRequest = { showSortMenu = false }
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text("Title A-Z") },
+                                onClick = {
+                                    onSortQueue(true)
+                                    showSortMenu = false
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Text("Title Z-A") },
+                                onClick = {
+                                    onSortQueue(false)
+                                    showSortMenu = false
+                                }
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    FilledIconButton(
+                        onClick = onBackToPlayer,
+                        shape = CircleShape,
+                        colors = IconButtonDefaults.filledIconButtonColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                            contentColor = MaterialTheme.colorScheme.onSurface
+                        ),
+                        modifier = Modifier.size(48.dp)
+                    ) {
+                        Icon(Icons.Rounded.MusicNote, "Now Playing", modifier = Modifier.size(24.dp))
+                    }
                 }
             }
             
@@ -1335,6 +1375,14 @@ private fun GestureQueueView(
                                         modifier = Modifier.size(16.dp)
                                     )
                                     Spacer(modifier = Modifier.width(8.dp))
+                                }
+
+                                IconButton(onClick = { onRemoveSong(song) }) {
+                                    Icon(
+                                        imageVector = Icons.Default.Delete,
+                                        contentDescription = "Remove from queue",
+                                        tint = onSurfaceVariantColor
+                                    )
                                 }
                             }
                         }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -37,6 +38,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import androidx.media3.common.Player
 import coil.compose.AsyncImage
@@ -117,6 +119,7 @@ fun PlayerSheetContent(
                     currentSong = currentSong,
                     onSongClick = { song -> viewModel.playQueue(currentQueue, song) },
                     onRemoveSong = { song -> viewModel.removeFromQueue(song.id) },
+                    onMoveSong = { fromIndex, toIndex -> viewModel.moveSongInQueue(fromIndex, toIndex) },
                     onSortQueue = { ascending -> viewModel.sortQueue(ascending) },
                     onLoadMore = onLoadMore,
                     isLoadingMore = isLoadingMore,
@@ -747,6 +750,7 @@ private fun ExpressiveQueueView(
     currentSong: Song?,
     onSongClick: (Song) -> Unit,
     onRemoveSong: (Song) -> Unit,
+    onMoveSong: (Int, Int) -> Unit,
     onSortQueue: (Boolean) -> Unit,
     onLoadMore: () -> Unit,
     isLoadingMore: Boolean,
@@ -762,6 +766,9 @@ private fun ExpressiveQueueView(
 ) {
     val primaryContainerColor = MaterialTheme.colorScheme.primaryContainer
     var showSortMenu by remember { mutableStateOf(false) }
+    var draggingIndex by remember { mutableIntStateOf(-1) }
+    var dragOffsetY by remember { mutableFloatStateOf(0f) }
+    val dragStepPx = with(LocalDensity.current) { 72.dp.toPx() }
     
     Box(
         modifier = Modifier
@@ -1144,6 +1151,43 @@ private fun ExpressiveQueueView(
                                         tint = onSurfaceVariantColor
                                     )
                                 }
+
+                                Icon(
+                                    imageVector = Icons.Default.DragHandle,
+                                    contentDescription = "Reorder queue item",
+                                    tint = onSurfaceVariantColor,
+                                    modifier = Modifier
+                                        .pointerInput(queue.size) {
+                                            detectDragGesturesAfterLongPress(
+                                                onDragStart = {
+                                                    draggingIndex = index
+                                                    dragOffsetY = 0f
+                                                },
+                                                onDragEnd = {
+                                                    draggingIndex = -1
+                                                    dragOffsetY = 0f
+                                                },
+                                                onDragCancel = {
+                                                    draggingIndex = -1
+                                                    dragOffsetY = 0f
+                                                }
+                                            ) { change, dragAmount ->
+                                                change.consume()
+                                                if (draggingIndex !in queue.indices) return@detectDragGesturesAfterLongPress
+
+                                                dragOffsetY += dragAmount.y
+                                                if (dragOffsetY > dragStepPx && draggingIndex < queue.lastIndex) {
+                                                    onMoveSong(draggingIndex, draggingIndex + 1)
+                                                    draggingIndex += 1
+                                                    dragOffsetY = 0f
+                                                } else if (dragOffsetY < -dragStepPx && draggingIndex > 0) {
+                                                    onMoveSong(draggingIndex, draggingIndex - 1)
+                                                    draggingIndex -= 1
+                                                    dragOffsetY = 0f
+                                                }
+                                            }
+                                        }
+                                )
                             }
                         }
                     }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
@@ -116,6 +116,8 @@ fun PlayerSheetContent(
                     queue = currentQueue,
                     currentSong = currentSong,
                     onSongClick = { song -> viewModel.playQueue(currentQueue, song) },
+                    onRemoveSong = { song -> viewModel.removeFromQueue(song.id) },
+                    onSortQueue = { ascending -> viewModel.sortQueue(ascending) },
                     onLoadMore = onLoadMore,
                     isLoadingMore = isLoadingMore,
                     onCollapse = onCollapse,
@@ -744,6 +746,8 @@ private fun ExpressiveQueueView(
     queue: List<Song>,
     currentSong: Song?,
     onSongClick: (Song) -> Unit,
+    onRemoveSong: (Song) -> Unit,
+    onSortQueue: (Boolean) -> Unit,
     onLoadMore: () -> Unit,
     isLoadingMore: Boolean,
     onCollapse: () -> Unit,
@@ -757,6 +761,7 @@ private fun ExpressiveQueueView(
     stableShapes: IconButtonShapes
 ) {
     val primaryContainerColor = MaterialTheme.colorScheme.primaryContainer
+    var showSortMenu by remember { mutableStateOf(false) }
     
     Box(
         modifier = Modifier
@@ -810,17 +815,54 @@ private fun ExpressiveQueueView(
                 }
             }
             
-            // Back to player button - static shape
-            FilledIconButton(
-                onClick = onBackToPlayer,
-                shape = CircleShape,
-                colors = IconButtonDefaults.filledIconButtonColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                    contentColor = MaterialTheme.colorScheme.onSurface
-                ),
-                modifier = Modifier.size(48.dp)
-            ) {
-                Icon(Icons.Rounded.MusicNote, "Now Playing", modifier = Modifier.size(24.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box {
+                    FilledIconButton(
+                        onClick = { showSortMenu = true },
+                        shape = CircleShape,
+                        colors = IconButtonDefaults.filledIconButtonColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                            contentColor = MaterialTheme.colorScheme.onSurface
+                        ),
+                        modifier = Modifier.size(48.dp)
+                    ) {
+                        Icon(Icons.Default.SortByAlpha, "Sort queue", modifier = Modifier.size(22.dp))
+                    }
+                    DropdownMenu(
+                        expanded = showSortMenu,
+                        onDismissRequest = { showSortMenu = false }
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("Title A-Z") },
+                            onClick = {
+                                onSortQueue(true)
+                                showSortMenu = false
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Title Z-A") },
+                            onClick = {
+                                onSortQueue(false)
+                                showSortMenu = false
+                            }
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                // Back to player button - static shape
+                FilledIconButton(
+                    onClick = onBackToPlayer,
+                    shape = CircleShape,
+                    colors = IconButtonDefaults.filledIconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        contentColor = MaterialTheme.colorScheme.onSurface
+                    ),
+                    modifier = Modifier.size(48.dp)
+                ) {
+                    Icon(Icons.Rounded.MusicNote, "Now Playing", modifier = Modifier.size(24.dp))
+                }
             }
         }
         
@@ -1093,6 +1135,14 @@ private fun ExpressiveQueueView(
                                         modifier = Modifier.size(16.dp)
                                     )
                                     Spacer(modifier = Modifier.width(8.dp))
+                                }
+
+                                IconButton(onClick = { onRemoveSong(song) }) {
+                                    Icon(
+                                        imageVector = Icons.Default.Delete,
+                                        contentDescription = "Remove from queue",
+                                        tint = onSurfaceVariantColor
+                                    )
                                 }
                             }
                         }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
@@ -500,6 +500,72 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
         }
     }
 
+    fun removeFromQueue(songId: String) {
+        val queue = _currentQueue.value
+        val removeIndex = queue.indexOfFirst { it.id == songId }
+        if (removeIndex < 0) return
+
+        val updatedQueue = queue.toMutableList().apply { removeAt(removeIndex) }
+        _currentQueue.value = updatedQueue
+
+        controller?.let { player ->
+            if (removeIndex < player.mediaItemCount) {
+                player.removeMediaItem(removeIndex)
+            }
+        }
+
+        if (updatedQueue.isEmpty()) {
+            controller?.stop()
+            _currentSong.value = null
+            _isPlaying.value = false
+            _progress.value = 0L
+            _duration.value = 0L
+            return
+        }
+
+        if (_currentSong.value?.id == songId) {
+            val fallbackIndex = removeIndex.coerceAtMost(updatedQueue.lastIndex)
+            val fallbackSong = updatedQueue[fallbackIndex]
+            _currentSong.value = fallbackSong
+            updateCurrentSongLikedStatus()
+            fetchLyrics(fallbackSong)
+        }
+    }
+
+    fun sortQueue(ascending: Boolean) {
+        val queue = _currentQueue.value
+        if (queue.size < 2) return
+
+        val currentSongId = _currentSong.value?.id
+        val sortedQueue = if (ascending) {
+            queue.sortedBy { it.title.lowercase() }
+        } else {
+            queue.sortedByDescending { it.title.lowercase() }
+        }
+        _currentQueue.value = sortedQueue
+
+        controller?.let { player ->
+            val currentIndex = currentSongId
+                ?.let { id -> sortedQueue.indexOfFirst { it.id == id } }
+                ?.takeIf { it >= 0 }
+                ?: 0
+            val currentPosition = player.currentPosition.coerceAtLeast(0L)
+            val shouldPlay = player.isPlaying || _playWhenReady.value
+
+            player.setMediaItems(
+                sortedQueue.map { createMediaItem(it) },
+                currentIndex,
+                currentPosition
+            )
+            player.prepare()
+            if (shouldPlay) {
+                player.play()
+            }
+        }
+
+        _currentSong.value = sortedQueue.find { it.id == currentSongId } ?: sortedQueue.firstOrNull()
+    }
+
     private fun createMediaItem(song: Song): MediaItem {
         return if (song.source == com.ivor.ivormusic.data.SongSource.LOCAL && song.uri != null) {
             // For local songs, we still need to set mediaId for proper tracking

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
@@ -566,6 +566,41 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
         _currentSong.value = sortedQueue.find { it.id == currentSongId } ?: sortedQueue.firstOrNull()
     }
 
+    fun moveSongInQueue(fromIndex: Int, toIndex: Int) {
+        val queue = _currentQueue.value
+        if (queue.size < 2) return
+        if (fromIndex == toIndex) return
+        if (fromIndex !in queue.indices || toIndex !in queue.indices) return
+
+        val currentSongId = _currentSong.value?.id
+        val reorderedQueue = queue.toMutableList().apply {
+            val movedSong = removeAt(fromIndex)
+            add(toIndex, movedSong)
+        }
+        _currentQueue.value = reorderedQueue
+
+        controller?.let { player ->
+            val currentIndex = currentSongId
+                ?.let { id -> reorderedQueue.indexOfFirst { it.id == id } }
+                ?.takeIf { it >= 0 }
+                ?: 0
+            val currentPosition = player.currentPosition.coerceAtLeast(0L)
+            val shouldPlay = player.isPlaying || _playWhenReady.value
+
+            player.setMediaItems(
+                reorderedQueue.map { createMediaItem(it) },
+                currentIndex,
+                currentPosition
+            )
+            player.prepare()
+            if (shouldPlay) {
+                player.play()
+            }
+        }
+
+        _currentSong.value = reorderedQueue.find { it.id == currentSongId } ?: reorderedQueue.firstOrNull()
+    }
+
     private fun createMediaItem(song: Song): MediaItem {
         return if (song.source == com.ivor.ivormusic.data.SongSource.LOCAL && song.uri != null) {
             // For local songs, we still need to set mediaId for proper tracking


### PR DESCRIPTION
### Motivation
- Provide users the ability to sort and remove items from the active playback queue and from locally created playlists so playlist/queue management is consistent across UIs.
- Keep the Media3 player timeline and playback state in sync when queue order changes or items are removed.

### Description
- Added `sortPlaylistSongs(playlistId, ascending)` to `PlaylistRepository` to persistently reorder local playlists and updated saving logic to refresh the cache after changes.
- Added `isLocalPlaylist`, `removeSongFromLocalPlaylist` and `sortLocalPlaylist` helpers in `HomeViewModel` to expose playlist operations to the UI.
- Implemented queue operations in `PlayerViewModel`: `removeFromQueue(songId)` to delete an item and handle empty-queue/current-song fallback, and `sortQueue(ascending)` to alphabetically sort the queue and re-sync the Media3 player timeline while preserving playback position/state where possible.
- Wired new actions into UI components: added sort menu (Title A–Z / Z–A) and per-item delete buttons to `ExpressiveQueueView` (`PlayerSheetContent`), `GestureQueueView` (`GesturePlayerContent`), and the playlist detail screen (`PlaylistDetailScreen`), and extended `SongListItem` to accept optional `trailingContent` for per-item controls.

### Testing
- Attempted to compile Kotlin with `./gradlew :app:compileDebugKotlin`, which failed in this environment due to SDK/tooling issue (`25.0.1`).
- Verified repository state and commit via Git; changes were committed successfully with message `Add sort and delete controls for queue and local playlists`.
- No other automated tests were run in this environment (unit/instrumentation tests were not executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df57abd5808331b1a5fbad8a89d59f)