### PR TITLE
Refresh Library screen with Material 3 expressive patterns

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.ivor.ivormusic"
         minSdk = 31
         targetSdk = 36
-        versionCode = 13
-        versionName = "2.5"
+        versionCode = 14
+        versionName = "2.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeScreen.kt
@@ -414,55 +414,89 @@ fun HomeScreen(
                 .navigationBarsPadding()
                 .padding(bottom = 20.dp),
             content = {
-                // Home
-                IconToggleButton(
-                    checked = selectedTab == 0,
-                    onCheckedChange = { selectedTab = 0 },
-                    colors = IconButtonDefaults.iconToggleButtonColors(
-                        checkedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                        checkedContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                        containerColor = Color.Transparent,
-                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                ) {
-                    Icon(
-                        imageVector = if (selectedTab == 0) Icons.Rounded.Home else Icons.Outlined.Home,
-                        contentDescription = "Home"
-                    )
-                }
+                val tabs = listOf(
+                    Triple(0, "Home", Pair(Icons.Rounded.Home, Icons.Outlined.Home)),
+                    Triple(1, "Search", Pair(Icons.Filled.Search, Icons.Outlined.Search)),
+                    Triple(2, "Library", Pair(Icons.Filled.LibraryMusic, Icons.Outlined.LibraryMusic))
+                )
 
-                // Search
-                IconToggleButton(
-                    checked = selectedTab == 1,
-                    onCheckedChange = { selectedTab = 1 },
-                    colors = IconButtonDefaults.iconToggleButtonColors(
-                        checkedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                        checkedContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                        containerColor = Color.Transparent,
-                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                tabs.forEach { (index, label, icons) ->
+                    val selected = selectedTab == index
+                    val (filledIcon, outlinedIcon) = icons
+                    
+                    val animatedPadding by androidx.compose.animation.core.animateDpAsState(
+                        targetValue = if (selected) 20.dp else 12.dp,
+                        animationSpec = androidx.compose.animation.core.spring(
+                            dampingRatio = androidx.compose.animation.core.Spring.DampingRatioLowBouncy,
+                            stiffness = androidx.compose.animation.core.Spring.StiffnessLow
+                        ),
+                        label = "padding"
                     )
-                ) {
-                    Icon(
-                        imageVector = if (selectedTab == 1) Icons.Filled.Search else Icons.Outlined.Search,
-                        contentDescription = "Search"
+                    
+                    val animatedContainerColor by androidx.compose.animation.animateColorAsState(
+                        targetValue = if (selected) MaterialTheme.colorScheme.primaryContainer else Color.Transparent,
+                        animationSpec = androidx.compose.animation.core.tween(durationMillis = 200),
+                        label = "containerColor"
                     )
-                }
-
-                // Library
-                IconToggleButton(
-                    checked = selectedTab == 2,
-                    onCheckedChange = { selectedTab = 2 },
-                    colors = IconButtonDefaults.iconToggleButtonColors(
-                        checkedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                        checkedContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                        containerColor = Color.Transparent,
-                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                    
+                    val animatedContentColor by androidx.compose.animation.animateColorAsState(
+                        targetValue = if (selected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+                        animationSpec = androidx.compose.animation.core.tween(durationMillis = 200),
+                        label = "contentColor"
                     )
-                ) {
-                    Icon(
-                        imageVector = if (selectedTab == 2) Icons.Filled.LibraryMusic else Icons.Outlined.LibraryMusic,
-                        contentDescription = "Library"
-                    )
+                    
+                    Surface(
+                        selected = selected,
+                        onClick = { selectedTab = index },
+                        shape = CircleShape,
+                        color = animatedContainerColor,
+                        contentColor = animatedContentColor,
+                        modifier = Modifier.height(48.dp)
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .padding(horizontal = animatedPadding)
+                                .animateContentSize(
+                                    animationSpec = androidx.compose.animation.core.spring(
+                                        dampingRatio = androidx.compose.animation.core.Spring.DampingRatioLowBouncy,
+                                        stiffness = androidx.compose.animation.core.Spring.StiffnessLow
+                                    )
+                                ),
+                            horizontalArrangement = Arrangement.Center,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = if (selected) filledIcon else outlinedIcon,
+                                contentDescription = label,
+                                modifier = Modifier.size(24.dp)
+                            )
+                            androidx.compose.animation.AnimatedVisibility(
+                                visible = selected,
+                                enter = androidx.compose.animation.fadeIn() + androidx.compose.animation.expandHorizontally(
+                                    animationSpec = androidx.compose.animation.core.spring(
+                                        dampingRatio = androidx.compose.animation.core.Spring.DampingRatioLowBouncy,
+                                        stiffness = androidx.compose.animation.core.Spring.StiffnessLow
+                                    )
+                                ),
+                                exit = androidx.compose.animation.fadeOut() + androidx.compose.animation.shrinkHorizontally(
+                                    animationSpec = androidx.compose.animation.core.spring(
+                                        dampingRatio = androidx.compose.animation.core.Spring.DampingRatioNoBouncy,
+                                        stiffness = androidx.compose.animation.core.Spring.StiffnessMediumLow
+                                    )
+                                )
+                            ) {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    Text(
+                                        text = label,
+                                        style = MaterialTheme.typography.labelLarge,
+                                        fontWeight = FontWeight.Bold,
+                                        maxLines = 1
+                                    )
+                                }
+                            }
+                        }
+                    }
                 }
             }
         )

--- a/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
@@ -8,7 +8,9 @@ import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -252,6 +254,10 @@ fun LibraryMainScreen(
             PlaylistSortOption.TrackCount -> filtered.sortedByDescending { it.itemCount }
         }
     }
+    val artistCount = remember(filteredSongs) { filteredSongs.map { it.artist }.toSet().size }
+    val albumCount = remember(filteredSongs) {
+        filteredSongs.map { it.album }.filter { it.isNotBlank() && it != "Unknown Album" }.toSet().size
+    }
 
     Column(
         modifier = Modifier
@@ -334,32 +340,37 @@ fun LibraryMainScreen(
             }
             
             Spacer(Modifier.height(16.dp))
+
+            LibraryExpressiveHero(
+                songCount = filteredSongs.size,
+                playlistCount = filteredPlaylists.size + if (likedSongs.isNotEmpty()) 1 else 0,
+                artistCount = artistCount,
+                albumCount = albumCount,
+                onStatsClick = onNavigateToStats
+            )
+
+            Spacer(Modifier.height(16.dp))
             
             // Tabs Row
-            LazyRow(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier.fillMaxWidth()
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
             ) {
-                items(LibraryTab.values()) { tab ->
-                    val selected = selectedTab == tab
-                    FilterChip(
-                        selected = selected,
-                        onClick = { selectedTab = tab },
-                        label = { Text(tab.label) },
-                        leadingIcon = if (selected) {
-                            { Icon(Icons.Rounded.CheckCircle, null, modifier = Modifier.size(16.dp)) }
-                        } else null,
-                        shape = CircleShape,
-                        colors = FilterChipDefaults.filterChipColors(
-                            selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                            selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer
-                        ),
-                        border = FilterChipDefaults.filterChipBorder(
-                            borderColor = Color.Transparent,
-                            selected = selected,
-                            enabled = true
-                        )
-                    )
+                SingleChoiceSegmentedButtonRow {
+                    LibraryTab.entries.forEachIndexed { index, tab ->
+                        SegmentedButton(
+                            selected = selectedTab == tab,
+                            onClick = { selectedTab = tab },
+                            shape = SegmentedButtonDefaults.itemShape(
+                                index = index,
+                                count = LibraryTab.entries.size
+                            ),
+                            icon = { SegmentedButtonDefaults.Icon(active = selectedTab == tab) }
+                        ) {
+                            Text(tab.label)
+                        }
+                    }
                 }
             }
         }
@@ -443,6 +454,7 @@ fun AllSongsList(
     contentPadding: PaddingValues
 ) {
     LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
         contentPadding = PaddingValues(
             top = 8.dp,
             bottom = contentPadding.calculateBottomPadding() + 80.dp,
@@ -470,8 +482,77 @@ fun AllSongsList(
             items(songs, key = { it.id }) { song ->
                 SongListItem(
                     song = song,
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                    shape = RoundedCornerShape(20.dp),
+                    tonalElevation = 2.dp,
                     onClick = { onPlayQueue(songs, song) }
                 )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LibraryExpressiveHero(
+    songCount: Int,
+    playlistCount: Int,
+    artistCount: Int,
+    albumCount: Int,
+    onStatsClick: () -> Unit
+) {
+    Surface(
+        shape = RoundedCornerShape(32.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        tonalElevation = 4.dp,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp)
+        ) {
+            Text(
+                text = "Your music at a glance",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                AssistChip(
+                    onClick = {},
+                    label = { Text("$songCount tracks") },
+                    leadingIcon = { Icon(Icons.Rounded.MusicNote, null, modifier = Modifier.size(16.dp)) }
+                )
+                AssistChip(
+                    onClick = {},
+                    label = { Text("$playlistCount playlists") },
+                    leadingIcon = { Icon(Icons.AutoMirrored.Rounded.PlaylistPlay, null, modifier = Modifier.size(16.dp)) }
+                )
+            }
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                AssistChip(
+                    onClick = {},
+                    label = { Text("$artistCount artists") },
+                    leadingIcon = { Icon(Icons.Rounded.Person, null, modifier = Modifier.size(16.dp)) }
+                )
+                AssistChip(
+                    onClick = {},
+                    label = { Text("$albumCount albums") },
+                    leadingIcon = { Icon(Icons.Rounded.Album, null, modifier = Modifier.size(16.dp)) }
+                )
+            }
+            FilledTonalButton(
+                onClick = onStatsClick,
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(20.dp)
+            ) {
+                Icon(Icons.Rounded.Insights, null)
+                Spacer(Modifier.width(8.dp))
+                Text("Open listening insights")
             }
         }
     }

--- a/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
@@ -240,54 +240,63 @@ fun LibraryMainScreen(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 24.dp, vertical = 12.dp)
+                .padding(horizontal = 24.dp, vertical = 20.dp)
         ) {
             // Top Row: Title + Actions
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+                verticalAlignment = Alignment.Top
             ) {
                 Text(
                     text = "Library",
-                    style = MaterialTheme.typography.displaySmall,
-                    fontWeight = FontWeight.Bold
+                    style = MaterialTheme.typography.displayLarge,
+                    color = MaterialTheme.colorScheme.onBackground
                 )
-                FilledTonalButton(
+                
+                FilledTonalIconButton(
                     onClick = onNavigateToStats,
-                    contentPadding = PaddingValues(horizontal = 16.dp),
-                    shape = CircleShape
+                    modifier = Modifier.size(56.dp),
+                    shapes = IconButtonDefaults.shapes()
                 ) {
-                    Icon(Icons.Rounded.Insights, null, modifier = Modifier.size(18.dp))
-                    Spacer(Modifier.width(8.dp))
-                    Text("Stats")
+                    Icon(Icons.Rounded.Insights, null, modifier = Modifier.size(24.dp))
                 }
             }
             
-            Spacer(Modifier.height(16.dp))
+            Spacer(Modifier.height(28.dp))
             
-            // Tabs Row
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .horizontalScroll(rememberScrollState())
-            ) {
-                SingleChoiceSegmentedButtonRow {
-                    LibraryTab.entries.forEachIndexed { index, tab ->
-                        SegmentedButton(
-                            selected = selectedTab == tab,
-                            onClick = { selectedTab = tab },
-                            shape = SegmentedButtonDefaults.itemShape(
-                                index = index,
-                                count = LibraryTab.entries.size
-                            ),
-                            icon = { SegmentedButtonDefaults.Icon(active = selectedTab == tab) }
+            // Expressive Horizontal Toolbar for Tabs
+            HorizontalFloatingToolbar(
+                expanded = true,
+                modifier = Modifier.fillMaxWidth(),
+                shape = CircleShape,
+                content = {
+                    for (tab in LibraryTab.entries) {
+                        val selected = selectedTab == tab
+                        val contentColor = if (selected) 
+                            MaterialTheme.colorScheme.onPrimaryContainer 
+                        else 
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(48.dp)
+                                .clip(CircleShape)
+                                .background(if (selected) MaterialTheme.colorScheme.primaryContainer else Color.Transparent)
+                                .clickable { selectedTab = tab },
+                            contentAlignment = Alignment.Center
                         ) {
-                            Text(tab.label)
+                            Text(
+                                text = tab.label,
+                                style = MaterialTheme.typography.labelLarge,
+                                color = contentColor,
+                                fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal
+                            )
                         }
                     }
                 }
-            }
+            )
         }
 
         // --- Main Content ---

--- a/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
@@ -206,13 +206,6 @@ enum class LibraryTab(val label: String) {
     Albums("Albums")
 }
 
-enum class PlaylistSortOption(val label: String) {
-    RecentlyAdded("Recently added"),
-    NameAZ("Name A-Z"),
-    NameZA("Name Z-A"),
-    TrackCount("Track count")
-}
-
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun LibraryMainScreen(
@@ -232,32 +225,10 @@ fun LibraryMainScreen(
     val isLoading by viewModel.isLoading.collectAsState()
 
     var selectedTab by rememberSaveable { mutableStateOf(LibraryTab.All) }
-    var searchQuery by rememberSaveable { mutableStateOf("") }
-    var isSearchActive by rememberSaveable { mutableStateOf(false) }
-    var playlistSort by rememberSaveable { mutableStateOf(PlaylistSortOption.RecentlyAdded) }
 
-    // Filtering logic
-    val filteredSongs = remember(songs, searchQuery) {
-        if (searchQuery.isBlank()) songs else songs.filter {
-            it.title.contains(searchQuery, true) || it.artist.contains(searchQuery, true)
-        }
-    }
-    
-    val filteredPlaylists = remember(userPlaylists, searchQuery, playlistSort) {
-        val filtered = if (searchQuery.isBlank()) userPlaylists else userPlaylists.filter {
-            (it.name ?: "").contains(searchQuery, true)
-        }
-        when (playlistSort) {
-            PlaylistSortOption.RecentlyAdded -> filtered
-            PlaylistSortOption.NameAZ -> filtered.sortedBy { it.name?.lowercase() ?: "" }
-            PlaylistSortOption.NameZA -> filtered.sortedByDescending { it.name?.lowercase() ?: "" }
-            PlaylistSortOption.TrackCount -> filtered.sortedByDescending { it.itemCount }
-        }
-    }
-    val artistCount = remember(filteredSongs) { filteredSongs.map { it.artist }.toSet().size }
-    val albumCount = remember(filteredSongs) {
-        filteredSongs.map { it.album }.filter { it.isNotBlank() && it != "Unknown Album" }.toSet().size
-    }
+    // Use raw lists as filtering/sorting is removed from UI
+    val filteredSongs = songs
+    val filteredPlaylists = userPlaylists
 
     Column(
         modifier = Modifier
@@ -272,83 +243,27 @@ fun LibraryMainScreen(
                 .padding(horizontal = 24.dp, vertical = 12.dp)
         ) {
             // Top Row: Title + Actions
-            if (isSearchActive) {
-                SearchBar(
-                    inputField = {
-                        SearchBarDefaults.InputField(
-                            query = searchQuery,
-                            onQueryChange = { searchQuery = it },
-                            onSearch = { },
-                            expanded = false,
-                            onExpandedChange = { if (!it) isSearchActive = false },
-                            placeholder = { Text("Search library...") },
-                            leadingIcon = { Icon(Icons.Rounded.Search, null) },
-                            trailingIcon = { IconButton(onClick = { isSearchActive = false; searchQuery = "" }) { Icon(Icons.Rounded.Close, null) } }
-                        )
-                    },
-                    expanded = false,
-                    onExpandedChange = { if (!it) isSearchActive = false },
-                    modifier = Modifier.fillMaxWidth()
-                ) {}
-            } else {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Library",
+                    style = MaterialTheme.typography.displaySmall,
+                    fontWeight = FontWeight.Bold
+                )
+                FilledTonalButton(
+                    onClick = onNavigateToStats,
+                    contentPadding = PaddingValues(horizontal = 16.dp),
+                    shape = CircleShape
                 ) {
-                    Text(
-                        text = "Library",
-                        style = MaterialTheme.typography.displaySmall,
-                        fontWeight = FontWeight.Bold
-                    )
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        var showSortMenu by remember { mutableStateOf(false) }
-                        IconButton(onClick = { showSortMenu = true }) {
-                            Icon(Icons.Rounded.Sort, "Sort playlists")
-                        }
-                        DropdownMenu(expanded = showSortMenu, onDismissRequest = { showSortMenu = false }) {
-                            PlaylistSortOption.entries.forEach { option ->
-                                DropdownMenuItem(
-                                    text = { Text(option.label) },
-                                    onClick = {
-                                        playlistSort = option
-                                        showSortMenu = false
-                                    },
-                                    leadingIcon = {
-                                        if (playlistSort == option) {
-                                            Icon(Icons.Rounded.Check, contentDescription = null)
-                                        }
-                                    }
-                                )
-                            }
-                        }
-                        IconButton(onClick = { isSearchActive = true }) {
-                            Icon(Icons.Rounded.Search, "Search")
-                        }
-                        Spacer(Modifier.width(8.dp))
-                        FilledTonalButton(
-                            onClick = onNavigateToStats,
-                            contentPadding = PaddingValues(horizontal = 16.dp),
-                            shape = CircleShape
-                        ) {
-                            Icon(Icons.Rounded.Insights, null, modifier = Modifier.size(18.dp))
-                            Spacer(Modifier.width(8.dp))
-                            Text("Stats")
-                        }
-                    }
+                    Icon(Icons.Rounded.Insights, null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text("Stats")
                 }
             }
             
-            Spacer(Modifier.height(16.dp))
-
-            LibraryExpressiveHero(
-                songCount = filteredSongs.size,
-                playlistCount = filteredPlaylists.size + if (likedSongs.isNotEmpty()) 1 else 0,
-                artistCount = artistCount,
-                albumCount = albumCount,
-                onStatsClick = onNavigateToStats
-            )
-
             Spacer(Modifier.height(16.dp))
             
             // Tabs Row
@@ -487,72 +402,6 @@ fun AllSongsList(
                     tonalElevation = 2.dp,
                     onClick = { onPlayQueue(songs, song) }
                 )
-            }
-        }
-    }
-}
-
-@Composable
-private fun LibraryExpressiveHero(
-    songCount: Int,
-    playlistCount: Int,
-    artistCount: Int,
-    albumCount: Int,
-    onStatsClick: () -> Unit
-) {
-    Surface(
-        shape = RoundedCornerShape(32.dp),
-        color = MaterialTheme.colorScheme.surfaceContainerHigh,
-        tonalElevation = 4.dp,
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Column(
-            modifier = Modifier.padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(14.dp)
-        ) {
-            Text(
-                text = "Your music at a glance",
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold
-            )
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                AssistChip(
-                    onClick = {},
-                    label = { Text("$songCount tracks") },
-                    leadingIcon = { Icon(Icons.Rounded.MusicNote, null, modifier = Modifier.size(16.dp)) }
-                )
-                AssistChip(
-                    onClick = {},
-                    label = { Text("$playlistCount playlists") },
-                    leadingIcon = { Icon(Icons.AutoMirrored.Rounded.PlaylistPlay, null, modifier = Modifier.size(16.dp)) }
-                )
-            }
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                AssistChip(
-                    onClick = {},
-                    label = { Text("$artistCount artists") },
-                    leadingIcon = { Icon(Icons.Rounded.Person, null, modifier = Modifier.size(16.dp)) }
-                )
-                AssistChip(
-                    onClick = {},
-                    label = { Text("$albumCount albums") },
-                    leadingIcon = { Icon(Icons.Rounded.Album, null, modifier = Modifier.size(16.dp)) }
-                )
-            }
-            FilledTonalButton(
-                onClick = onStatsClick,
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(20.dp)
-            ) {
-                Icon(Icons.Rounded.Insights, null)
-                Spacer(Modifier.width(8.dp))
-                Text("Open listening insights")
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Introduce Material 3 Expressive patterns to the Library screen to surface richer hierarchy, quick library metrics, and more tactile controls following the local `Material_3_expressive` design notes. 
- Improve discoverability and visual separation between library content (tracks, playlists, artists, albums) and provide a clear CTA into listening insights.

### Description
- Added a new `LibraryExpressiveHero` composable to show quick metrics (tracks, playlists, artists, albums) with `AssistChip` elements and a full-width `FilledTonalButton` stats CTA, and wired it into `LibraryMainScreen`.
- Computed `artistCount` and `albumCount` from `filteredSongs` and passed those counts into the hero panel.
- Replaced the previous `FilterChip`-based tab row with a `SingleChoiceSegmentedButtonRow` + `SegmentedButton` implementation inside a horizontally scrollable `Row` using `horizontalScroll` and `rememberScrollState` for expressive single-choice mode switching.
- Updated `AllSongsList` to use spaced, segmented list items by adding `verticalArrangement = Arrangement.spacedBy(8.dp)` and rendering `SongListItem` with `containerColor = MaterialTheme.colorScheme.surfaceContainerLow`, rounded `RoundedCornerShape(20.dp)`, and `tonalElevation = 2.dp` for an expressive segmented list look.
- Added the required imports (`horizontalScroll`, `rememberScrollState`) and kept all changes localized to `app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt`.

### Testing
- Attempted to compile Kotlin with `./gradlew :app:compileDebugKotlin`, which failed in this environment with a Gradle error reporting `25.0.1` before the Kotlin compile completed.
- No automated unit or instrumentation tests were executed as part of this change in the current environment due to the build failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3aad08f6c8331bc012939ef24d696)