### PR TITLE
Add playlist sorting/edit/delete tools and seamless queue drag controls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,26 @@ jobs:
     - name: Build Debug APK
       run: ./gradlew assembleDebug
 
-    - name: Upload Debug APK
+    - name: Upload Debug APK (Universal)
       uses: actions/upload-artifact@v4
       with:
-        name: app-debug
-        path: app/build/outputs/apk/debug/*.apk
+        name: app-debug-universal
+        path: app/build/outputs/apk/debug/*universal*.apk
+        if-no-files-found: error
+        retention-days: 14
+
+    - name: Upload Debug APK (arm64-v8a)
+      uses: actions/upload-artifact@v4
+      with:
+        name: app-debug-arm64-v8a
+        path: app/build/outputs/apk/debug/*arm64-v8a*.apk
+        if-no-files-found: error
+        retention-days: 14
+
+    - name: Upload Debug APK (armeabi-v7a)
+      uses: actions/upload-artifact@v4
+      with:
+        name: app-debug-armeabi-v7a
+        path: app/build/outputs/apk/debug/*armeabi-v7a*.apk
+        if-no-files-found: error
         retention-days: 14

--- a/Agents.md
+++ b/Agents.md
@@ -1,0 +1,85 @@
+# Agent Notes
+
+## Start Android Emulator From E Drive Only
+
+Use the SDK from `E:\sdk` and keep the Android user home on `E:\Android\.android`.
+
+PowerShell:
+
+```powershell
+$env:ANDROID_SDK_ROOT='E:\sdk'
+$env:ANDROID_HOME='E:\sdk'
+$env:ANDROID_USER_HOME='E:\Android\.android'
+$env:ANDROID_AVD_HOME='E:\Android\.android\avd'
+```
+
+List available emulators:
+
+```powershell
+& 'E:\sdk\emulator\emulator.exe' -list-avds
+```
+
+Start the working emulator created for this repo:
+
+```powershell
+Start-Process -FilePath 'E:\sdk\emulator\emulator.exe' -ArgumentList '-avd musicapp_emulator'
+```
+
+Check whether it is visible:
+
+```powershell
+adb devices
+```
+
+Notes:
+
+- `flutter_emulator` is an `arm` AVD and this emulator build does not run it here.
+- `musicapp_emulator` is the safe default because it was created from the `x86_64` system image already installed in `E:\sdk`.
+- The old `.ini` entries in `E:\Android\.android\avd` are not enough by themselves. The actual `.avd` folder must exist too.
+
+## Create The E Drive Emulator Again If Needed
+
+If `musicapp_emulator` is missing, recreate it with:
+
+```powershell
+$env:ANDROID_SDK_ROOT='E:\sdk'
+$env:ANDROID_HOME='E:\sdk'
+$env:ANDROID_USER_HOME='E:\Android\.android'
+$env:ANDROID_AVD_HOME='E:\Android\.android\avd'
+New-Item -ItemType Directory -Force -Path $env:ANDROID_AVD_HOME | Out-Null
+'' | & 'E:\sdk\cmdline-tools\latest\bin\avdmanager.bat' create avd -n musicapp_emulator -k 'system-images;android-33;google_apis_playstore;x86_64' -d pixel
+```
+
+## What If I Want To Test On Android 16
+
+This project is already configured for Android 16 level APIs:
+
+- `app/build.gradle.kts` uses `compileSdk = 36`
+- `app/build.gradle.kts` uses `targetSdk = 36`
+
+That means code changes for Android 16 are not the first blocker. The main requirement is an Android 16 emulator image.
+
+If you want to test specifically on Android 16:
+
+1. Install a system image for API 36 in `E:\sdk\system-images`.
+2. Create a new `x86_64` AVD on `E:` with that API 36 image.
+3. Start that AVD with the same E-drive environment variables shown above.
+4. Run the app with `.\gradlew installDebug` or from Android Studio after selecting that emulator.
+
+Example AVD creation command after the API 36 image is installed:
+
+```powershell
+$env:ANDROID_SDK_ROOT='E:\sdk'
+$env:ANDROID_HOME='E:\sdk'
+$env:ANDROID_USER_HOME='E:\Android\.android'
+$env:ANDROID_AVD_HOME='E:\Android\.android\avd'
+'' | & 'E:\sdk\cmdline-tools\latest\bin\avdmanager.bat' create avd -n musicapp_android16 -k 'system-images;android-36;google_apis_playstore;x86_64' -d pixel
+```
+
+Then start it with:
+
+```powershell
+Start-Process -FilePath 'E:\sdk\emulator\emulator.exe' -ArgumentList '-avd musicapp_android16'
+```
+
+If API 36 is not installed yet, install it into `E:\sdk` first through Android Studio SDK Manager or `sdkmanager`.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
             isEnable = true
             reset()
             include("arm64-v8a", "armeabi-v7a")
-            isUniversalApk = false
+            isUniversalApk = true
         }
     }
     //Only for Release apk that is why I hardcoded cause if you want to make as a maintainer release apk you can change here in future we will make it the correct way

--- a/app/src/main/java/com/ivor/ivormusic/data/PlaylistDisplayItem.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/PlaylistDisplayItem.kt
@@ -5,7 +5,8 @@ data class PlaylistDisplayItem(
     val url: String,
     val uploaderName: String,
     val itemCount: Int = -1,
-    val thumbnailUrl: String? = null
+    val thumbnailUrl: String? = null,
+    val description: String? = null
 ) {
     val id: String
         get() = if (url.contains("list=")) url.substringAfter("list=") else url

--- a/app/src/main/java/com/ivor/ivormusic/data/PlaylistRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/PlaylistRepository.kt
@@ -108,6 +108,33 @@ class PlaylistRepository(private val context: Context) {
         
         loadPlaylists()
     }
+
+    suspend fun updatePlaylist(
+        playlistId: String,
+        name: String,
+        description: String?
+    ) = withContext(Dispatchers.IO) {
+        val playlist = _userPlaylists.value.find { it.id == playlistId } ?: return@withContext
+        val trimmedName = name.trim()
+        if (trimmedName.isBlank()) return@withContext
+
+        val shouldRegenerateCover = playlist.coverUri?.contains("cover_${playlist.id}.png") == true &&
+            playlist.name.firstOrNull()?.uppercaseChar() != trimmedName.firstOrNull()?.uppercaseChar()
+
+        val updatedCover = if (shouldRegenerateCover) {
+            "file://${generateCoverArt(trimmedName, playlist.id)}"
+        } else {
+            playlist.coverUri
+        }
+
+        savePlaylist(
+            playlist.copy(
+                name = trimmedName,
+                description = description?.trim().takeUnless { it.isNullOrBlank() },
+                coverUri = updatedCover
+            )
+        )
+    }
     
     private suspend fun savePlaylist(playlist: UserPlaylist) {
         val file = File(playlistDir, "${playlist.id}.json")

--- a/app/src/main/java/com/ivor/ivormusic/data/PlaylistRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/PlaylistRepository.kt
@@ -97,6 +97,23 @@ class PlaylistRepository(private val context: Context) {
         )
         savePlaylist(updatedPlaylist)
     }
+
+    suspend fun moveSongInPlaylist(
+        playlistId: String,
+        fromIndex: Int,
+        toIndex: Int
+    ) = withContext(Dispatchers.IO) {
+        val playlist = _userPlaylists.value.find { it.id == playlistId } ?: return@withContext
+        if (fromIndex == toIndex) return@withContext
+        if (fromIndex !in playlist.songs.indices || toIndex !in playlist.songs.indices) return@withContext
+
+        val reorderedSongs = playlist.songs.toMutableList().apply {
+            val movedSong = removeAt(fromIndex)
+            add(toIndex, movedSong)
+        }
+
+        savePlaylist(playlist.copy(songs = reorderedSongs))
+    }
     
     suspend fun deletePlaylist(playlistId: String) = withContext(Dispatchers.IO) {
         val file = File(playlistDir, "$playlistId.json")

--- a/app/src/main/java/com/ivor/ivormusic/data/PlaylistRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/PlaylistRepository.kt
@@ -114,6 +114,14 @@ class PlaylistRepository(private val context: Context) {
 
         savePlaylist(playlist.copy(songs = reorderedSongs))
     }
+
+    suspend fun replacePlaylistSongs(
+        playlistId: String,
+        songs: List<Song>
+    ) = withContext(Dispatchers.IO) {
+        val playlist = _userPlaylists.value.find { it.id == playlistId } ?: return@withContext
+        savePlaylist(playlist.copy(songs = songs))
+    }
     
     suspend fun deletePlaylist(playlistId: String) = withContext(Dispatchers.IO) {
         val file = File(playlistDir, "$playlistId.json")

--- a/app/src/main/java/com/ivor/ivormusic/data/UserPlaylist.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/UserPlaylist.kt
@@ -20,7 +20,8 @@ data class UserPlaylist(
             itemCount = songs.size,
             thumbnailUrl = coverUri ?: songs.firstOrNull()?.let { 
                 it.highResThumbnailUrl ?: it.thumbnailUrl ?: it.albumArtUri?.toString() 
-            }
+            },
+            description = description
         )
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
@@ -404,6 +404,12 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    fun moveSongInLocalPlaylist(playlistId: String, fromIndex: Int, toIndex: Int) {
+        viewModelScope.launch {
+            playlistRepository.moveSongInPlaylist(playlistId, fromIndex, toIndex)
+        }
+    }
+
     // Stats
     private val statsRepository = com.ivor.ivormusic.data.StatsRepository(application)
     private val _globalStats = MutableStateFlow(com.ivor.ivormusic.data.GlobalStats())

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
@@ -410,6 +410,12 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    fun replaceLocalPlaylistSongs(playlistId: String, songs: List<Song>) {
+        viewModelScope.launch {
+            playlistRepository.replacePlaylistSongs(playlistId, songs)
+        }
+    }
+
     // Stats
     private val statsRepository = com.ivor.ivormusic.data.StatsRepository(application)
     private val _globalStats = MutableStateFlow(com.ivor.ivormusic.data.GlobalStats())

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -71,6 +72,10 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         val localItems = localPlaylists.map { it.toDisplayItem() }
         localItems + ytPlaylists
     }.stateIn(viewModelScope, kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000), emptyList())
+    
+    val localPlaylistIds: StateFlow<Set<String>> = playlistRepository.userPlaylists
+        .map { playlists -> playlists.map { it.id }.toSet() }
+        .stateIn(viewModelScope, kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000), emptySet())
 
     private val _userAvatar = MutableStateFlow<String?>(sessionManager.getUserAvatar())
     val userAvatar: StateFlow<String?> = _userAvatar.asStateFlow()
@@ -384,6 +389,18 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     fun addSongToLocalPlaylist(playlistId: String, song: Song) {
         viewModelScope.launch {
             playlistRepository.addSongToPlaylist(playlistId, song)
+        }
+    }
+
+    fun updateLocalPlaylist(playlistId: String, name: String, description: String?) {
+        viewModelScope.launch {
+            playlistRepository.updatePlaylist(playlistId, name, description)
+        }
+    }
+
+    fun deleteLocalPlaylist(playlistId: String) {
+        viewModelScope.launch {
+            playlistRepository.deletePlaylist(playlistId)
         }
     }
 

--- a/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
@@ -875,8 +875,9 @@ fun PlaylistDetailScreen(
     var showEditDialog by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf(false) }
     var isReorderMode by remember { mutableStateOf(false) }
-    var draggingIndex by remember { mutableStateOf<Int?>(null) }
+    var draggingSongId by remember { mutableStateOf<String?>(null) }
     var dragOffsetY by remember { mutableFloatStateOf(0f) }
+    var reorderDirty by remember { mutableStateOf(false) }
     val density = androidx.compose.ui.platform.LocalDensity.current
     val itemHeightPx = with(density) { 72.dp.toPx() }
 
@@ -923,7 +924,13 @@ fun PlaylistDetailScreen(
                     }
                 },
                 navigationIcon = {
-                    IconButton(onClick = onBack) {
+                    IconButton(onClick = {
+                        if (reorderDirty) {
+                            viewModel.replaceLocalPlaylistSongs(resolvedPlaylist.id, songs)
+                            reorderDirty = false
+                        }
+                        onBack()
+                    }) {
                         Icon(Icons.AutoMirrored.Rounded.ArrowBack, "Back")
                     }
                 },
@@ -933,8 +940,12 @@ fun PlaylistDetailScreen(
                             onClick = {
                                 val enablingReorder = !isReorderMode
                                 isReorderMode = enablingReorder
-                                draggingIndex = null
+                                draggingSongId = null
                                 dragOffsetY = 0f
+                                if (!enablingReorder && reorderDirty) {
+                                    viewModel.replaceLocalPlaylistSongs(resolvedPlaylist.id, songs)
+                                    reorderDirty = false
+                                }
                                 if (enablingReorder) {
                                     isSearchActive = false
                                     searchQuery = ""
@@ -956,8 +967,12 @@ fun PlaylistDetailScreen(
                     IconButton(onClick = {
                         if (isReorderMode) {
                             isReorderMode = false
-                            draggingIndex = null
+                            draggingSongId = null
                             dragOffsetY = 0f
+                            if (reorderDirty) {
+                                viewModel.replaceLocalPlaylistSongs(resolvedPlaylist.id, songs)
+                                reorderDirty = false
+                            }
                         }
                         isSearchActive = !isSearchActive
                     }) {
@@ -974,7 +989,7 @@ fun PlaylistDetailScreen(
             )
         },
         floatingActionButton = {
-            if (filteredSongs.isNotEmpty()) {
+            if (filteredSongs.isNotEmpty() && !isReorderMode) {
                 ExtendedFloatingActionButton(
                     text = { Text("Play All") },
                     icon = { Icon(Icons.Rounded.PlayArrow, null) },
@@ -1051,15 +1066,30 @@ fun PlaylistDetailScreen(
                         )
 
                         if (isLocalPlaylist && isReorderMode) {
-                            Text(
-                                text = "Long-press and drag songs to change the playlist order",
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                textAlign = TextAlign.Center,
+                            Surface(
+                                shape = RoundedCornerShape(20.dp),
+                                color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.75f),
                                 modifier = Modifier
                                     .padding(horizontal = 24.dp)
-                                    .padding(top = 12.dp)
-                            )
+                                    .padding(top = 16.dp)
+                            ) {
+                                Row(
+                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Rounded.DragHandle,
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.onSecondaryContainer
+                                    )
+                                    Text(
+                                        text = "Reorder mode is on. Long-press a song and drag it anywhere in the playlist.",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onSecondaryContainer
+                                    )
+                                }
+                            }
                         }
 
                         if (!resolvedPlaylist.description.isNullOrBlank()) {
@@ -1128,10 +1158,10 @@ fun PlaylistDetailScreen(
                 } else {
                     itemsIndexed(
                         items = filteredSongs,
-                        key = { index, song -> "playlist_${resolvedPlaylist.id}_${song.id}_$index" }
+                        key = { _, song -> "playlist_${resolvedPlaylist.id}_${song.id}" }
                     ) { index, song ->
                         val reorderEnabled = isLocalPlaylist && isReorderMode && searchQuery.isBlank()
-                        val isDragging = draggingIndex == index
+                        val isDragging = draggingSongId == song.id
 
                         SongListItem(
                             song = song,
@@ -1142,43 +1172,51 @@ fun PlaylistDetailScreen(
                                 .offset(y = if (isDragging) with(density) { dragOffsetY.toDp() } else 0.dp)
                                 .then(
                                     if (reorderEnabled) {
-                                        Modifier.pointerInput(song.id, songs.size) {
+                                        Modifier.pointerInput(song.id) {
                                             detectDragGesturesAfterLongPress(
                                                 onDragStart = {
-                                                    val currentIndex = songs.indexOfFirst { it.id == song.id }
-                                                    draggingIndex = if (currentIndex >= 0) currentIndex else index
+                                                    draggingSongId = song.id
                                                     dragOffsetY = 0f
                                                 },
                                                 onDragEnd = {
-                                                    draggingIndex = null
+                                                    draggingSongId = null
                                                     dragOffsetY = 0f
+                                                    if (reorderDirty) {
+                                                        viewModel.replaceLocalPlaylistSongs(resolvedPlaylist.id, songs)
+                                                        reorderDirty = false
+                                                    }
                                                 },
                                                 onDragCancel = {
-                                                    draggingIndex = null
+                                                    draggingSongId = null
                                                     dragOffsetY = 0f
+                                                    if (reorderDirty) {
+                                                        viewModel.replaceLocalPlaylistSongs(resolvedPlaylist.id, songs)
+                                                        reorderDirty = false
+                                                    }
                                                 },
                                                 onDrag = { change, dragAmount ->
                                                     change.consume()
-                                                    if (draggingIndex == null) return@detectDragGesturesAfterLongPress
+                                                    if (draggingSongId == null) return@detectDragGesturesAfterLongPress
                                                     dragOffsetY += dragAmount.y
-                                                    while (dragOffsetY > itemHeightPx && draggingIndex!! < songs.lastIndex) {
-                                                        val fromIndex = draggingIndex!!
+                                                    var activeIndex = songs.indexOfFirst { it.id == draggingSongId }
+                                                    while (dragOffsetY > itemHeightPx && activeIndex in 0 until songs.lastIndex) {
+                                                        val fromIndex = activeIndex
                                                         val toIndex = fromIndex + 1
                                                         songs = songs.toMutableList().apply {
                                                             add(toIndex, removeAt(fromIndex))
                                                         }
-                                                        viewModel.moveSongInLocalPlaylist(resolvedPlaylist.id, fromIndex, toIndex)
-                                                        draggingIndex = toIndex
+                                                        reorderDirty = true
+                                                        activeIndex = toIndex
                                                         dragOffsetY -= itemHeightPx
                                                     }
-                                                    while (dragOffsetY < -itemHeightPx && draggingIndex!! > 0) {
-                                                        val fromIndex = draggingIndex!!
+                                                    while (dragOffsetY < -itemHeightPx && activeIndex > 0) {
+                                                        val fromIndex = activeIndex
                                                         val toIndex = fromIndex - 1
                                                         songs = songs.toMutableList().apply {
                                                             add(toIndex, removeAt(fromIndex))
                                                         }
-                                                        viewModel.moveSongInLocalPlaylist(resolvedPlaylist.id, fromIndex, toIndex)
-                                                        draggingIndex = toIndex
+                                                        reorderDirty = true
+                                                        activeIndex = toIndex
                                                         dragOffsetY += itemHeightPx
                                                     }
                                                 }
@@ -1190,14 +1228,32 @@ fun PlaylistDetailScreen(
                                 ),
                             trailingContent = if (reorderEnabled) {
                                 {
-                                    Icon(
-                                        imageVector = Icons.Rounded.DragHandle,
-                                        contentDescription = "Drag to reorder",
-                                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
+                                    Surface(
+                                        shape = RoundedCornerShape(14.dp),
+                                        color = if (isDragging) {
+                                            MaterialTheme.colorScheme.primaryContainer
+                                        } else {
+                                            MaterialTheme.colorScheme.surfaceContainerHighest
+                                        }
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Rounded.DragHandle,
+                                            contentDescription = "Drag to reorder",
+                                            tint = if (isDragging) {
+                                                MaterialTheme.colorScheme.onPrimaryContainer
+                                            } else {
+                                                MaterialTheme.colorScheme.onSurfaceVariant
+                                            },
+                                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)
+                                        )
+                                    }
                                 }
                             } else null,
-                            onClick = { onPlayQueue(filteredSongs, song) }
+                            onClick = {
+                                if (!reorderEnabled) {
+                                    onPlayQueue(filteredSongs, song)
+                                }
+                            }
                         )
                     }
                 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.List
 import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
-import androidx.compose.material.icons.automirrored.rounded.Sort
 import androidx.compose.material.icons.rounded.*
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.*
@@ -198,6 +197,13 @@ enum class LibraryTab(val label: String) {
     Albums("Albums")
 }
 
+enum class PlaylistSortOption(val label: String) {
+    RecentlyAdded("Recently added"),
+    NameAZ("Name A-Z"),
+    NameZA("Name Z-A"),
+    TrackCount("Track count")
+}
+
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun LibraryMainScreen(
@@ -212,12 +218,14 @@ fun LibraryMainScreen(
     onNavigateToStats: () -> Unit
 ) {
     val userPlaylists by viewModel.userPlaylists.collectAsState()
+    val localPlaylistIds by viewModel.localPlaylistIds.collectAsState()
     val likedSongs by viewModel.likedSongs.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
 
     var selectedTab by rememberSaveable { mutableStateOf(LibraryTab.All) }
     var searchQuery by rememberSaveable { mutableStateOf("") }
     var isSearchActive by rememberSaveable { mutableStateOf(false) }
+    var playlistSort by rememberSaveable { mutableStateOf(PlaylistSortOption.RecentlyAdded) }
 
     // Filtering logic
     val filteredSongs = remember(songs, searchQuery) {
@@ -226,9 +234,15 @@ fun LibraryMainScreen(
         }
     }
     
-    val filteredPlaylists = remember(userPlaylists, searchQuery) {
-        if (searchQuery.isBlank()) userPlaylists else userPlaylists.filter {
+    val filteredPlaylists = remember(userPlaylists, searchQuery, playlistSort) {
+        val filtered = if (searchQuery.isBlank()) userPlaylists else userPlaylists.filter {
             (it.name ?: "").contains(searchQuery, true)
+        }
+        when (playlistSort) {
+            PlaylistSortOption.RecentlyAdded -> filtered
+            PlaylistSortOption.NameAZ -> filtered.sortedBy { it.name?.lowercase() ?: "" }
+            PlaylistSortOption.NameZA -> filtered.sortedByDescending { it.name?.lowercase() ?: "" }
+            PlaylistSortOption.TrackCount -> filtered.sortedByDescending { it.itemCount }
         }
     }
 
@@ -275,6 +289,26 @@ fun LibraryMainScreen(
                         fontWeight = FontWeight.Bold
                     )
                     Row(verticalAlignment = Alignment.CenterVertically) {
+                        var showSortMenu by remember { mutableStateOf(false) }
+                        IconButton(onClick = { showSortMenu = true }) {
+                            Icon(Icons.Rounded.Sort, "Sort playlists")
+                        }
+                        DropdownMenu(expanded = showSortMenu, onDismissRequest = { showSortMenu = false }) {
+                            PlaylistSortOption.entries.forEach { option ->
+                                DropdownMenuItem(
+                                    text = { Text(option.label) },
+                                    onClick = {
+                                        playlistSort = option
+                                        showSortMenu = false
+                                    },
+                                    leadingIcon = {
+                                        if (playlistSort == option) {
+                                            Icon(Icons.Rounded.Check, contentDescription = null)
+                                        }
+                                    }
+                                )
+                            }
+                        }
                         IconButton(onClick = { isSearchActive = true }) {
                             Icon(Icons.Rounded.Search, "Search")
                         }
@@ -355,8 +389,15 @@ fun LibraryMainScreen(
                     LibraryTab.Playlists -> {
                         PlaylistsGrid(
                             playlists = filteredPlaylists,
+                            localPlaylistIds = localPlaylistIds,
                             likedSongs = likedSongs,
                             onPlaylistClick = onNavigateToPlaylist,
+                            onEditPlaylist = { playlist, newName, newDescription ->
+                                viewModel.updateLocalPlaylist(playlist.id, newName, newDescription)
+                            },
+                            onDeletePlaylist = { playlist ->
+                                viewModel.deleteLocalPlaylist(playlist.id)
+                            },
                             onLikedSongsClick = {
                                 onNavigateToPlaylist(PlaylistDisplayItem("Liked Songs", "LM", "You", likedSongs.size, null))
                             },
@@ -432,8 +473,11 @@ fun AllSongsList(
 @Composable
 fun PlaylistsGrid(
     playlists: List<PlaylistDisplayItem>,
+    localPlaylistIds: Set<String>,
     likedSongs: List<Song>,
     onPlaylistClick: (PlaylistDisplayItem) -> Unit,
+    onEditPlaylist: (playlist: PlaylistDisplayItem, newName: String, newDescription: String?) -> Unit,
+    onDeletePlaylist: (playlist: PlaylistDisplayItem) -> Unit,
     onLikedSongsClick: () -> Unit,
     contentPadding: PaddingValues
 ) {
@@ -460,10 +504,14 @@ fun PlaylistsGrid(
             )
         }
         items(playlists) { playlist ->
+            val isLocalPlaylist = localPlaylistIds.contains(playlist.id)
             ExpressivePlaylistCard(
                 name = playlist.name ?: "Untitled",
                 count = playlist.itemCount,
                 thumbnailUrl = playlist.thumbnailUrl,
+                isEditable = isLocalPlaylist,
+                onEditConfirmed = { name, description -> onEditPlaylist(playlist, name, description) },
+                onDeleteConfirmed = { onDeletePlaylist(playlist) },
                 onClick = { onPlaylistClick(playlist) }
             )
         }
@@ -611,8 +659,15 @@ fun ExpressivePlaylistCard(
     thumbnailUrl: String?,
     subtitle: String? = null,
     isLiked: Boolean = false,
+    isEditable: Boolean = false,
+    onEditConfirmed: (String, String?) -> Unit = { _, _ -> },
+    onDeleteConfirmed: () -> Unit = {},
     onClick: () -> Unit
 ) {
+    var showMenu by remember { mutableStateOf(false) }
+    var showEditDialog by remember { mutableStateOf(false) }
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
     Column(modifier = Modifier.clickable { onClick() }) {
         Surface(
             shape = RoundedCornerShape(20.dp),
@@ -636,9 +691,112 @@ fun ExpressivePlaylistCard(
             }
         }
         Spacer(Modifier.height(12.dp))
-        Text(name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
-        Text(subtitle ?: "$count songs", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text(subtitle ?: "$count songs", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1)
+            }
+            if (isEditable) {
+                Box {
+                    IconButton(onClick = { showMenu = true }) {
+                        Icon(Icons.Rounded.MoreVert, contentDescription = "Playlist options")
+                    }
+                    DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
+                        DropdownMenuItem(
+                            text = { Text("Edit") },
+                            onClick = {
+                                showMenu = false
+                                showEditDialog = true
+                            },
+                            leadingIcon = { Icon(Icons.Rounded.Edit, contentDescription = null) }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Delete") },
+                            onClick = {
+                                showMenu = false
+                                showDeleteDialog = true
+                            },
+                            leadingIcon = { Icon(Icons.Rounded.Delete, contentDescription = null) }
+                        )
+                    }
+                }
+            }
+        }
     }
+
+    if (showEditDialog) {
+        EditPlaylistDialog(
+            initialName = name,
+            initialDescription = null,
+            onDismiss = { showEditDialog = false },
+            onConfirm = { newName, newDescription ->
+                onEditConfirmed(newName, newDescription)
+                showEditDialog = false
+            }
+        )
+    }
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = { Text("Delete playlist?") },
+            text = { Text("This will permanently remove \"$name\" and its local metadata.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    onDeleteConfirmed()
+                    showDeleteDialog = false
+                }) {
+                    Text("Delete")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteDialog = false }) { Text("Cancel") }
+            }
+        )
+    }
+}
+
+@Composable
+private fun EditPlaylistDialog(
+    initialName: String,
+    initialDescription: String?,
+    onDismiss: () -> Unit,
+    onConfirm: (name: String, description: String?) -> Unit
+) {
+    var name by remember(initialName) { mutableStateOf(initialName) }
+    var description by remember(initialDescription) { mutableStateOf(initialDescription ?: "") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Edit playlist") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Name") },
+                    singleLine = true
+                )
+                OutlinedTextField(
+                    value = description,
+                    onValueChange = { description = it },
+                    label = { Text("Description") },
+                    maxLines = 2
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(name.trim(), description.trim().ifBlank { null }) },
+                enabled = name.isNotBlank()
+            ) { Text("Save") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        }
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
@@ -6,9 +6,11 @@ import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -30,18 +32,21 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.PlaylistDisplayItem
 import com.ivor.ivormusic.data.Song
 import com.ivor.ivormusic.ui.artist.ArtistScreen
 import com.ivor.ivormusic.ui.components.ExpressivePullToRefresh
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.runtime.mutableFloatStateOf
 import com.ivor.ivormusic.ui.home.HomeViewModel
 
 /**
@@ -509,6 +514,7 @@ fun PlaylistsGrid(
                 name = playlist.name ?: "Untitled",
                 count = playlist.itemCount,
                 thumbnailUrl = playlist.thumbnailUrl,
+                description = playlist.description,
                 isEditable = isLocalPlaylist,
                 onEditConfirmed = { name, description -> onEditPlaylist(playlist, name, description) },
                 onDeleteConfirmed = { onDeletePlaylist(playlist) },
@@ -658,6 +664,7 @@ fun ExpressivePlaylistCard(
     count: Int,
     thumbnailUrl: String?,
     subtitle: String? = null,
+    description: String? = null,
     isLiked: Boolean = false,
     isEditable: Boolean = false,
     onEditConfirmed: (String, String?) -> Unit = { _, _ -> },
@@ -730,7 +737,7 @@ fun ExpressivePlaylistCard(
     if (showEditDialog) {
         EditPlaylistDialog(
             initialName = name,
-            initialDescription = null,
+            initialDescription = description,
             onDismiss = { showEditDialog = false },
             onConfirm = { newName, newDescription ->
                 onEditConfirmed(newName, newDescription)
@@ -800,7 +807,12 @@ private fun EditPlaylistDialog(
 }
 
 @Composable
-fun SongListItem(song: Song, onClick: () -> Unit) {
+fun SongListItem(
+    song: Song,
+    modifier: Modifier = Modifier,
+    trailingContent: (@Composable () -> Unit)? = null,
+    onClick: () -> Unit
+) {
     ListItem(
         headlineContent = { Text(song.title, maxLines = 1, overflow = TextOverflow.Ellipsis, fontWeight = FontWeight.SemiBold) },
         supportingContent = { Text(song.artist, maxLines = 1, overflow = TextOverflow.Ellipsis) },
@@ -816,7 +828,8 @@ fun SongListItem(song: Song, onClick: () -> Unit) {
                     Box(contentAlignment = Alignment.Center) { Icon(Icons.Rounded.MusicNote, null, tint = MaterialTheme.colorScheme.onSurfaceVariant) }
             }
         },
-        modifier = Modifier.clickable(onClick = onClick),
+        trailingContent = trailingContent,
+        modifier = modifier.clickable(onClick = onClick),
         colors = ListItemDefaults.colors(containerColor = Color.Transparent)
     )
 }
@@ -848,10 +861,25 @@ fun PlaylistDetailScreen(
     preloadedSongs: List<Song>? = null,
     isAlbum: Boolean = false
 ) {
+    val userPlaylists by viewModel.userPlaylists.collectAsState()
+    val localPlaylistIds by viewModel.localPlaylistIds.collectAsState()
+    val resolvedPlaylist = remember(playlist, userPlaylists) {
+        userPlaylists.firstOrNull { it.id == playlist.id } ?: playlist
+    }
+    val isLocalPlaylist = remember(playlist.id, localPlaylistIds, isAlbum) {
+        !isAlbum && localPlaylistIds.contains(playlist.id)
+    }
     var songs by remember { mutableStateOf(preloadedSongs ?: emptyList()) }
     val isLoading by viewModel.isLoading.collectAsState()
     val isFetching = remember { mutableStateOf(songs.isEmpty()) }
-    
+    var showEditDialog by remember { mutableStateOf(false) }
+    var showDeleteDialog by remember { mutableStateOf(false) }
+    var isReorderMode by remember { mutableStateOf(false) }
+    var draggingIndex by remember { mutableStateOf<Int?>(null) }
+    var dragOffsetY by remember { mutableFloatStateOf(0f) }
+    val density = androidx.compose.ui.platform.LocalDensity.current
+    val itemHeightPx = with(density) { 72.dp.toPx() }
+
     // Search State
     var searchQuery by remember { mutableStateOf("") }
     var isSearchActive by remember { mutableStateOf(false) }
@@ -869,10 +897,10 @@ fun PlaylistDetailScreen(
         }
     }
 
-    LaunchedEffect(playlist.id) {
+    LaunchedEffect(resolvedPlaylist.id) {
         if (preloadedSongs == null) {
             isFetching.value = true
-            songs = viewModel.fetchPlaylistSongs(playlist.id)
+            songs = viewModel.fetchPlaylistSongs(resolvedPlaylist.id)
             isFetching.value = false
         }
     }
@@ -887,7 +915,7 @@ fun PlaylistDetailScreen(
                         exit = fadeOut() + slideOutVertically { it / 2 }
                     ) {
                         Text(
-                            playlist.name ?: "Unknown", 
+                            resolvedPlaylist.name ?: "Unknown",
                             maxLines = 1, 
                             overflow = TextOverflow.Ellipsis,
                             style = MaterialTheme.typography.titleMedium
@@ -900,7 +928,39 @@ fun PlaylistDetailScreen(
                     }
                 },
                 actions = {
-                    IconButton(onClick = { isSearchActive = !isSearchActive }) {
+                    if (isLocalPlaylist) {
+                        IconButton(
+                            onClick = {
+                                val enablingReorder = !isReorderMode
+                                isReorderMode = enablingReorder
+                                draggingIndex = null
+                                dragOffsetY = 0f
+                                if (enablingReorder) {
+                                    isSearchActive = false
+                                    searchQuery = ""
+                                }
+                            }
+                        ) {
+                            Icon(
+                                imageVector = if (isReorderMode) Icons.Rounded.Done else Icons.Rounded.DragHandle,
+                                contentDescription = if (isReorderMode) "Finish reordering" else "Reorder playlist"
+                            )
+                        }
+                        IconButton(onClick = { showEditDialog = true }) {
+                            Icon(Icons.Rounded.Edit, contentDescription = "Rename playlist")
+                        }
+                        IconButton(onClick = { showDeleteDialog = true }) {
+                            Icon(Icons.Rounded.Delete, contentDescription = "Delete playlist")
+                        }
+                    }
+                    IconButton(onClick = {
+                        if (isReorderMode) {
+                            isReorderMode = false
+                            draggingIndex = null
+                            dragOffsetY = 0f
+                        }
+                        isSearchActive = !isSearchActive
+                    }) {
                         Icon(
                             imageVector = if (isSearchActive) Icons.Rounded.Close else Icons.Rounded.Search,
                             contentDescription = "Search in playlist"
@@ -962,8 +1022,8 @@ fun PlaylistDetailScreen(
                             shadowElevation = 12.dp,
                             color = MaterialTheme.colorScheme.surfaceContainerHighest
                         ) {
-                             if (playlist.thumbnailUrl != null && playlist.thumbnailUrl != "null") {
-                                 AsyncImage(model = playlist.thumbnailUrl, contentDescription = null, contentScale = ContentScale.Crop)
+                             if (resolvedPlaylist.thumbnailUrl != null && resolvedPlaylist.thumbnailUrl != "null") {
+                                 AsyncImage(model = resolvedPlaylist.thumbnailUrl, contentDescription = null, contentScale = ContentScale.Crop)
                              } else {
                                 Box(contentAlignment = Alignment.Center) {
                                      Icon(if (isAlbum) Icons.Rounded.Album else Icons.AutoMirrored.Rounded.PlaylistPlay, null, modifier = Modifier.size(80.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
@@ -975,7 +1035,7 @@ fun PlaylistDetailScreen(
                         
                         // Title & Subtitle
                         Text(
-                            text = playlist.name ?: "Unknown",
+                            text = resolvedPlaylist.name ?: "Unknown",
                             style = MaterialTheme.typography.displaySmall, // Expressive Typography
                             fontWeight = FontWeight.Bold,
                             textAlign = TextAlign.Center,
@@ -983,12 +1043,36 @@ fun PlaylistDetailScreen(
                         )
                         
                         Text(
-                            text = if (isAlbum) "Album • ${playlist.uploaderName} • ${songs.size} tracks" else "Playlist • ${songs.size} tracks",
+                            text = if (isAlbum) "Album • ${resolvedPlaylist.uploaderName} • ${songs.size} tracks" else "Playlist • ${songs.size} tracks",
                             style = MaterialTheme.typography.titleMedium,
                             color = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.padding(horizontal = 24.dp).padding(top = 8.dp),
                             textAlign = TextAlign.Center
                         )
+
+                        if (isLocalPlaylist && isReorderMode) {
+                            Text(
+                                text = "Long-press and drag songs to change the playlist order",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                textAlign = TextAlign.Center,
+                                modifier = Modifier
+                                    .padding(horizontal = 24.dp)
+                                    .padding(top = 12.dp)
+                            )
+                        }
+
+                        if (!resolvedPlaylist.description.isNullOrBlank()) {
+                            Text(
+                                text = resolvedPlaylist.description,
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                textAlign = TextAlign.Center,
+                                modifier = Modifier
+                                    .padding(horizontal = 24.dp)
+                                    .padding(top = 12.dp)
+                            )
+                        }
                     }
                 }
             }
@@ -1042,14 +1126,116 @@ fun PlaylistDetailScreen(
                         }
                     }
                 } else {
-                    items(filteredSongs) { song ->
+                    itemsIndexed(
+                        items = filteredSongs,
+                        key = { index, song -> "playlist_${resolvedPlaylist.id}_${song.id}_$index" }
+                    ) { index, song ->
+                        val reorderEnabled = isLocalPlaylist && isReorderMode && searchQuery.isBlank()
+                        val isDragging = draggingIndex == index
+
                         SongListItem(
-                            song = song, 
+                            song = song,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .animateItem()
+                                .zIndex(if (isDragging) 2f else 0f)
+                                .offset(y = if (isDragging) with(density) { dragOffsetY.toDp() } else 0.dp)
+                                .then(
+                                    if (reorderEnabled) {
+                                        Modifier.pointerInput(song.id, songs.size) {
+                                            detectDragGesturesAfterLongPress(
+                                                onDragStart = {
+                                                    val currentIndex = songs.indexOfFirst { it.id == song.id }
+                                                    draggingIndex = if (currentIndex >= 0) currentIndex else index
+                                                    dragOffsetY = 0f
+                                                },
+                                                onDragEnd = {
+                                                    draggingIndex = null
+                                                    dragOffsetY = 0f
+                                                },
+                                                onDragCancel = {
+                                                    draggingIndex = null
+                                                    dragOffsetY = 0f
+                                                },
+                                                onDrag = { change, dragAmount ->
+                                                    change.consume()
+                                                    if (draggingIndex == null) return@detectDragGesturesAfterLongPress
+                                                    dragOffsetY += dragAmount.y
+                                                    while (dragOffsetY > itemHeightPx && draggingIndex!! < songs.lastIndex) {
+                                                        val fromIndex = draggingIndex!!
+                                                        val toIndex = fromIndex + 1
+                                                        songs = songs.toMutableList().apply {
+                                                            add(toIndex, removeAt(fromIndex))
+                                                        }
+                                                        viewModel.moveSongInLocalPlaylist(resolvedPlaylist.id, fromIndex, toIndex)
+                                                        draggingIndex = toIndex
+                                                        dragOffsetY -= itemHeightPx
+                                                    }
+                                                    while (dragOffsetY < -itemHeightPx && draggingIndex!! > 0) {
+                                                        val fromIndex = draggingIndex!!
+                                                        val toIndex = fromIndex - 1
+                                                        songs = songs.toMutableList().apply {
+                                                            add(toIndex, removeAt(fromIndex))
+                                                        }
+                                                        viewModel.moveSongInLocalPlaylist(resolvedPlaylist.id, fromIndex, toIndex)
+                                                        draggingIndex = toIndex
+                                                        dragOffsetY += itemHeightPx
+                                                    }
+                                                }
+                                            )
+                                        }
+                                    } else {
+                                        Modifier
+                                    }
+                                ),
+                            trailingContent = if (reorderEnabled) {
+                                {
+                                    Icon(
+                                        imageVector = Icons.Rounded.DragHandle,
+                                        contentDescription = "Drag to reorder",
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            } else null,
                             onClick = { onPlayQueue(filteredSongs, song) }
                         )
                     }
                 }
             }
         }
+    }
+
+    if (showEditDialog && isLocalPlaylist) {
+        EditPlaylistDialog(
+            initialName = resolvedPlaylist.name,
+            initialDescription = resolvedPlaylist.description,
+            onDismiss = { showEditDialog = false },
+            onConfirm = { newName, newDescription ->
+                viewModel.updateLocalPlaylist(resolvedPlaylist.id, newName, newDescription)
+                showEditDialog = false
+            }
+        )
+    }
+
+    if (showDeleteDialog && isLocalPlaylist) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = { Text("Delete playlist?") },
+            text = { Text("This will permanently remove \"${resolvedPlaylist.name}\" and its local metadata.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.deleteLocalPlaylist(resolvedPlaylist.id)
+                    showDeleteDialog = false
+                    onBack()
+                }) {
+                    Text("Delete")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
@@ -2,6 +2,7 @@ package com.ivor.ivormusic.ui.library
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.*
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
@@ -38,6 +39,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import coil.compose.AsyncImage
@@ -810,28 +812,109 @@ private fun EditPlaylistDialog(
 fun SongListItem(
     song: Song,
     modifier: Modifier = Modifier,
+    containerColor: Color = Color.Transparent,
+    tonalElevation: Dp = 0.dp,
+    shadowElevation: Dp = 0.dp,
+    shape: androidx.compose.ui.graphics.Shape = RoundedCornerShape(0.dp),
     trailingContent: (@Composable () -> Unit)? = null,
     onClick: () -> Unit
 ) {
-    ListItem(
-        headlineContent = { Text(song.title, maxLines = 1, overflow = TextOverflow.Ellipsis, fontWeight = FontWeight.SemiBold) },
-        supportingContent = { Text(song.artist, maxLines = 1, overflow = TextOverflow.Ellipsis) },
-        leadingContent = {
-            Surface(
-                shape = RoundedCornerShape(12.dp),
-                color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                modifier = Modifier.size(48.dp)
+    Surface(
+        modifier = modifier,
+        color = containerColor,
+        shape = shape,
+        tonalElevation = tonalElevation,
+        shadowElevation = shadowElevation
+    ) {
+        ListItem(
+            headlineContent = { Text(song.title, maxLines = 1, overflow = TextOverflow.Ellipsis, fontWeight = FontWeight.SemiBold) },
+            supportingContent = { Text(song.artist, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+            leadingContent = {
+                Surface(
+                    shape = RoundedCornerShape(12.dp),
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    modifier = Modifier.size(48.dp)
+                ) {
+                    if (song.albumArtUri != null || song.thumbnailUrl != null)
+                        AsyncImage(model = song.highResThumbnailUrl ?: song.albumArtUri ?: song.thumbnailUrl, contentDescription = null, contentScale = ContentScale.Crop)
+                    else
+                        Box(contentAlignment = Alignment.Center) { Icon(Icons.Rounded.MusicNote, null, tint = MaterialTheme.colorScheme.onSurfaceVariant) }
+                }
+            },
+            trailingContent = trailingContent,
+            modifier = Modifier.clickable(onClick = onClick),
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent)
+        )
+    }
+}
+
+@Composable
+private fun ReorderModeCard(
+    trackCount: Int,
+    onDone: () -> Unit
+) {
+    ElevatedCard(
+        shape = RoundedCornerShape(28.dp),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer
+        ),
+        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 8.dp),
+        modifier = Modifier
+            .padding(horizontal = 24.dp)
+            .padding(top = 16.dp)
+            .fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                if (song.albumArtUri != null || song.thumbnailUrl != null)
-                    AsyncImage(model = song.highResThumbnailUrl ?: song.albumArtUri ?: song.thumbnailUrl, contentDescription = null, contentScale = ContentScale.Crop)
-                else
-                    Box(contentAlignment = Alignment.Center) { Icon(Icons.Rounded.MusicNote, null, tint = MaterialTheme.colorScheme.onSurfaceVariant) }
+                Surface(
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.secondary,
+                    modifier = Modifier.size(44.dp)
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(
+                            imageVector = Icons.Rounded.DragHandle,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSecondary
+                        )
+                    }
+                }
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Reorder Playlist",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer
+                    )
+                    Text(
+                        text = "Long-press any track and drag it anywhere. $trackCount tracks will keep this new order.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.82f)
+                    )
+                }
             }
-        },
-        trailingContent = trailingContent,
-        modifier = modifier.clickable(onClick = onClick),
-        colors = ListItemDefaults.colors(containerColor = Color.Transparent)
-    )
+
+            FilledTonalButton(
+                onClick = onDone,
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(20.dp),
+                colors = ButtonDefaults.filledTonalButtonColors(
+                    containerColor = MaterialTheme.colorScheme.secondary,
+                    contentColor = MaterialTheme.colorScheme.onSecondary
+                )
+            ) {
+                Icon(Icons.Rounded.Done, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text("Done Reordering", style = MaterialTheme.typography.titleMedium)
+            }
+        }
+    }
 }
 
 @Composable
@@ -1066,30 +1149,18 @@ fun PlaylistDetailScreen(
                         )
 
                         if (isLocalPlaylist && isReorderMode) {
-                            Surface(
-                                shape = RoundedCornerShape(20.dp),
-                                color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.75f),
-                                modifier = Modifier
-                                    .padding(horizontal = 24.dp)
-                                    .padding(top = 16.dp)
-                            ) {
-                                Row(
-                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
-                                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                                    verticalAlignment = Alignment.CenterVertically
-                                ) {
-                                    Icon(
-                                        imageVector = Icons.Rounded.DragHandle,
-                                        contentDescription = null,
-                                        tint = MaterialTheme.colorScheme.onSecondaryContainer
-                                    )
-                                    Text(
-                                        text = "Reorder mode is on. Long-press a song and drag it anywhere in the playlist.",
-                                        style = MaterialTheme.typography.bodyMedium,
-                                        color = MaterialTheme.colorScheme.onSecondaryContainer
-                                    )
+                            ReorderModeCard(
+                                trackCount = songs.size,
+                                onDone = {
+                                    isReorderMode = false
+                                    draggingSongId = null
+                                    dragOffsetY = 0f
+                                    if (reorderDirty) {
+                                        viewModel.replaceLocalPlaylistSongs(resolvedPlaylist.id, songs)
+                                        reorderDirty = false
+                                    }
                                 }
-                            }
+                            )
                         }
 
                         if (!resolvedPlaylist.description.isNullOrBlank()) {
@@ -1162,12 +1233,36 @@ fun PlaylistDetailScreen(
                     ) { index, song ->
                         val reorderEnabled = isLocalPlaylist && isReorderMode && searchQuery.isBlank()
                         val isDragging = draggingSongId == song.id
+                        val animatedContainerColor by animateColorAsState(
+                            targetValue = when {
+                                isDragging -> MaterialTheme.colorScheme.primaryContainer
+                                reorderEnabled -> MaterialTheme.colorScheme.surfaceContainerLow
+                                else -> Color.Transparent
+                            },
+                            animationSpec = spring(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessMediumLow),
+                            label = "playlist_row_container"
+                        )
+                        val animatedTonalElevation by animateDpAsState(
+                            targetValue = when {
+                                isDragging -> 8.dp
+                                reorderEnabled -> 2.dp
+                                else -> 0.dp
+                            },
+                            animationSpec = spring(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessMediumLow),
+                            label = "playlist_row_tonal"
+                        )
+                        val animatedShadowElevation by animateDpAsState(
+                            targetValue = if (isDragging) 10.dp else 0.dp,
+                            animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessLow),
+                            label = "playlist_row_shadow"
+                        )
 
                         SongListItem(
                             song = song,
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .animateItem()
+                                .padding(horizontal = 12.dp, vertical = if (reorderEnabled) 4.dp else 0.dp)
+                                .then(if (isDragging) Modifier else Modifier.animateItem())
                                 .zIndex(if (isDragging) 2f else 0f)
                                 .offset(y = if (isDragging) with(density) { dragOffsetY.toDp() } else 0.dp)
                                 .then(
@@ -1226,25 +1321,39 @@ fun PlaylistDetailScreen(
                                         Modifier
                                     }
                                 ),
+                            containerColor = animatedContainerColor,
+                            tonalElevation = animatedTonalElevation,
+                            shadowElevation = animatedShadowElevation,
+                            shape = if (reorderEnabled) RoundedCornerShape(24.dp) else RoundedCornerShape(0.dp),
                             trailingContent = if (reorderEnabled) {
                                 {
-                                    Surface(
-                                        shape = RoundedCornerShape(14.dp),
-                                        color = if (isDragging) {
-                                            MaterialTheme.colorScheme.primaryContainer
-                                        } else {
-                                            MaterialTheme.colorScheme.surfaceContainerHighest
-                                        }
+                                    Column(
+                                        horizontalAlignment = Alignment.End,
+                                        verticalArrangement = Arrangement.spacedBy(6.dp)
                                     ) {
-                                        Icon(
-                                            imageVector = Icons.Rounded.DragHandle,
-                                            contentDescription = "Drag to reorder",
-                                            tint = if (isDragging) {
-                                                MaterialTheme.colorScheme.onPrimaryContainer
+                                        Surface(
+                                            shape = RoundedCornerShape(14.dp),
+                                            color = if (isDragging) {
+                                                MaterialTheme.colorScheme.tertiaryContainer
                                             } else {
-                                                MaterialTheme.colorScheme.onSurfaceVariant
-                                            },
-                                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)
+                                                MaterialTheme.colorScheme.surfaceContainerHighest
+                                            }
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Rounded.DragHandle,
+                                                contentDescription = "Drag to reorder",
+                                                tint = if (isDragging) {
+                                                    MaterialTheme.colorScheme.onTertiaryContainer
+                                                } else {
+                                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                                },
+                                                modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)
+                                            )
+                                        }
+                                        Text(
+                                            text = if (isDragging) "Moving" else "Hold",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
                                         )
                                     }
                                 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
@@ -1009,10 +1009,11 @@ private fun ExpressiveQueueView(
                                 .animateItem()
                                 .zIndex(if (isDragging) 2f else 0f)
                                 .offset(y = if (isDragging) with(density) { dragOffsetY.toDp() } else 0.dp)
-                                .pointerInput(index, queue.size) {
+                                .pointerInput(song.id) {
                                     detectDragGesturesAfterLongPress(
                                         onDragStart = {
-                                            draggingIndex = index
+                                            val currentIndex = queue.indexOfFirst { it.id == song.id }
+                                            draggingIndex = if (currentIndex >= 0) currentIndex else index
                                             dragOffsetY = 0f
                                         },
                                         onDragEnd = {
@@ -1025,7 +1026,7 @@ private fun ExpressiveQueueView(
                                         },
                                         onDrag = { change, dragAmount ->
                                             change.consume()
-                                            if (draggingIndex != index) return@detectDragGesturesAfterLongPress
+                                            if (draggingIndex == null) return@detectDragGesturesAfterLongPress
                                             dragOffsetY += dragAmount.y
                                             while (dragOffsetY > itemHeightPx && draggingIndex!! < queue.lastIndex) {
                                                 onMoveSong(draggingIndex!!, draggingIndex!! + 1)

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.input.pointer.consume
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
@@ -1150,7 +1149,7 @@ private fun ExpressiveQueueView(
                                     modifier = Modifier.size(32.dp)
                                 ) {
                                     Icon(
-                                        imageVector = Icons.Rounded.Close,
+                                        imageVector = Icons.Filled.Close,
                                         contentDescription = "Remove from queue",
                                         tint = onSurfaceVariantColor
                                     )

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
@@ -5,8 +5,10 @@ import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -33,11 +35,14 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.consume
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.media3.common.Player
 import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.Song
@@ -116,6 +121,8 @@ fun PlayerSheetContent(
                     queue = currentQueue,
                     currentSong = currentSong,
                     onSongClick = { song -> viewModel.playQueue(currentQueue, song) },
+                    onMoveSong = { from, to -> viewModel.moveQueueItem(from, to) },
+                    onRemoveSong = { index -> viewModel.removeQueueItem(index) },
                     onLoadMore = onLoadMore,
                     isLoadingMore = isLoadingMore,
                     onCollapse = onCollapse,
@@ -738,12 +745,14 @@ private fun ExpressiveNowPlayingView(
  * - Currently playing indicator with expressive icon
  * - Load more button with shape morphing
  */
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalFoundationApi::class)
 @Composable
 private fun ExpressiveQueueView(
     queue: List<Song>,
     currentSong: Song?,
     onSongClick: (Song) -> Unit,
+    onMoveSong: (fromIndex: Int, toIndex: Int) -> Unit,
+    onRemoveSong: (index: Int) -> Unit,
     onLoadMore: () -> Unit,
     isLoadingMore: Boolean,
     onCollapse: () -> Unit,
@@ -757,6 +766,10 @@ private fun ExpressiveQueueView(
     stableShapes: IconButtonShapes
 ) {
     val primaryContainerColor = MaterialTheme.colorScheme.primaryContainer
+    var draggingIndex by remember { mutableStateOf<Int?>(null) }
+    var dragOffsetY by remember { mutableFloatStateOf(0f) }
+    val density = LocalDensity.current
+    val itemHeightPx = with(density) { 80.dp.toPx() }
     
     Box(
         modifier = Modifier
@@ -989,9 +1002,45 @@ private fun ExpressiveQueueView(
                     // ========== QUEUE ITEMS ==========
                     itemsIndexed(queue, key = { _, song -> "queue_${song.id}" }) { index, song ->
                         val isCurrent = song.id == currentSong?.id
+                        val isDragging = draggingIndex == index
                         
                         Surface(
-                            modifier = Modifier.fillMaxWidth(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .animateItem()
+                                .zIndex(if (isDragging) 2f else 0f)
+                                .offset(y = if (isDragging) with(density) { dragOffsetY.toDp() } else 0.dp)
+                                .pointerInput(index, queue.size) {
+                                    detectDragGesturesAfterLongPress(
+                                        onDragStart = {
+                                            draggingIndex = index
+                                            dragOffsetY = 0f
+                                        },
+                                        onDragEnd = {
+                                            draggingIndex = null
+                                            dragOffsetY = 0f
+                                        },
+                                        onDragCancel = {
+                                            draggingIndex = null
+                                            dragOffsetY = 0f
+                                        },
+                                        onDrag = { change, dragAmount ->
+                                            change.consume()
+                                            if (draggingIndex != index) return@detectDragGesturesAfterLongPress
+                                            dragOffsetY += dragAmount.y
+                                            while (dragOffsetY > itemHeightPx && draggingIndex!! < queue.lastIndex) {
+                                                onMoveSong(draggingIndex!!, draggingIndex!! + 1)
+                                                draggingIndex = draggingIndex!! + 1
+                                                dragOffsetY -= itemHeightPx
+                                            }
+                                            while (dragOffsetY < -itemHeightPx && draggingIndex!! > 0) {
+                                                onMoveSong(draggingIndex!!, draggingIndex!! - 1)
+                                                draggingIndex = draggingIndex!! - 1
+                                                dragOffsetY += itemHeightPx
+                                            }
+                                        }
+                                    )
+                                },
                             shape = RoundedCornerShape(20.dp),
                             color = if (isCurrent) primaryColor.copy(alpha = 0.12f) 
                                    else MaterialTheme.colorScheme.surfaceContainerLow,
@@ -1093,6 +1142,18 @@ private fun ExpressiveQueueView(
                                         modifier = Modifier.size(16.dp)
                                     )
                                     Spacer(modifier = Modifier.width(8.dp))
+                                }
+
+                                IconButton(
+                                    onClick = { onRemoveSong(index) },
+                                    enabled = queue.size > 1,
+                                    modifier = Modifier.size(32.dp)
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Rounded.Close,
+                                        contentDescription = "Remove from queue",
+                                        tint = onSurfaceVariantColor
+                                    )
                                 }
                             }
                         }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
@@ -500,6 +500,30 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
         }
     }
 
+    fun moveQueueItem(fromIndex: Int, toIndex: Int) {
+        val currentList = _currentQueue.value
+        if (fromIndex !in currentList.indices || toIndex !in currentList.indices || fromIndex == toIndex) return
+
+        val mutable = currentList.toMutableList()
+        val movedSong = mutable.removeAt(fromIndex)
+        mutable.add(toIndex, movedSong)
+        _currentQueue.value = mutable
+
+        controller?.moveMediaItem(fromIndex, toIndex)
+    }
+
+    fun removeQueueItem(index: Int) {
+        val currentList = _currentQueue.value
+        if (index !in currentList.indices) return
+        if (currentList.size <= 1) return
+
+        val mutable = currentList.toMutableList()
+        mutable.removeAt(index)
+        _currentQueue.value = mutable
+
+        controller?.removeMediaItem(index)
+    }
+
     private fun createMediaItem(song: Song): MediaItem {
         return if (song.source == com.ivor.ivormusic.data.SongSource.LOCAL && song.uri != null) {
             // For local songs, we still need to set mediaId for proper tracking


### PR DESCRIPTION
### Motivation
- Enable full local playlist management (edit name/description, delete) and provide a better UX for ordering and managing the play queue. 
- Provide user-facing playlist sorting options and make queue reordering/removal feel native with long-press drag gestures and smooth animations.

### Description
- Added `updatePlaylist` to `PlaylistRepository` which trims input, regenerates generated cover art when the leading letter changes, and persists the updated `UserPlaylist` JSON file.
- Exposed local playlist IDs and new actions in `HomeViewModel` via `localPlaylistIds`, `updateLocalPlaylist(...)`, and `deleteLocalPlaylist(...)` so the UI only allows edits for local playlists.
- Library UI changes in `LibraryScreen.kt`: added `PlaylistSortOption` (RecentlyAdded, Name A→Z, Name Z→A, TrackCount), a header sort menu, sorted/filtered `filteredPlaylists`, and wired sort selection to the grid.
- Playlist card UX updates: `ExpressivePlaylistCard` now supports `isEditable`, an overflow menu with `Edit` (opens `EditPlaylistDialog`) and `Delete` (confirmation `AlertDialog`) options, and these call through to the `HomeViewModel` actions.
- Player queue improvements: `PlayerViewModel` gets `moveQueueItem(fromIndex,toIndex)` and `removeQueueItem(index)` that update `_currentQueue` and call the Media3 `controller` methods (`moveMediaItem` / `removeMediaItem`).
- Player sheet UI (`PlayerSheetContent.kt`) now implements `ExpressiveQueueView` drag support: long-press + `detectDragGesturesAfterLongPress`, per-item dragging state, animated placement (`animateItem()` + `zIndex` + offset), and a per-item remove `IconButton`; the UI calls the new `PlayerViewModel` queue functions.
- Minor import and icon adjustments to fix API usage (`pointerInput`, `consume`, `Sort` icon usage).

### Testing
- Attempted compile: ran `./gradlew :app:compileDebugKotlin`, which failed in this environment due to a Gradle/SDK toolchain error (`25.0.1`) unrelated to the Kotlin changes, so full compilation verification could not be completed. 
- Local static checks: source files were parsed and lightweight searches (`rg`, `sed`) were used to verify symbols and wiring; changes committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e36ca337dc833185ab9d4ef8d0655b)