### PR TITLE
Add playlist & queue sorting, reordering and removal; UI interactions and CI/build tweaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,12 +27,12 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
-    - name: Build Debug APK
+    - name: Build Debug APKs (v7a, v8a, universal)
       run: ./gradlew assembleDebug
 
-    - name: Upload Debug APK
+    - name: Upload Debug APKs
       uses: actions/upload-artifact@v4
       with:
-        name: app-debug
+        name: app-debug-abis
         path: app/build/outputs/apk/debug/*.apk
         retention-days: 14

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,13 @@ First off, thank you for considering contributing to **Koda**! It's people like 
 - Follow the existing code style (Kotlin coding conventions).
 - Open a PR with a clear title and description.
 
+#### PR Troubleshooting (Codex)
+- If you see: **"Codex does not currently support updating PRs that are updated outside of Codex"**, create a **new PR** instead of trying to update the existing one.
+- Recommended flow:
+  1. Create a fresh branch from the latest `main`.
+  2. Cherry-pick or re-apply your commits.
+  3. Open a new PR with a short note linking the old PR for context.
+
 ## Development Setup
 
 1. **Clone the repo**: `git clone https://github.com/Ivorisnoob/Koda.git`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
             isEnable = true
             reset()
             include("arm64-v8a", "armeabi-v7a")
-            isUniversalApk = false
+            isUniversalApk = true
         }
     }
     //Only for Release apk that is why I hardcoded cause if you want to make as a maintainer release apk you can change here in future we will make it the correct way

--- a/app/src/main/java/com/ivor/ivormusic/data/PlaylistRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/PlaylistRepository.kt
@@ -97,6 +97,32 @@ class PlaylistRepository(private val context: Context) {
         )
         savePlaylist(updatedPlaylist)
     }
+
+    suspend fun sortPlaylistSongs(playlistId: String, ascending: Boolean = true) = withContext(Dispatchers.IO) {
+        val currentList = _userPlaylists.value
+        val playlist = currentList.find { it.id == playlistId } ?: return@withContext
+
+        val sortedSongs = if (ascending) {
+            playlist.songs.sortedBy { it.title.lowercase() }
+        } else {
+            playlist.songs.sortedByDescending { it.title.lowercase() }
+        }
+
+        val updatedPlaylist = playlist.copy(songs = sortedSongs)
+        savePlaylist(updatedPlaylist)
+    }
+
+    suspend fun moveSongInPlaylist(playlistId: String, fromIndex: Int, toIndex: Int) = withContext(Dispatchers.IO) {
+        val currentList = _userPlaylists.value
+        val playlist = currentList.find { it.id == playlistId } ?: return@withContext
+        if (fromIndex !in playlist.songs.indices || toIndex !in playlist.songs.indices || fromIndex == toIndex) return@withContext
+
+        val mutableSongs = playlist.songs.toMutableList()
+        val movedSong = mutableSongs.removeAt(fromIndex)
+        mutableSongs.add(toIndex, movedSong)
+
+        savePlaylist(playlist.copy(songs = mutableSongs))
+    }
     
     suspend fun deletePlaylist(playlistId: String) = withContext(Dispatchers.IO) {
         val file = File(playlistDir, "$playlistId.json")

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
@@ -219,6 +219,28 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         }
 
     }
+
+    fun isLocalPlaylist(playlistId: String): Boolean {
+        return playlistRepository.userPlaylists.value.any { it.id == playlistId }
+    }
+
+    fun removeSongFromLocalPlaylist(playlistId: String, songId: String) {
+        viewModelScope.launch {
+            playlistRepository.removeSongFromPlaylist(playlistId, songId)
+        }
+    }
+
+    fun sortLocalPlaylist(playlistId: String, ascending: Boolean) {
+        viewModelScope.launch {
+            playlistRepository.sortPlaylistSongs(playlistId, ascending)
+        }
+    }
+
+    fun moveSongInLocalPlaylist(playlistId: String, fromIndex: Int, toIndex: Int) {
+        viewModelScope.launch {
+            playlistRepository.moveSongInPlaylist(playlistId, fromIndex, toIndex)
+        }
+    }
     
 
     

--- a/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
@@ -6,9 +6,11 @@ import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.animateItemPlacement
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -31,12 +33,15 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.PlaylistDisplayItem
 import com.ivor.ivormusic.data.Song
@@ -44,6 +49,8 @@ import com.ivor.ivormusic.ui.artist.ArtistScreen
 import com.ivor.ivormusic.ui.components.ExpressivePullToRefresh
 import androidx.compose.foundation.ExperimentalFoundationApi
 import com.ivor.ivormusic.ui.home.HomeViewModel
+import kotlin.math.abs
+import kotlin.math.roundToInt
 
 /**
  * The Main Library Navigation Hub.
@@ -642,7 +649,12 @@ fun ExpressivePlaylistCard(
 }
 
 @Composable
-fun SongListItem(song: Song, onClick: () -> Unit) {
+fun SongListItem(
+    song: Song,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    trailingContent: (@Composable () -> Unit)? = null
+) {
     ListItem(
         headlineContent = { Text(song.title, maxLines = 1, overflow = TextOverflow.Ellipsis, fontWeight = FontWeight.SemiBold) },
         supportingContent = { Text(song.artist, maxLines = 1, overflow = TextOverflow.Ellipsis) },
@@ -658,7 +670,8 @@ fun SongListItem(song: Song, onClick: () -> Unit) {
                     Box(contentAlignment = Alignment.Center) { Icon(Icons.Rounded.MusicNote, null, tint = MaterialTheme.colorScheme.onSurfaceVariant) }
             }
         },
-        modifier = Modifier.clickable(onClick = onClick),
+        trailingContent = trailingContent,
+        modifier = modifier.clickable(onClick = onClick),
         colors = ListItemDefaults.colors(containerColor = Color.Transparent)
     )
 }
@@ -693,10 +706,15 @@ fun PlaylistDetailScreen(
     var songs by remember { mutableStateOf(preloadedSongs ?: emptyList()) }
     val isLoading by viewModel.isLoading.collectAsState()
     val isFetching = remember { mutableStateOf(songs.isEmpty()) }
+    val isLocalPlaylist = remember(playlist.id) { viewModel.isLocalPlaylist(playlist.id) }
     
     // Search State
     var searchQuery by remember { mutableStateOf("") }
     var isSearchActive by remember { mutableStateOf(false) }
+    var showSortMenu by remember { mutableStateOf(false) }
+    var draggingSongId by remember { mutableStateOf<String?>(null) }
+    var dragOffsetY by remember { mutableStateOf(0f) }
+    val dragThresholdPx = with(androidx.compose.ui.platform.LocalDensity.current) { 52.dp.toPx() }
 
     // Scroll State for FAB and App Bar
     val listState = androidx.compose.foundation.lazy.rememberLazyListState()
@@ -716,6 +734,12 @@ fun PlaylistDetailScreen(
             isFetching.value = true
             songs = viewModel.fetchPlaylistSongs(playlist.id)
             isFetching.value = false
+        }
+    }
+
+    LaunchedEffect(playlist.id, isLocalPlaylist, isLoading) {
+        if (isLocalPlaylist) {
+            songs = viewModel.fetchPlaylistSongs(playlist.id)
         }
     }
 
@@ -742,6 +766,36 @@ fun PlaylistDetailScreen(
                     }
                 },
                 actions = {
+                    if (isLocalPlaylist) {
+                        Box {
+                            IconButton(onClick = { showSortMenu = true }) {
+                                Icon(
+                                    imageVector = Icons.Rounded.SortByAlpha,
+                                    contentDescription = "Sort playlist"
+                                )
+                            }
+                            DropdownMenu(
+                                expanded = showSortMenu,
+                                onDismissRequest = { showSortMenu = false }
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text("Title A-Z") },
+                                    onClick = {
+                                        viewModel.sortLocalPlaylist(playlist.id, ascending = true)
+                                        showSortMenu = false
+                                    }
+                                )
+                                DropdownMenuItem(
+                                    text = { Text("Title Z-A") },
+                                    onClick = {
+                                        viewModel.sortLocalPlaylist(playlist.id, ascending = false)
+                                        showSortMenu = false
+                                    }
+                                )
+                            }
+                        }
+                    }
+
                     IconButton(onClick = { isSearchActive = !isSearchActive }) {
                         Icon(
                             imageVector = if (isSearchActive) Icons.Rounded.Close else Icons.Rounded.Search,
@@ -884,10 +938,77 @@ fun PlaylistDetailScreen(
                         }
                     }
                 } else {
-                    items(filteredSongs) { song ->
+                    items(filteredSongs, key = { it.id }) { song ->
+                        val isDragging = draggingSongId == song.id
                         SongListItem(
                             song = song, 
-                            onClick = { onPlayQueue(filteredSongs, song) }
+                            onClick = { onPlayQueue(filteredSongs, song) },
+                            modifier = Modifier
+                                .offset {
+                                    IntOffset(
+                                        x = 0,
+                                        y = if (isDragging) dragOffsetY.roundToInt() else 0
+                                    )
+                                }
+                                .zIndex(if (isDragging) 2f else 0f)
+                                .animateItemPlacement(),
+                            trailingContent = if (isLocalPlaylist) {
+                                {
+                                    Row(
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        horizontalArrangement = Arrangement.spacedBy(4.dp)
+                                    ) {
+                                        IconButton(
+                                            onClick = { viewModel.removeSongFromLocalPlaylist(playlist.id, song.id) }
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Rounded.Delete,
+                                                contentDescription = "Remove from playlist"
+                                            )
+                                        }
+                                        Icon(
+                                            imageVector = Icons.Rounded.DragHandle,
+                                            contentDescription = "Drag to reorder",
+                                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            modifier = Modifier.pointerInput(song.id, songs) {
+                                                detectDragGesturesAfterLongPress(
+                                                    onDragStart = {
+                                                        draggingSongId = song.id
+                                                        dragOffsetY = 0f
+                                                    },
+                                                    onDragCancel = {
+                                                        draggingSongId = null
+                                                        dragOffsetY = 0f
+                                                    },
+                                                    onDragEnd = {
+                                                        draggingSongId = null
+                                                        dragOffsetY = 0f
+                                                    }
+                                                ) { change, dragAmount ->
+                                                    change.consume()
+                                                    if (draggingSongId != song.id) return@detectDragGesturesAfterLongPress
+                                                    dragOffsetY += dragAmount.y
+
+                                                    if (abs(dragOffsetY) >= dragThresholdPx) {
+                                                        val fromIndex = songs.indexOfFirst { it.id == song.id }
+                                                        val direction = if (dragOffsetY > 0) 1 else -1
+                                                        val toIndex = (fromIndex + direction).coerceIn(0, songs.lastIndex)
+
+                                                        if (fromIndex != -1 && toIndex != fromIndex) {
+                                                            val mutableSongs = songs.toMutableList()
+                                                            val movedSong = mutableSongs.removeAt(fromIndex)
+                                                            mutableSongs.add(toIndex, movedSong)
+                                                            songs = mutableSongs
+                                                            viewModel.moveSongInLocalPlaylist(playlist.id, fromIndex, toIndex)
+                                                        }
+                                                        dragOffsetY = 0f
+                                                    }
+                                                }
+                                            }
+                                        )
+                                    }
+                                }
+                            } else null
                         )
                     }
                 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/GesturePlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/GesturePlayerContent.kt
@@ -12,10 +12,12 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.animateItemPlacement
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -52,6 +54,7 @@ import com.ivor.ivormusic.data.Song
 import com.ivor.ivormusic.data.LyricsResult
 import java.util.Locale
 import kotlin.math.absoluteValue
+import kotlin.math.abs
 import kotlin.math.roundToInt
 
 /**
@@ -121,6 +124,9 @@ fun GesturePlayerSheetContent(
                     queue = currentQueue,
                     currentSong = currentSong,
                     onSongClick = { song -> viewModel.playQueue(currentQueue, song) },
+                    onRemoveSong = { song -> viewModel.removeFromQueue(song.id) },
+                    onSortQueue = { ascending -> viewModel.sortQueue(ascending) },
+                    onMoveSong = { from, to -> viewModel.moveQueueItem(from, to) },
                     onCollapse = onCollapse,
                     onBackToPlayer = { showQueue = false },
                     onLoadMore = onLoadMore,
@@ -1011,6 +1017,9 @@ private fun GestureQueueView(
     queue: List<Song>,
     currentSong: Song?,
     onSongClick: (Song) -> Unit,
+    onRemoveSong: (Song) -> Unit,
+    onSortQueue: (Boolean) -> Unit,
+    onMoveSong: (Int, Int) -> Unit,
     onCollapse: () -> Unit,
     onBackToPlayer: () -> Unit,
     onLoadMore: () -> Unit,
@@ -1022,6 +1031,10 @@ private fun GestureQueueView(
     onSurfaceColor: Color,
     onSurfaceVariantColor: Color
 ) {
+    var showSortMenu by remember { mutableStateOf(false) }
+    var draggingSongId by remember { mutableStateOf<String?>(null) }
+    var dragOffsetY by remember { mutableStateOf(0f) }
+    val dragThresholdPx = with(LocalDensity.current) { 56.dp.toPx() }
     // Guard against invalid dimensions during transitions
     BoxWithConstraints(
         modifier = Modifier
@@ -1078,16 +1091,51 @@ private fun GestureQueueView(
                     }
                 }
                 
-                FilledIconButton(
-                    onClick = onBackToPlayer,
-                    shape = CircleShape,
-                    colors = IconButtonDefaults.filledIconButtonColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                        contentColor = MaterialTheme.colorScheme.onSurface
-                    ),
-                    modifier = Modifier.size(48.dp)
-                ) {
-                    Icon(Icons.Rounded.MusicNote, "Now Playing", modifier = Modifier.size(24.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box {
+                        FilledIconButton(
+                            onClick = { showSortMenu = true },
+                            shape = CircleShape,
+                            colors = IconButtonDefaults.filledIconButtonColors(
+                                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                                contentColor = MaterialTheme.colorScheme.onSurface
+                            ),
+                            modifier = Modifier.size(48.dp)
+                        ) {
+                            Icon(Icons.Default.SortByAlpha, "Sort queue", modifier = Modifier.size(22.dp))
+                        }
+                        DropdownMenu(
+                            expanded = showSortMenu,
+                            onDismissRequest = { showSortMenu = false }
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text("Title A-Z") },
+                                onClick = {
+                                    onSortQueue(true)
+                                    showSortMenu = false
+                                }
+                            )
+                            DropdownMenuItem(
+                                text = { Text("Title Z-A") },
+                                onClick = {
+                                    onSortQueue(false)
+                                    showSortMenu = false
+                                }
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    FilledIconButton(
+                        onClick = onBackToPlayer,
+                        shape = CircleShape,
+                        colors = IconButtonDefaults.filledIconButtonColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                            contentColor = MaterialTheme.colorScheme.onSurface
+                        ),
+                        modifier = Modifier.size(48.dp)
+                    ) {
+                        Icon(Icons.Rounded.MusicNote, "Now Playing", modifier = Modifier.size(24.dp))
+                    }
                 }
             }
             
@@ -1217,9 +1265,19 @@ private fun GestureQueueView(
                     // Queue items
                     itemsIndexed(queue, key = { index, song -> "gesture_queue_${song.id}_$index" }) { index, song ->
                         val isCurrent = song.id == currentSong?.id
+                        val isDragging = draggingSongId == song.id
                         
                         Surface(
-                            modifier = Modifier.fillMaxWidth(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .offset {
+                                    IntOffset(
+                                        x = 0,
+                                        y = if (isDragging) dragOffsetY.roundToInt() else 0
+                                    )
+                                }
+                                .zIndex(if (isDragging) 2f else 0f)
+                                .animateItemPlacement(),
                             shape = RoundedCornerShape(20.dp),
                             color = if (isCurrent) primaryColor.copy(alpha = 0.12f) 
                                    else MaterialTheme.colorScheme.surfaceContainerLow,
@@ -1312,29 +1370,75 @@ private fun GestureQueueView(
                                 
                                 Spacer(modifier = Modifier.width(8.dp))
 
-                                // Download Status Icon
-                                if (isDownloading(song.id)) {
-                                    CircularWavyProgressIndicator(
-                                        modifier = Modifier.size(16.dp),
-                                        color = if (isCurrent) primaryColor else onSurfaceVariantColor
-                                    )
-                                    Spacer(modifier = Modifier.width(8.dp))
-                                } else if (isDownloaded(song.id)) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                                ) {
+                                    // Download Status Icon
+                                    if (isDownloading(song.id)) {
+                                        CircularWavyProgressIndicator(
+                                            modifier = Modifier.size(16.dp),
+                                            color = if (isCurrent) primaryColor else onSurfaceVariantColor
+                                        )
+                                    } else if (isDownloaded(song.id)) {
+                                        Icon(
+                                            imageVector = Icons.Rounded.CheckCircle,
+                                            contentDescription = "Downloaded",
+                                            tint = if (isCurrent) primaryColor else onSurfaceVariantColor,
+                                            modifier = Modifier.size(18.dp)
+                                        )
+                                    } else if (isLocalOriginal(song)) {
+                                        Icon(
+                                            imageVector = Icons.Rounded.Smartphone,
+                                            contentDescription = "Local",
+                                            tint = if (isCurrent) primaryColor.copy(alpha = 0.7f) else onSurfaceVariantColor.copy(alpha = 0.7f),
+                                            modifier = Modifier.size(16.dp)
+                                        )
+                                    }
+
+                                    IconButton(onClick = { onRemoveSong(song) }) {
+                                        Icon(
+                                            imageVector = Icons.Default.Delete,
+                                            contentDescription = "Remove from queue",
+                                            tint = onSurfaceVariantColor
+                                        )
+                                    }
+
                                     Icon(
-                                        imageVector = Icons.Rounded.CheckCircle,
-                                        contentDescription = "Downloaded",
-                                        tint = if (isCurrent) primaryColor else onSurfaceVariantColor,
-                                        modifier = Modifier.size(18.dp)
+                                        imageVector = Icons.Rounded.DragHandle,
+                                        contentDescription = "Drag to reorder",
+                                        tint = onSurfaceVariantColor,
+                                        modifier = Modifier
+                                            .pointerInput(song.id, queue) {
+                                                detectDragGesturesAfterLongPress(
+                                                    onDragStart = {
+                                                        draggingSongId = song.id
+                                                        dragOffsetY = 0f
+                                                    },
+                                                    onDragCancel = {
+                                                        draggingSongId = null
+                                                        dragOffsetY = 0f
+                                                    },
+                                                    onDragEnd = {
+                                                        draggingSongId = null
+                                                        dragOffsetY = 0f
+                                                    }
+                                                ) { change, dragAmount ->
+                                                    change.consume()
+                                                    if (draggingSongId != song.id) return@detectDragGesturesAfterLongPress
+                                                    dragOffsetY += dragAmount.y
+                                                    if (abs(dragOffsetY) >= dragThresholdPx) {
+                                                        val currentIndex = queue.indexOfFirst { it.id == song.id }
+                                                        val direction = if (dragOffsetY > 0) 1 else -1
+                                                        val targetIndex = (currentIndex + direction).coerceIn(0, queue.lastIndex)
+                                                        if (currentIndex != -1 && targetIndex != currentIndex) {
+                                                            onMoveSong(currentIndex, targetIndex)
+                                                        }
+                                                        dragOffsetY = 0f
+                                                    }
+                                                }
+                                            }
                                     )
-                                    Spacer(modifier = Modifier.width(8.dp))
-                                } else if (isLocalOriginal(song)) {
-                                    Icon(
-                                        imageVector = Icons.Rounded.Smartphone,
-                                        contentDescription = "Local",
-                                        tint = if (isCurrent) primaryColor.copy(alpha = 0.7f) else onSurfaceVariantColor.copy(alpha = 0.7f),
-                                        modifier = Modifier.size(16.dp)
-                                    )
-                                    Spacer(modifier = Modifier.width(8.dp))
                                 }
                             }
                         }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
@@ -7,8 +7,10 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.animateItemPlacement
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -33,15 +35,20 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.media3.common.Player
 import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.Song
 import com.ivor.ivormusic.data.LyricsResult
+import kotlin.math.abs
+import kotlin.math.roundToInt
 
 /**
  *  Material 3 Expressive Music Player
@@ -116,6 +123,9 @@ fun PlayerSheetContent(
                     queue = currentQueue,
                     currentSong = currentSong,
                     onSongClick = { song -> viewModel.playQueue(currentQueue, song) },
+                    onRemoveSong = { song -> viewModel.removeFromQueue(song.id) },
+                    onSortQueue = { ascending -> viewModel.sortQueue(ascending) },
+                    onMoveSong = { from, to -> viewModel.moveQueueItem(from, to) },
                     onLoadMore = onLoadMore,
                     isLoadingMore = isLoadingMore,
                     onCollapse = onCollapse,
@@ -744,6 +754,9 @@ private fun ExpressiveQueueView(
     queue: List<Song>,
     currentSong: Song?,
     onSongClick: (Song) -> Unit,
+    onRemoveSong: (Song) -> Unit,
+    onSortQueue: (Boolean) -> Unit,
+    onMoveSong: (Int, Int) -> Unit,
     onLoadMore: () -> Unit,
     isLoadingMore: Boolean,
     onCollapse: () -> Unit,
@@ -757,6 +770,10 @@ private fun ExpressiveQueueView(
     stableShapes: IconButtonShapes
 ) {
     val primaryContainerColor = MaterialTheme.colorScheme.primaryContainer
+    var showSortMenu by remember { mutableStateOf(false) }
+    var draggingSongId by remember { mutableStateOf<String?>(null) }
+    var dragOffsetY by remember { mutableStateOf(0f) }
+    val dragThresholdPx = with(LocalDensity.current) { 56.dp.toPx() }
     
     Box(
         modifier = Modifier
@@ -810,17 +827,54 @@ private fun ExpressiveQueueView(
                 }
             }
             
-            // Back to player button - static shape
-            FilledIconButton(
-                onClick = onBackToPlayer,
-                shape = CircleShape,
-                colors = IconButtonDefaults.filledIconButtonColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                    contentColor = MaterialTheme.colorScheme.onSurface
-                ),
-                modifier = Modifier.size(48.dp)
-            ) {
-                Icon(Icons.Rounded.MusicNote, "Now Playing", modifier = Modifier.size(24.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box {
+                    FilledIconButton(
+                        onClick = { showSortMenu = true },
+                        shape = CircleShape,
+                        colors = IconButtonDefaults.filledIconButtonColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                            contentColor = MaterialTheme.colorScheme.onSurface
+                        ),
+                        modifier = Modifier.size(48.dp)
+                    ) {
+                        Icon(Icons.Default.SortByAlpha, "Sort queue", modifier = Modifier.size(22.dp))
+                    }
+                    DropdownMenu(
+                        expanded = showSortMenu,
+                        onDismissRequest = { showSortMenu = false }
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("Title A-Z") },
+                            onClick = {
+                                onSortQueue(true)
+                                showSortMenu = false
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Title Z-A") },
+                            onClick = {
+                                onSortQueue(false)
+                                showSortMenu = false
+                            }
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                // Back to player button - static shape
+                FilledIconButton(
+                    onClick = onBackToPlayer,
+                    shape = CircleShape,
+                    colors = IconButtonDefaults.filledIconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        contentColor = MaterialTheme.colorScheme.onSurface
+                    ),
+                    modifier = Modifier.size(48.dp)
+                ) {
+                    Icon(Icons.Rounded.MusicNote, "Now Playing", modifier = Modifier.size(24.dp))
+                }
             }
         }
         
@@ -989,9 +1043,19 @@ private fun ExpressiveQueueView(
                     // ========== QUEUE ITEMS ==========
                     itemsIndexed(queue, key = { _, song -> "queue_${song.id}" }) { index, song ->
                         val isCurrent = song.id == currentSong?.id
+                        val isDragging = draggingSongId == song.id
                         
                         Surface(
-                            modifier = Modifier.fillMaxWidth(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .offset {
+                                    IntOffset(
+                                        x = 0,
+                                        y = if (isDragging) dragOffsetY.roundToInt() else 0
+                                    )
+                                }
+                                .zIndex(if (isDragging) 2f else 0f)
+                                .animateItemPlacement(),
                             shape = RoundedCornerShape(20.dp),
                             color = if (isCurrent) primaryColor.copy(alpha = 0.12f) 
                                    else MaterialTheme.colorScheme.surfaceContainerLow,
@@ -1070,29 +1134,75 @@ private fun ExpressiveQueueView(
                                 
                                 Spacer(modifier = Modifier.width(8.dp))
 
-                                // Download Status Icon
-                                if (isDownloading(song.id)) {
-                                    CircularWavyProgressIndicator(
-                                        modifier = Modifier.size(16.dp),
-                                        color = if (isCurrent) primaryColor else onSurfaceVariantColor
-                                    )
-                                    Spacer(modifier = Modifier.width(8.dp))
-                                } else if (isDownloaded(song.id)) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                                ) {
+                                    // Download Status Icon
+                                    if (isDownloading(song.id)) {
+                                        CircularWavyProgressIndicator(
+                                            modifier = Modifier.size(16.dp),
+                                            color = if (isCurrent) primaryColor else onSurfaceVariantColor
+                                        )
+                                    } else if (isDownloaded(song.id)) {
+                                        Icon(
+                                            imageVector = Icons.Rounded.CheckCircle,
+                                            contentDescription = "Downloaded",
+                                            tint = if (isCurrent) primaryColor else onSurfaceVariantColor,
+                                            modifier = Modifier.size(18.dp)
+                                        )
+                                    } else if (isLocalOriginal(song)) {
+                                        Icon(
+                                            imageVector = Icons.Rounded.Smartphone,
+                                            contentDescription = "Local",
+                                            tint = if (isCurrent) primaryColor.copy(alpha=0.7f) else onSurfaceVariantColor.copy(alpha=0.7f),
+                                            modifier = Modifier.size(16.dp)
+                                        )
+                                    }
+
+                                    IconButton(onClick = { onRemoveSong(song) }) {
+                                        Icon(
+                                            imageVector = Icons.Default.Delete,
+                                            contentDescription = "Remove from queue",
+                                            tint = onSurfaceVariantColor
+                                        )
+                                    }
+
                                     Icon(
-                                        imageVector = Icons.Rounded.CheckCircle,
-                                        contentDescription = "Downloaded",
-                                        tint = if (isCurrent) primaryColor else onSurfaceVariantColor,
-                                        modifier = Modifier.size(18.dp)
+                                        imageVector = Icons.Rounded.DragHandle,
+                                        contentDescription = "Drag to reorder",
+                                        tint = onSurfaceVariantColor,
+                                        modifier = Modifier
+                                            .pointerInput(song.id, queue) {
+                                                detectDragGesturesAfterLongPress(
+                                                    onDragStart = {
+                                                        draggingSongId = song.id
+                                                        dragOffsetY = 0f
+                                                    },
+                                                    onDragCancel = {
+                                                        draggingSongId = null
+                                                        dragOffsetY = 0f
+                                                    },
+                                                    onDragEnd = {
+                                                        draggingSongId = null
+                                                        dragOffsetY = 0f
+                                                    }
+                                                ) { change, dragAmount ->
+                                                    change.consume()
+                                                    if (draggingSongId != song.id) return@detectDragGesturesAfterLongPress
+                                                    dragOffsetY += dragAmount.y
+                                                    if (abs(dragOffsetY) >= dragThresholdPx) {
+                                                        val currentIndex = queue.indexOfFirst { it.id == song.id }
+                                                        val direction = if (dragOffsetY > 0) 1 else -1
+                                                        val targetIndex = (currentIndex + direction).coerceIn(0, queue.lastIndex)
+                                                        if (currentIndex != -1 && targetIndex != currentIndex) {
+                                                            onMoveSong(currentIndex, targetIndex)
+                                                        }
+                                                        dragOffsetY = 0f
+                                                    }
+                                                }
+                                            }
                                     )
-                                    Spacer(modifier = Modifier.width(8.dp))
-                                } else if (isLocalOriginal(song)) {
-                                    Icon(
-                                        imageVector = Icons.Rounded.Smartphone,
-                                        contentDescription = "Local",
-                                        tint = if (isCurrent) primaryColor.copy(alpha=0.7f) else onSurfaceVariantColor.copy(alpha=0.7f),
-                                        modifier = Modifier.size(16.dp)
-                                    )
-                                    Spacer(modifier = Modifier.width(8.dp))
                                 }
                             }
                         }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
@@ -500,6 +500,88 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
         }
     }
 
+    fun removeFromQueue(songId: String) {
+        val queue = _currentQueue.value
+        val removeIndex = queue.indexOfFirst { it.id == songId }
+        if (removeIndex < 0) return
+
+        val updatedQueue = queue.toMutableList().apply { removeAt(removeIndex) }
+        _currentQueue.value = updatedQueue
+
+        controller?.let { player ->
+            if (removeIndex < player.mediaItemCount) {
+                player.removeMediaItem(removeIndex)
+            }
+        }
+
+        if (updatedQueue.isEmpty()) {
+            controller?.stop()
+            _currentSong.value = null
+            _isPlaying.value = false
+            _progress.value = 0L
+            _duration.value = 0L
+            return
+        }
+
+        if (_currentSong.value?.id == songId) {
+            val fallbackIndex = removeIndex.coerceAtMost(updatedQueue.lastIndex)
+            val fallbackSong = updatedQueue[fallbackIndex]
+            _currentSong.value = fallbackSong
+            updateCurrentSongLikedStatus()
+            fetchLyrics(fallbackSong)
+        }
+    }
+
+    fun sortQueue(ascending: Boolean) {
+        val queue = _currentQueue.value
+        if (queue.size < 2) return
+
+        val currentSongId = _currentSong.value?.id
+        val sortedQueue = if (ascending) {
+            queue.sortedBy { it.title.lowercase() }
+        } else {
+            queue.sortedByDescending { it.title.lowercase() }
+        }
+        _currentQueue.value = sortedQueue
+
+        controller?.let { player ->
+            val currentIndex = currentSongId
+                ?.let { id -> sortedQueue.indexOfFirst { it.id == id } }
+                ?.takeIf { it >= 0 }
+                ?: 0
+            val currentPosition = player.currentPosition.coerceAtLeast(0L)
+            val shouldPlay = player.isPlaying || _playWhenReady.value
+
+            player.setMediaItems(
+                sortedQueue.map { createMediaItem(it) },
+                currentIndex,
+                currentPosition
+            )
+            player.prepare()
+            if (shouldPlay) {
+                player.play()
+            }
+        }
+
+        _currentSong.value = sortedQueue.find { it.id == currentSongId } ?: sortedQueue.firstOrNull()
+    }
+
+    fun moveQueueItem(fromIndex: Int, toIndex: Int) {
+        val queue = _currentQueue.value
+        if (fromIndex !in queue.indices || toIndex !in queue.indices || fromIndex == toIndex) return
+
+        val mutableQueue = queue.toMutableList()
+        val movedSong = mutableQueue.removeAt(fromIndex)
+        mutableQueue.add(toIndex, movedSong)
+        _currentQueue.value = mutableQueue
+
+        controller?.let { player ->
+            if (fromIndex < player.mediaItemCount && toIndex < player.mediaItemCount) {
+                player.moveMediaItem(fromIndex, toIndex)
+            }
+        }
+    }
+
     private fun createMediaItem(song: Song): MediaItem {
         return if (song.source == com.ivor.ivormusic.data.SongSource.LOCAL && song.uri != null) {
             // For local songs, we still need to set mediaId for proper tracking


### PR DESCRIPTION
### Motivation
- Provide users the ability to manage local playlists and the play queue with sorting, drag-reordering and removal actions in the UI. 
- Keep the player queue and playlist state in sync with media controller updates when items are moved or removed. 
- Improve CI artifacts to include ABI builds and document PR troubleshooting for contributors.

### Description
- Added persistent playlist operations in `PlaylistRepository`: `sortPlaylistSongs` and `moveSongInPlaylist` to sort and reorder songs and save changes via `savePlaylist`.
- Extended `HomeViewModel` with helpers `isLocalPlaylist`, `removeSongFromLocalPlaylist`, `sortLocalPlaylist`, and `moveSongInLocalPlaylist` that call repository functions on `viewModelScope`.
- Updated playlist detail UI (`PlaylistDetailScreen`, `LibraryScreen`) to support: title A-Z / Z-A sorting, remove button, drag-handle long-press reordering with local optimistic UI reordering and calls to view model to persist changes, and `SongListItem` signature to accept `modifier` and `trailingContent` for these controls.
- Implemented queue management in the player layer (`PlayerViewModel`): `removeFromQueue`, `sortQueue`, and `moveQueueItem`, which update `_currentQueue` and the media `controller` (add/remove/move/set media items) while keeping the current song and playback state consistent.
- Enhanced player UI screens (`GesturePlayerContent`, `GestureQueueView`, `PlayerSheetContent`, `ExpressiveQueueView`) to expose queue actions: sort menu, delete-from-queue button, long-press drag-to-reorder with animated placement and temporary elevation while dragging, and load-more controls remain unchanged.
- Minor build and repository changes: enabled `splits.abi.isUniversalApk = true` in `app/build.gradle.kts`, updated GitHub Actions `build.yml` step names and artifact name to `app-debug-abis`, and added a small `CONTRIBUTING.md` section with PR troubleshooting guidance for Codex-related PR updates.

### Testing
- Built the debug APK artifacts with `./gradlew assembleDebug` (CI job updated to upload ABI APKs) and the build completed successfully. 
- No additional automated unit or instrumentation tests were added for the new features in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df57abd5808331b1a5fbad8a89d59f)