### PR TITLE
Add timed comments overlay for video player and rework onboarding UI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.ivor.ivormusic"
         minSdk = 31
         targetSdk = 36
-        versionCode = 17
-        versionName = "3.6"
+        versionCode = 18
+        versionName = "4.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -55,6 +55,7 @@ class MainActivity : ComponentActivity() {
             val videoMode by themeViewModel.videoMode.collectAsState()
             val playerStyle by themeViewModel.playerStyle.collectAsState()
             val saveVideoHistory by themeViewModel.saveVideoHistory.collectAsState()
+            val timedCommentsEnabled by themeViewModel.timedCommentsEnabled.collectAsState()
             val excludedFolders by themeViewModel.excludedFolders.collectAsState()
             val oemFixEnabled by themeViewModel.oemFixEnabled.collectAsState()
             val manualScanEnabled by themeViewModel.manualScanEnabled.collectAsState()
@@ -94,6 +95,8 @@ class MainActivity : ComponentActivity() {
                         onPlayerStyleChange = { themeViewModel.setPlayerStyle(it) },
                         saveVideoHistory = saveVideoHistory,
                         onSaveVideoHistoryToggle = { themeViewModel.setSaveVideoHistory(it) },
+                        timedCommentsEnabled = timedCommentsEnabled,
+                        onTimedCommentsToggle = { themeViewModel.setTimedCommentsEnabled(it) },
                         excludedFolders = excludedFolders,
                         onAddExcludedFolder = { themeViewModel.addExcludedFolder(it) },
                         onRemoveExcludedFolder = { themeViewModel.removeExcludedFolder(it) },
@@ -136,6 +139,8 @@ fun MusicApp(
     onPlayerStyleChange: (PlayerStyle) -> Unit,
     saveVideoHistory: Boolean,
     onSaveVideoHistoryToggle: (Boolean) -> Unit,
+    timedCommentsEnabled: Boolean,
+    onTimedCommentsToggle: (Boolean) -> Unit,
     excludedFolders: Set<String>,
     onAddExcludedFolder: (String) -> Unit,
     onRemoveExcludedFolder: (String) -> Unit,
@@ -247,6 +252,8 @@ fun MusicApp(
                     onPlayerStyleChange = onPlayerStyleChange,
                     saveVideoHistory = saveVideoHistory,
                     onSaveVideoHistoryToggle = onSaveVideoHistoryToggle,
+                    timedCommentsEnabled = timedCommentsEnabled,
+                    onTimedCommentsToggle = onTimedCommentsToggle,
                     excludedFolders = excludedFolders,
                     onAddExcludedFolder = onAddExcludedFolder,
                     onRemoveExcludedFolder = onRemoveExcludedFolder,
@@ -350,7 +357,8 @@ fun MusicApp(
         }
         
         com.ivor.ivormusic.ui.video.VideoPlayerOverlay(
-            viewModel = videoPlayerViewModel
+            viewModel = videoPlayerViewModel,
+            timedCommentsEnabled = timedCommentsEnabled
         )
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
@@ -33,6 +33,9 @@ class ThemePreferences(context: Context) {
     
     private val _saveVideoHistory = MutableStateFlow(getSaveVideoHistoryPreference())
     val saveVideoHistory: StateFlow<Boolean> = _saveVideoHistory.asStateFlow()
+
+    private val _timedCommentsEnabled = MutableStateFlow(getTimedCommentsEnabledPreference())
+    val timedCommentsEnabled: StateFlow<Boolean> = _timedCommentsEnabled.asStateFlow()
     
     private val _excludedFolders = MutableStateFlow(getExcludedFoldersPreference())
     val excludedFolders: StateFlow<Set<String>> = _excludedFolders.asStateFlow()
@@ -69,6 +72,7 @@ class ThemePreferences(context: Context) {
         private const val KEY_VIDEO_MODE = "video_mode"
         private const val KEY_PLAYER_STYLE = "player_style"
         private const val KEY_SAVE_VIDEO_HISTORY = "save_video_history"
+        private const val KEY_TIMED_COMMENTS_ENABLED = "timed_comments_enabled"
         private const val KEY_EXCLUDED_FOLDERS = "excluded_folders"
         private const val KEY_CACHE_ENABLED = "cache_enabled"
         private const val KEY_MAX_CACHE_SIZE_MB = "max_cache_size_mb"
@@ -264,6 +268,21 @@ class ThemePreferences(context: Context) {
      */
     fun toggleSaveVideoHistory() {
         setSaveVideoHistory(!_saveVideoHistory.value)
+    }
+
+    /**
+     * Get the stored timed comments preference. Defaults to false (off).
+     */
+    private fun getTimedCommentsEnabledPreference(): Boolean {
+        return prefs.getBoolean(KEY_TIMED_COMMENTS_ENABLED, false)
+    }
+
+    /**
+     * Save timed comments preference and update the flow.
+     */
+    fun setTimedCommentsEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_TIMED_COMMENTS_ENABLED, enabled).apply()
+        _timedCommentsEnabled.value = enabled
     }
     
     /**

--- a/app/src/main/java/com/ivor/ivormusic/data/VideoEngagement.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/VideoEngagement.kt
@@ -44,3 +44,12 @@ data class CommentsPage(
     val comments: List<CommentItem>,
     val nextPageToken: String?
 )
+
+/**
+ * A comment whose text references a playback timestamp (e.g. "2:31 is wild").
+ * timeMs is the first timestamp mentioned in the comment, in milliseconds.
+ */
+data class TimedComment(
+    val comment: CommentItem,
+    val timeMs: Long
+)

--- a/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
@@ -2521,6 +2521,29 @@ class YouTubeRepository(private val context: Context) {
                  }
              }
              
+             // Channel avatar lives inline in the lockup metadata:
+             // metadata.image.decoratedAvatarViewModel.avatar.avatarViewModel.image.sources[]
+             val channelIconUrl = metadata
+                 ?.optJSONObject("image")
+                 ?.optJSONObject("decoratedAvatarViewModel")
+                 ?.optJSONObject("avatar")
+                 ?.optJSONObject("avatarViewModel")
+                 ?.optJSONObject("image")
+                 ?.optJSONArray("sources")
+                 ?.let { sources ->
+                     var bestUrl: String? = null
+                     var maxWidth = -1
+                     for (i in 0 until sources.length()) {
+                         val source = sources.optJSONObject(i)
+                         val width = source?.optInt("width", 0) ?: 0
+                         if (width >= maxWidth) {
+                             maxWidth = width
+                             bestUrl = source?.optString("url")
+                         }
+                     }
+                     bestUrl?.takeIf { it.isNotBlank() }
+                 }
+
              // Get thumbnail
              val contentImage = lockupViewModel.optJSONObject("contentImage")
              val thumbnailViewModel = contentImage?.optJSONObject("collectionThumbnailViewModel")
@@ -2611,7 +2634,7 @@ class YouTubeRepository(private val context: Context) {
                 title = title,
                 channelName = channelName,
                 channelId = channelId,
-                channelIconUrl = null, // Skip heavy recursion for icon
+                channelIconUrl = channelIconUrl,
                 thumbnailUrl = thumbnailUrl,
                 duration = durationSeconds,
                 viewCount = viewCount,

--- a/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
@@ -1235,6 +1235,70 @@ class YouTubeRepository(private val context: Context) {
         visitorData: String,
         extraClientFields: org.json.JSONObject = org.json.JSONObject(),
     ): String? = withContext(Dispatchers.IO) {
+        val streamingData = fetchPlayerStreamingData(
+            videoId, clientName, clientVersion, clientNameId, userAgent, visitorData, extraClientFields
+        ) ?: return@withContext null
+
+        val formats = mutableListOf<org.json.JSONObject>()
+        streamingData.optJSONArray("adaptiveFormats")?.let { arr ->
+            for (i in 0 until arr.length()) formats.add(arr.getJSONObject(i))
+        }
+        streamingData.optJSONArray("formats")?.let { arr ->
+            for (i in 0 until arr.length()) formats.add(arr.getJSONObject(i))
+        }
+
+        fun hasPlayableUrl(f: org.json.JSONObject): Boolean = !f.optString("url").isNullOrEmpty()
+
+        val audioFormats = formats.filter {
+            it.optString("mimeType").contains("audio") && hasPlayableUrl(it)
+        }
+        android.util.Log.d(
+            "YouTubeRepository",
+            "Resolve[InnerTube/$clientName] formats=${formats.size} audioOnly=${audioFormats.size} videoId=$videoId",
+        )
+
+        audioFormats.maxByOrNull { it.optInt("bitrate") }?.optString("url")
+            ?.takeIf { it.isNotEmpty() }?.let { return@withContext it }
+
+        // No audio-only stream available — fall back to a muxed MP4 (itag 18 etc.).
+        // ExoPlayer happily plays just the audio track of these.
+        val muxedFormats = formats.filter {
+            it.optString("mimeType").startsWith("video/") && hasPlayableUrl(it)
+        }
+        muxedFormats.minByOrNull { it.optInt("bitrate") }?.optString("url")
+            ?.takeIf { it.isNotEmpty() }?.let {
+                android.util.Log.w(
+                    "YouTubeRepository",
+                    "Resolve[InnerTube/$clientName] using muxed video format videoId=$videoId (no audio-only)",
+                )
+                return@withContext it
+            }
+
+        val cipheredCount = formats.count {
+            !it.optString("signatureCipher").isNullOrEmpty() ||
+                !it.optString("cipher").isNullOrEmpty()
+        }
+        android.util.Log.w(
+            "YouTubeRepository",
+            "Resolve[InnerTube/$clientName] no usable URL videoId=$videoId ciphered=${cipheredCount}/${formats.size}",
+        )
+        null
+    }
+
+    /**
+     * Single-client InnerTube /player call returning the raw streamingData
+     * object, or null on any failure (HTTP error, bad playability, missing
+     * streamingData). Shared by audio resolution and video quality listing.
+     */
+    private suspend fun fetchPlayerStreamingData(
+        videoId: String,
+        clientName: String,
+        clientVersion: String,
+        clientNameId: Int,
+        userAgent: String,
+        visitorData: String,
+        extraClientFields: org.json.JSONObject = org.json.JSONObject(),
+    ): org.json.JSONObject? = withContext(Dispatchers.IO) {
         try {
             val clientObj = org.json.JSONObject().apply {
                 put("clientName", clientName)
@@ -1313,58 +1377,13 @@ class YouTubeRepository(private val context: Context) {
                 return@withContext null
             }
 
-            val streamingData = root.optJSONObject("streamingData") ?: run {
+            root.optJSONObject("streamingData") ?: run {
                 android.util.Log.w(
                     "YouTubeRepository",
                     "Resolve[InnerTube/$clientName] no streamingData videoId=$videoId",
                 )
-                return@withContext null
+                null
             }
-
-            val formats = mutableListOf<org.json.JSONObject>()
-            streamingData.optJSONArray("adaptiveFormats")?.let { arr ->
-                for (i in 0 until arr.length()) formats.add(arr.getJSONObject(i))
-            }
-            streamingData.optJSONArray("formats")?.let { arr ->
-                for (i in 0 until arr.length()) formats.add(arr.getJSONObject(i))
-            }
-
-            fun hasPlayableUrl(f: org.json.JSONObject): Boolean = !f.optString("url").isNullOrEmpty()
-
-            val audioFormats = formats.filter {
-                it.optString("mimeType").contains("audio") && hasPlayableUrl(it)
-            }
-            android.util.Log.d(
-                "YouTubeRepository",
-                "Resolve[InnerTube/$clientName] formats=${formats.size} audioOnly=${audioFormats.size} videoId=$videoId",
-            )
-
-            audioFormats.maxByOrNull { it.optInt("bitrate") }?.optString("url")
-                ?.takeIf { it.isNotEmpty() }?.let { return@withContext it }
-
-            // No audio-only stream available — fall back to a muxed MP4 (itag 18 etc.).
-            // ExoPlayer happily plays just the audio track of these.
-            val muxedFormats = formats.filter {
-                it.optString("mimeType").startsWith("video/") && hasPlayableUrl(it)
-            }
-            muxedFormats.minByOrNull { it.optInt("bitrate") }?.optString("url")
-                ?.takeIf { it.isNotEmpty() }?.let {
-                    android.util.Log.w(
-                        "YouTubeRepository",
-                        "Resolve[InnerTube/$clientName] using muxed video format videoId=$videoId (no audio-only)",
-                    )
-                    return@withContext it
-                }
-
-            val cipheredCount = formats.count {
-                !it.optString("signatureCipher").isNullOrEmpty() ||
-                    !it.optString("cipher").isNullOrEmpty()
-            }
-            android.util.Log.w(
-                "YouTubeRepository",
-                "Resolve[InnerTube/$clientName] no usable URL videoId=$videoId ciphered=${cipheredCount}/${formats.size}",
-            )
-            null
         } catch (e: Exception) {
             android.util.Log.e(
                 "YouTubeRepository",
@@ -2531,20 +2550,37 @@ class YouTubeRepository(private val context: Context) {
              val overlays = thumbnailViewModel?.optJSONArray("overlays")
              var durationSeconds = 0L
              var durationText = ""
+             var hasLiveBadge = false
              if (overlays != null) {
-                 for (i in 0 until overlays.length()) {
-                     val overlayItem = overlays.optJSONObject(i)
-                     // Try thumbnailOverlayBadgeViewModel path
-                     val badgeText = overlayItem?.optJSONObject("thumbnailOverlayBadgeViewModel")
-                         ?.optJSONArray("thumbnailBadges")?.optJSONObject(0)
-                         ?.optJSONObject("thumbnailBadgeViewModel")?.optString("text")
-                     if (badgeText != null && badgeText.contains(":")) {
-                         durationText = badgeText
-                         durationSeconds = parseDurationToSeconds(badgeText)
-                         break
+                 overlayLoop@ for (i in 0 until overlays.length()) {
+                     val overlayItem = overlays.optJSONObject(i) ?: continue
+                     // Badge containers: legacy thumbnailOverlayBadgeViewModel.thumbnailBadges
+                     // and the modern (2026) thumbnailBottomOverlayViewModel.badges
+                     val badgeArrays = listOfNotNull(
+                         overlayItem.optJSONObject("thumbnailOverlayBadgeViewModel")
+                             ?.optJSONArray("thumbnailBadges"),
+                         overlayItem.optJSONObject("thumbnailBottomOverlayViewModel")
+                             ?.optJSONArray("badges")
+                     )
+                     for (badges in badgeArrays) {
+                         for (j in 0 until badges.length()) {
+                             val badge = badges.optJSONObject(j)
+                                 ?.optJSONObject("thumbnailBadgeViewModel") ?: continue
+                             val badgeText = badge.optString("text")
+                             if (badge.optString("badgeStyle").contains("LIVE") ||
+                                 badgeText.equals("LIVE", ignoreCase = true)
+                             ) {
+                                 hasLiveBadge = true
+                             }
+                             if (badgeText.contains(":")) {
+                                 durationText = badgeText
+                                 durationSeconds = parseDurationToSeconds(badgeText)
+                                 break@overlayLoop
+                             }
+                         }
                      }
                      // Try thumbnailOverlayTimeStatusRenderer path
-                     val timeStatus = overlayItem?.optJSONObject("thumbnailOverlayTimeStatusRenderer")
+                     val timeStatus = overlayItem.optJSONObject("thumbnailOverlayTimeStatusRenderer")
                          ?.optJSONObject("text")?.optString("simpleText")
                      if (timeStatus != null && timeStatus.contains(":")) {
                          durationText = timeStatus
@@ -2566,7 +2602,8 @@ class YouTubeRepository(private val context: Context) {
              }
              
              // Assume it's not live if we couldn't find duration (most videos have a duration)
-             val isLive = durationText.contains("LIVE", ignoreCase = true) || 
+             val isLive = hasLiveBadge ||
+                         durationText.contains("LIVE", ignoreCase = true) ||
                          viewCount.contains("watching", ignoreCase = true)
              
             return VideoItem(
@@ -2843,6 +2880,24 @@ class YouTubeRepository(private val context: Context) {
      * Use this to start playback ASAP, then call getVideoDetails() for the rest.
      */
     suspend fun getVideoStreamQualities(videoId: String): List<VideoQuality> = withContext(Dispatchers.IO) {
+        // Primary: direct InnerTube /player with the ANDROID_VR client. It returns
+        // the full adaptive ladder (up to 2160p60) with direct, unciphered URLs,
+        // where NewPipe's WEB-based extraction often degrades to the muxed 360p
+        // format 18 (PO-Token enforcement).
+        try {
+            val innerTubeQualities = getVideoQualitiesFromInnerTube(videoId)
+            if (innerTubeQualities.isNotEmpty()) {
+                android.util.Log.i(
+                    "YouTubeRepo",
+                    "Video qualities via InnerTube: ${innerTubeQualities.size} for $videoId"
+                )
+                return@withContext innerTubeQualities
+            }
+        } catch (e: Exception) {
+            android.util.Log.w("YouTubeRepo", "InnerTube quality resolution failed, falling back to NewPipe", e)
+        }
+
+        // Fallback: NewPipe extractor.
         try {
             val streamUrl = "https://www.youtube.com/watch?v=$videoId"
             val ytService = ServiceList.all().find { it.serviceInfo.name == "YouTube" } 
@@ -2888,6 +2943,125 @@ class YouTubeRepository(private val context: Context) {
             android.util.Log.e("YouTubeRepo", "Error getting video stream qualities", e)
             emptyList()
         }
+    }
+
+    /**
+     * Resolve the full video quality ladder via InnerTube: ANDROID_VR first
+     * (no PO token, unciphered URLs), IOS as fallback. Returns an empty list
+     * when neither client yields usable streamingData.
+     */
+    private suspend fun getVideoQualitiesFromInnerTube(videoId: String): List<VideoQuality> {
+        val visitorData = getVisitorData()
+
+        val androidVrExtras = org.json.JSONObject().apply {
+            put("androidSdkVersion", 32)
+            put("deviceMake", "Oculus")
+            put("deviceModel", "Quest 3")
+            put("osName", "Android")
+            put("osVersion", "12L")
+        }
+        val iosExtras = org.json.JSONObject().apply {
+            put("deviceMake", "Apple")
+            put("deviceModel", "iPhone16,2")
+            put("osName", "iPhone")
+            put("osVersion", "18.1.0.22B83")
+        }
+
+        val streamingData = fetchPlayerStreamingData(
+            videoId = videoId,
+            clientName = "ANDROID_VR",
+            clientVersion = ANDROID_VR_VERSION,
+            clientNameId = ANDROID_VR_CLIENT_ID,
+            userAgent = ANDROID_VR_USER_AGENT,
+            visitorData = visitorData,
+            extraClientFields = androidVrExtras,
+        ) ?: fetchPlayerStreamingData(
+            videoId = videoId,
+            clientName = "IOS",
+            clientVersion = IOS_VERSION,
+            clientNameId = IOS_CLIENT_ID,
+            userAgent = IOS_USER_AGENT,
+            visitorData = visitorData,
+            extraClientFields = iosExtras,
+        ) ?: return emptyList()
+
+        return parseQualitiesFromStreamingData(streamingData)
+    }
+
+    private fun parseQualitiesFromStreamingData(streamingData: org.json.JSONObject): List<VideoQuality> {
+        fun org.json.JSONArray.objects(): List<org.json.JSONObject> =
+            (0 until length()).mapNotNull { optJSONObject(it) }
+
+        val adaptive = streamingData.optJSONArray("adaptiveFormats")?.objects() ?: emptyList()
+        val muxed = streamingData.optJSONArray("formats")?.objects() ?: emptyList()
+
+        // Best separate audio track; prefer AAC (mp4a) for broad hardware support,
+        // then highest bitrate.
+        val bestAudioUrl = adaptive
+            .filter { it.optString("mimeType").startsWith("audio/") && it.optString("url").isNotEmpty() }
+            .maxWithOrNull(
+                compareBy(
+                    { if (it.optString("mimeType").contains("mp4a")) 1 else 0 },
+                    { it.optInt("bitrate") }
+                )
+            )
+            ?.optString("url")?.takeIf { it.isNotEmpty() }
+
+        // Codec preference for the video track: H.264 decodes everywhere,
+        // VP9 is widely supported, AV1 only on recent chipsets.
+        fun codecRank(mimeType: String): Int = when {
+            mimeType.contains("avc1") -> 3
+            mimeType.contains("vp9") || mimeType.contains("vp09") -> 2
+            else -> 1
+        }
+
+        fun container(mimeType: String): String =
+            mimeType.substringAfter("video/").substringBefore(";").ifEmpty { "mp4" }
+
+        val qualities = mutableListOf<VideoQuality>()
+
+        // Video-only adaptive formats, one entry per quality label, merged with
+        // the best audio track at playback time.
+        if (bestAudioUrl != null) {
+            adaptive
+                .filter {
+                    it.optString("mimeType").startsWith("video/") &&
+                        it.optString("url").isNotEmpty() &&
+                        it.optString("qualityLabel").isNotEmpty()
+                }
+                .groupBy { it.optString("qualityLabel") }
+                .forEach { (label, formats) ->
+                    val best = formats.maxWithOrNull(
+                        compareBy({ codecRank(it.optString("mimeType")) }, { it.optInt("bitrate") })
+                    ) ?: return@forEach
+                    qualities.add(
+                        VideoQuality(
+                            resolution = label,
+                            url = best.optString("url"),
+                            format = container(best.optString("mimeType")),
+                            isDASH = false,
+                            audioUrl = bestAudioUrl
+                        )
+                    )
+                }
+        }
+
+        // Muxed formats (itag 18 etc.) fill in labels not already covered and
+        // keep playback possible when no audio-only track exists.
+        muxed.forEach { f ->
+            val label = f.optString("qualityLabel")
+            val url = f.optString("url")
+            if (label.isNotEmpty() && url.isNotEmpty() && qualities.none { it.resolution == label }) {
+                qualities.add(VideoQuality(label, url, container(f.optString("mimeType")), false))
+            }
+        }
+
+        // Highest resolution first, 60fps variants before 30fps at equal height.
+        fun height(label: String): Int = label.takeWhile { it.isDigit() }.toIntOrNull() ?: 0
+        fun fps(label: String): Int = label.substringAfter("p", "").takeWhile { it.isDigit() }.toIntOrNull() ?: 30
+        return qualities.sortedWith(
+            compareByDescending<VideoQuality> { height(it.resolution) }.thenByDescending { fps(it.resolution) }
+        )
     }
 
     /**

--- a/app/src/main/java/com/ivor/ivormusic/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/onboarding/OnboardingScreen.kt
@@ -7,8 +7,10 @@ import android.os.Build
 import android.os.Environment
 import android.provider.Settings
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
@@ -17,6 +19,8 @@ import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -29,9 +33,9 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.pager.HorizontalPager
@@ -41,8 +45,10 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.ArrowForward
 import androidx.compose.material.icons.rounded.Album
+import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.CloudSync
 import androidx.compose.material.icons.rounded.Folder
@@ -51,24 +57,26 @@ import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material.icons.rounded.NotificationsActive
 import androidx.compose.material.icons.rounded.Palette
 import androidx.compose.material.icons.rounded.PhoneAndroid
-import androidx.compose.material.icons.rounded.Security
+import androidx.compose.material.icons.rounded.Tune
 import androidx.compose.material.icons.rounded.Videocam
 import androidx.compose.material.icons.rounded.Wallpaper
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ButtonGroupDefaults
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.LinearWavyProgressIndicator
 import androidx.compose.material3.MaterialShapes
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
-import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.ToggleButton
+import androidx.compose.material3.ToggleButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -78,19 +86,23 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Matrix
 import androidx.compose.ui.graphics.Outline
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.asComposePath
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.graphics.shapes.Morph
 import androidx.graphics.shapes.RoundedPolygon
 import androidx.graphics.shapes.toPath
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
@@ -100,9 +112,10 @@ import com.ivor.ivormusic.data.PlayerStyle
 import com.ivor.ivormusic.data.SessionManager
 import com.ivor.ivormusic.ui.auth.YouTubeAuthDialog
 import com.ivor.ivormusic.ui.theme.ThemeMode
+import kotlin.math.absoluteValue
 import kotlinx.coroutines.launch
 
-private const val ONBOARDING_PAGE_COUNT = 9
+private const val ONBOARDING_PAGE_COUNT = 6
 
 @OptIn(ExperimentalPermissionsApi::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -153,255 +166,396 @@ fun OnboardingScreen(
         )
     }
 
+    val isLastPage = pagerState.currentPage == ONBOARDING_PAGE_COUNT - 1
+
     Box(
         modifier = Modifier
             .fillMaxSize()
             .background(
                 brush = Brush.linearGradient(
                     colors = listOf(
-                        MaterialTheme.colorScheme.background,
+                        MaterialTheme.colorScheme.surface,
                         MaterialTheme.colorScheme.surfaceContainerLow,
-                        MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.65f)
+                        MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.35f)
                     ),
                     start = Offset.Zero,
-                    end = Offset(1200f, 1800f)
+                    end = Offset(1400f, 2200f)
                 )
             )
     ) {
-        AnimatedBackdrop()
+        OnboardingBackdrop()
 
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .windowInsetsPadding(WindowInsets.navigationBars)
-                .padding(horizontal = 20.dp, vertical = 24.dp)
+                .windowInsetsPadding(WindowInsets.systemBars)
+                .padding(horizontal = 24.dp)
+                .padding(top = 8.dp, bottom = 20.dp)
         ) {
-            Text(
-                text = "Koda setup",
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.primary,
-                fontWeight = FontWeight.Bold
-            )
-            Spacer(modifier = Modifier.height(10.dp))
-            Text(
-                text = "Set the app up your way.",
-                style = MaterialTheme.typography.displayLarge,
-                color = MaterialTheme.colorScheme.onBackground,
-                modifier = Modifier.fillMaxWidth(0.86f)
-            )
-            Spacer(modifier = Modifier.height(10.dp))
-            Text(
-                text = "Local files, streaming, video mode, and sign-in stay optional. You can change everything later in Settings.",
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-
-            Spacer(modifier = Modifier.height(24.dp))
-
-            HorizontalPager(
-                state = pagerState,
-                contentPadding = PaddingValues(end = 24.dp),
-                pageSpacing = 16.dp,
-                modifier = Modifier.weight(1f)
-            ) { page ->
-                when (page) {
-                    0 -> LocalMusicPage(
-                        loadLocalSongs = loadLocalSongs,
-                        onLoadLocalSongsToggle = onLoadLocalSongsToggle,
-                        storagePermissionGranted = storagePermissionState.status.isGranted,
-                        onRequestStoragePermission = { storagePermissionState.launchPermissionRequest() }
-                    )
-                    1 -> YouTubeConnectionPage(
-                        isLoggedIn = isLoggedIn,
-                        onConnectYouTube = { showAuthDialog = true }
-                    )
-                    2 -> VideoModePage(
-                        videoMode = videoMode,
-                        onVideoModeToggle = onVideoModeToggle
-                    )
-                    3 -> ThemePage(
-                        currentThemeMode = currentThemeMode,
-                        onThemeModeChange = onThemeModeChange
-                    )
-                    4 -> PlayerStylePage(
-                        playerStyle = playerStyle,
-                        onPlayerStyleChange = onPlayerStyleChange
-                    )
-                    5 -> AmbientBackgroundPage(
-                        ambientBackground = ambientBackground,
-                        onAmbientBackgroundToggle = onAmbientBackgroundToggle
-                    )
-                    6 -> CrossfadePage(
-                        crossfadeEnabled = crossfadeEnabled,
-                        onCrossfadeEnabledToggle = onCrossfadeEnabledToggle
-                    )
-                    7 -> PermissionsPage(
-                        loadLocalSongs = loadLocalSongs,
-                        storagePermissionGranted = storagePermissionState.status.isGranted,
-                        onRequestStoragePermission = { storagePermissionState.launchPermissionRequest() },
-                        notificationPermissionGranted = notificationPermissionState?.status?.isGranted ?: true,
-                        onRequestNotificationPermission = { notificationPermissionState?.launchPermissionRequest() }
-                    )
-                    else -> CompatibilityPage(
-                        manualScanEnabled = manualScanEnabled,
-                        onManualScanEnabledToggle = { enabled ->
-                            if (enabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !Environment.isExternalStorageManager()) {
-                                val intent = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply {
-                                    data = Uri.parse("package:${context.packageName}")
-                                }
-                                context.startActivity(intent)
-                            }
-                            onManualScanEnabledToggle(enabled)
-                        }
-                    )
-                }
-            }
-
-            Spacer(modifier = Modifier.height(20.dp))
-
+            // Top bar: wordmark + skip
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    repeat(ONBOARDING_PAGE_COUNT) { index ->
-                        val selected = pagerState.currentPage == index
-                        val width by animateFloatAsState(
-                            targetValue = if (selected) 28f else 10f,
-                            animationSpec = spring(),
-                            label = "pagerIndicatorWidth"
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(34.dp)
+                            .clip(PolygonShape(MaterialShapes.Cookie9Sided))
+                            .background(MaterialTheme.colorScheme.primary),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            imageVector = Icons.Rounded.MusicNote,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onPrimary,
+                            modifier = Modifier.size(18.dp)
                         )
-                        Box(
-                            modifier = Modifier
-                                .height(10.dp)
-                                .width(width.dp)
-                                .clip(CircleShape)
-                                .background(
-                                    if (selected) MaterialTheme.colorScheme.primary
-                                    else MaterialTheme.colorScheme.surfaceContainerHighest
-                                )
+                    }
+                    Text(
+                        text = "Koda",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+
+                AnimatedVisibility(
+                    visible = !isLastPage,
+                    enter = fadeIn(),
+                    exit = fadeOut()
+                ) {
+                    TextButton(onClick = onFinish) {
+                        Text("Skip")
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.weight(1f),
+                beyondViewportPageCount = 1,
+                verticalAlignment = Alignment.Top
+            ) { page ->
+                val pageOffset =
+                    (pagerState.currentPage - page) + pagerState.currentPageOffsetFraction
+                Box(
+                    modifier = Modifier.graphicsLayer {
+                        val fraction = 1f - pageOffset.absoluteValue.coerceIn(0f, 1f)
+                        alpha = 0.3f + 0.7f * fraction
+                        val scale = 0.94f + 0.06f * fraction
+                        scaleX = scale
+                        scaleY = scale
+                    }
+                ) {
+                    when (page) {
+                        0 -> WelcomePage()
+                        1 -> LibraryPage(
+                            loadLocalSongs = loadLocalSongs,
+                            onLoadLocalSongsToggle = onLoadLocalSongsToggle,
+                            storagePermissionGranted = storagePermissionState.status.isGranted,
+                            onRequestStoragePermission = { storagePermissionState.launchPermissionRequest() }
+                        )
+                        2 -> YouTubePage(
+                            isLoggedIn = isLoggedIn,
+                            onConnectYouTube = { showAuthDialog = true }
+                        )
+                        3 -> VideoModePage(
+                            videoMode = videoMode,
+                            onVideoModeToggle = onVideoModeToggle
+                        )
+                        4 -> LookAndFeelPage(
+                            currentThemeMode = currentThemeMode,
+                            onThemeModeChange = onThemeModeChange,
+                            ambientBackground = ambientBackground,
+                            onAmbientBackgroundToggle = onAmbientBackgroundToggle,
+                            playerStyle = playerStyle,
+                            onPlayerStyleChange = onPlayerStyleChange
+                        )
+                        else -> FinalTouchesPage(
+                            crossfadeEnabled = crossfadeEnabled,
+                            onCrossfadeEnabledToggle = onCrossfadeEnabledToggle,
+                            notificationPermissionGranted = notificationPermissionState?.status?.isGranted ?: true,
+                            onRequestNotificationPermission = { notificationPermissionState?.launchPermissionRequest() },
+                            manualScanEnabled = manualScanEnabled,
+                            onManualScanEnabledToggle = { enabled ->
+                                if (enabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !Environment.isExternalStorageManager()) {
+                                    val intent = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply {
+                                        data = Uri.parse("package:${context.packageName}")
+                                    }
+                                    context.startActivity(intent)
+                                }
+                                onManualScanEnabledToggle(enabled)
+                            }
                         )
                     }
                 }
+            }
 
-                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    AnimatedVisibility(
-                        visible = pagerState.currentPage > 0,
-                        enter = fadeIn(),
-                        exit = fadeOut()
-                    ) {
-                        OutlinedButton(
-                            onClick = {
-                                scope.launch {
-                                    pagerState.animateScrollToPage(pagerState.currentPage - 1)
-                                }
-                            },
-                            shape = RoundedCornerShape(18.dp)
-                        ) {
-                            Text("Back")
-                        }
-                    }
+            Spacer(modifier = Modifier.height(18.dp))
 
-                    Button(
+            // Bottom bar: wavy progress + navigation
+            val progress by animateFloatAsState(
+                targetValue = (pagerState.currentPage + 1f) / ONBOARDING_PAGE_COUNT,
+                animationSpec = spring(stiffness = Spring.StiffnessLow),
+                label = "onboardingProgress"
+            )
+
+            Text(
+                text = "Step ${pagerState.currentPage + 1} of $ONBOARDING_PAGE_COUNT",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(10.dp))
+            LinearWavyProgressIndicator(
+                progress = { progress },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(modifier = Modifier.height(18.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                AnimatedVisibility(
+                    visible = pagerState.currentPage > 0,
+                    enter = fadeIn() + scaleIn(),
+                    exit = fadeOut() + scaleOut()
+                ) {
+                    FilledTonalIconButton(
                         onClick = {
-                            if (pagerState.currentPage == ONBOARDING_PAGE_COUNT - 1) {
-                                onFinish()
-                            } else {
-                                scope.launch {
-                                    pagerState.animateScrollToPage(pagerState.currentPage + 1)
-                                }
+                            scope.launch {
+                                pagerState.animateScrollToPage(pagerState.currentPage - 1)
                             }
                         },
-                        shape = RoundedCornerShape(22.dp),
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.primary
-                        )
+                        shapes = IconButtonDefaults.shapes(),
+                        modifier = Modifier.size(56.dp)
                     ) {
-                        Text(if (pagerState.currentPage == ONBOARDING_PAGE_COUNT - 1) "Start listening" else "Continue")
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Icon(
-                            imageVector = if (pagerState.currentPage == ONBOARDING_PAGE_COUNT - 1) Icons.Rounded.CheckCircle else Icons.AutoMirrored.Rounded.ArrowForward,
-                            contentDescription = null
-                        )
+                        Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = "Back")
                     }
+                }
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                Button(
+                    onClick = {
+                        if (isLastPage) {
+                            onFinish()
+                        } else {
+                            scope.launch {
+                                pagerState.animateScrollToPage(pagerState.currentPage + 1)
+                            }
+                        }
+                    },
+                    shapes = ButtonDefaults.shapes(),
+                    modifier = Modifier.height(56.dp),
+                    contentPadding = PaddingValues(horizontal = 28.dp)
+                ) {
+                    Text(
+                        text = if (isLastPage) "Start listening" else "Continue",
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Icon(
+                        imageVector = if (isLastPage) Icons.Rounded.CheckCircle else Icons.AutoMirrored.Rounded.ArrowForward,
+                        contentDescription = null
+                    )
                 }
             }
         }
     }
 }
 
+// ---------------- Pages ----------------
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun LocalMusicPage(
+private fun WelcomePage() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(bottom = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        Spacer(modifier = Modifier.height(8.dp))
+
+        MorphingHero(icon = Icons.Rounded.MusicNote)
+
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            Text(
+                text = "Welcome to Koda",
+                style = MaterialTheme.typography.displaySmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center
+            )
+            Text(
+                text = "Music and videos, your local files, and a player that adapts to you. A few quick choices and you are in.",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+        }
+
+        Surface(
+            shape = RoundedCornerShape(28.dp),
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(
+                modifier = Modifier.padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(18.dp)
+            ) {
+                FeatureRow(
+                    icon = Icons.Rounded.CloudSync,
+                    shape = MaterialShapes.Flower,
+                    title = "Stream anything",
+                    subtitle = "Music and videos powered by YouTube Music"
+                )
+                FeatureRow(
+                    icon = Icons.Rounded.Folder,
+                    shape = MaterialShapes.Circle,
+                    title = "Your local library",
+                    subtitle = "Songs already on this device play right alongside"
+                )
+                FeatureRow(
+                    icon = Icons.Rounded.Palette,
+                    shape = MaterialShapes.SoftBurst,
+                    title = "Made yours",
+                    subtitle = "Dynamic color, ambient artwork and player styles"
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LibraryPage(
     loadLocalSongs: Boolean,
     onLoadLocalSongsToggle: (Boolean) -> Unit,
     storagePermissionGranted: Boolean,
     onRequestStoragePermission: () -> Unit
 ) {
-    OnboardingPage(
+    OnboardingPageScaffold(
         icon = Icons.Rounded.Folder,
         iconShape = MaterialShapes.Circle,
-        title = "Local music",
-        body = "Use music already stored on this device. This is best when you want Koda to behave like a normal offline-capable music player.",
-        details = listOf(
-            "When this is on, Home and Search start from your phone's audio library.",
-            "Koda only asks for media access if you choose local music.",
-            "Turn this off if you want the first screen to use YouTube Music discovery instead."
-        )
+        title = "Your music",
+        body = "Bring the songs already stored on this device into Home, Search and Library. Skip it if you want a streaming-first setup."
     ) {
-        ToggleCard(
+        SettingSwitchRow(
             icon = Icons.Rounded.Folder,
             title = "Scan device audio",
-            subtitle = "Show songs from local storage across Home, Search, and Library.",
+            subtitle = "Show local songs across the app",
             checked = loadLocalSongs,
             onCheckedChange = onLoadLocalSongsToggle
         )
 
-        PermissionCard(
-            icon = Icons.Rounded.Album,
-            title = "Music access",
-            subtitle = if (loadLocalSongs) {
-                "Required for local library scanning. You can skip it and grant it later."
-            } else {
-                "Not needed while local audio scanning is off."
-            },
-            granted = storagePermissionGranted || !loadLocalSongs,
-            actionLabel = if (storagePermissionGranted || !loadLocalSongs) "Ready" else "Allow access",
-            onAction = onRequestStoragePermission,
-            actionEnabled = loadLocalSongs && !storagePermissionGranted
-        )
+        AnimatedVisibility(visible = loadLocalSongs) {
+            PermissionRow(
+                icon = Icons.Rounded.Album,
+                title = "Music access",
+                subtitle = if (storagePermissionGranted) {
+                    "Koda can read your audio library."
+                } else {
+                    "Needed to find songs on this device."
+                },
+                granted = storagePermissionGranted,
+                actionLabel = "Allow",
+                onAction = onRequestStoragePermission
+            )
+        }
+
+        HintText("Only your audio files are read. Nothing leaves the device.")
     }
 }
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun YouTubeConnectionPage(
+private fun YouTubePage(
     isLoggedIn: Boolean,
     onConnectYouTube: () -> Unit
 ) {
-    OnboardingPage(
+    OnboardingPageScaffold(
         icon = Icons.Rounded.CloudSync,
         iconShape = MaterialShapes.Flower,
         title = "YouTube Music",
-        body = "Connect only if you want personal YouTube Music data. Search and public streaming can still work without making Google account setup part of onboarding.",
-        details = listOf(
-            "Connected accounts can show personalized recommendations, liked songs, and playlists.",
-            "Cookies are stored by the existing secure session manager.",
-            "Skipping sign-in keeps the app usable and avoids forcing account setup."
-        )
+        body = "Connect your account for personalized recommendations, liked songs and playlists. Search and streaming work without it."
     ) {
-        PermissionCard(
-            icon = Icons.Rounded.CloudSync,
-            title = if (isLoggedIn) "Account connected" else "Optional account connection",
-            subtitle = if (isLoggedIn) {
-                "Personalized YouTube Music features are available."
-            } else {
-                "Use this only when playlists, liked songs, and account recommendations matter to you."
-            },
-            granted = isLoggedIn,
-            actionLabel = if (isLoggedIn) "Connected" else "Connect YouTube Music",
-            onAction = onConnectYouTube,
-            actionEnabled = !isLoggedIn
-        )
+        Surface(
+            shape = RoundedCornerShape(24.dp),
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(
+                modifier = Modifier.padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(46.dp)
+                            .clip(RoundedCornerShape(16.dp))
+                            .background(
+                                if (isLoggedIn) MaterialTheme.colorScheme.primaryContainer
+                                else MaterialTheme.colorScheme.secondaryContainer
+                            ),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            imageVector = if (isLoggedIn) Icons.Rounded.Check else Icons.Rounded.CloudSync,
+                            contentDescription = null,
+                            tint = if (isLoggedIn) MaterialTheme.colorScheme.onPrimaryContainer
+                            else MaterialTheme.colorScheme.onSecondaryContainer
+                        )
+                    }
+                    Column {
+                        Text(
+                            text = if (isLoggedIn) "Account connected" else "Not connected",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        Text(
+                            text = if (isLoggedIn) {
+                                "Personalized recommendations are ready."
+                            } else {
+                                "Optional, and you can sign in later from Settings."
+                            },
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+
+                if (!isLoggedIn) {
+                    Button(
+                        onClick = onConnectYouTube,
+                        shapes = ButtonDefaults.shapes(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(52.dp)
+                    ) {
+                        Text("Connect YouTube Music")
+                    }
+                }
+            }
+        }
+
+        HintText("Your session is stored securely on this device only.")
     }
 }
 
@@ -410,192 +564,511 @@ private fun VideoModePage(
     videoMode: Boolean,
     onVideoModeToggle: (Boolean) -> Unit
 ) {
-    OnboardingPage(
+    OnboardingPageScaffold(
         icon = Icons.Rounded.Videocam,
         iconShape = MaterialShapes.Arch,
         title = "Video mode",
-        body = "Video mode shifts discovery toward music videos and watch history, while keeping the in-app video player available.",
-        details = listOf(
-            "Turn this on if you want video discovery on the main tab.",
-            "The app can play videos in-app and keep a mini player overlay.",
-            "Turn it off for a cleaner music-first layout."
-        )
+        body = "Turn the Home tab into a video feed with an in-app player, mini player and picture-in-picture. You can flip between music and video any time."
     ) {
-        ToggleCard(
+        SettingSwitchRow(
             icon = Icons.Rounded.Videocam,
             title = "Enable video mode",
-            subtitle = "Show video home, video search results, and video history surfaces.",
+            subtitle = "Video home, video search and watch history",
             checked = videoMode,
             onCheckedChange = onVideoModeToggle
         )
+
+        HintText("Off keeps a cleaner, music-first layout. The video player stays available either way.")
     }
 }
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun ThemePage(
+private fun LookAndFeelPage(
     currentThemeMode: ThemeMode,
-    onThemeModeChange: (ThemeMode) -> Unit
-) {
-    OnboardingPage(
-        icon = Icons.Rounded.Palette,
-        iconShape = MaterialShapes.Diamond,
-        title = "Theme",
-        body = "Choose the color mode used on first launch. The app still uses Material 3 dynamic color where the device supports it.",
-        details = listOf(
-            "System follows the phone's light or dark setting.",
-            "Dark gives the player a more focused media-app feel.",
-            "Light keeps library and settings screens brighter in daytime use."
-        )
-    ) {
-        ThemeSelector(
-            currentThemeMode = currentThemeMode,
-            onThemeModeChange = onThemeModeChange
-        )
-    }
-}
-
-@Composable
-private fun PlayerStylePage(
+    onThemeModeChange: (ThemeMode) -> Unit,
+    ambientBackground: Boolean,
+    onAmbientBackgroundToggle: (Boolean) -> Unit,
     playerStyle: PlayerStyle,
     onPlayerStyleChange: (PlayerStyle) -> Unit
 ) {
-    OnboardingPage(
-        icon = Icons.Rounded.MusicNote,
-        iconShape = MaterialShapes.Flower,
-        title = "Player controls",
-        body = "Pick how the now-playing screen should feel. This only changes the player interaction model, not playback quality or queue behavior.",
-        details = listOf(
-            "Classic keeps visible playback controls and is easier to learn.",
-            "Gesture uses swipe-driven movement for a more fluid player.",
-            "You can switch between them later without losing your queue or settings."
-        )
+    OnboardingPageScaffold(
+        icon = Icons.Rounded.Palette,
+        iconShape = MaterialShapes.Diamond,
+        title = "Look and feel",
+        body = "Koda uses Material You dynamic color. Choose how it should behave on this device."
     ) {
-        PlayerStyleSelector(
-            playerStyle = playerStyle,
-            onPlayerStyleChange = onPlayerStyleChange
-        )
-    }
-}
+        ChoiceCard(title = "Theme") {
+            ConnectedChoiceGroup(
+                options = listOf(
+                    ThemeMode.SYSTEM to "System",
+                    ThemeMode.DARK to "Dark",
+                    ThemeMode.LIGHT to "Light"
+                ),
+                selected = currentThemeMode,
+                onSelect = onThemeModeChange
+            )
+        }
 
-@Composable
-private fun AmbientBackgroundPage(
-    ambientBackground: Boolean,
-    onAmbientBackgroundToggle: (Boolean) -> Unit
-) {
-    OnboardingPage(
-        icon = Icons.Rounded.Wallpaper,
-        iconShape = MaterialShapes.SoftBurst,
-        title = "Ambient artwork",
-        body = "Ambient backgrounds let album art influence the visual tone of the player and browse surfaces.",
-        details = listOf(
-            "This makes the app feel more responsive to the song you are playing.",
-            "Keep it on for a richer media-player look.",
-            "Turn it off if you prefer cleaner, steadier backgrounds."
-        )
-    ) {
-        ToggleCard(
+        SettingSwitchRow(
             icon = Icons.Rounded.Wallpaper,
-            title = "Use ambient backgrounds",
-            subtitle = "Let artwork colors subtly influence the interface.",
+            title = "Ambient artwork",
+            subtitle = "Let album art color the player background",
             checked = ambientBackground,
             onCheckedChange = onAmbientBackgroundToggle
         )
+
+        ChoiceCard(title = "Player style") {
+            ConnectedChoiceGroup(
+                options = listOf(
+                    PlayerStyle.CLASSIC to "Classic",
+                    PlayerStyle.GESTURE to "Gesture"
+                ),
+                selected = playerStyle,
+                onSelect = onPlayerStyleChange
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = if (playerStyle == PlayerStyle.GESTURE) {
+                    "Swipe-driven player with fluid, physical motion."
+                } else {
+                    "Familiar buttons for play, pause and skipping."
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
     }
 }
 
 @Composable
-private fun CrossfadePage(
+private fun FinalTouchesPage(
     crossfadeEnabled: Boolean,
-    onCrossfadeEnabledToggle: (Boolean) -> Unit
-) {
-    OnboardingPage(
-        icon = Icons.Rounded.GraphicEq,
-        iconShape = MaterialShapes.Pill,
-        title = "Crossfade",
-        body = "Crossfade softens the handoff between songs. It is useful for playlists and long listening sessions, but not everyone wants overlap between tracks.",
-        details = listOf(
-            "When enabled, the player fades from one track into the next.",
-            "It can make shuffled playback feel smoother.",
-            "Disable it if you want album transitions and track endings to stay exact."
-        )
-    ) {
-        ToggleCard(
-            icon = Icons.Rounded.GraphicEq,
-            title = "Crossfade playback",
-            subtitle = "Blend neighboring songs during continuous playback.",
-            checked = crossfadeEnabled,
-            onCheckedChange = onCrossfadeEnabledToggle
-        )
-    }
-}
-
-@Composable
-private fun PermissionsPage(
-    loadLocalSongs: Boolean,
-    storagePermissionGranted: Boolean,
-    onRequestStoragePermission: () -> Unit,
+    onCrossfadeEnabledToggle: (Boolean) -> Unit,
     notificationPermissionGranted: Boolean,
-    onRequestNotificationPermission: () -> Unit
-) {
-    OnboardingPage(
-        icon = Icons.Rounded.Security,
-        iconShape = MaterialShapes.Pentagon,
-        title = "Permissions",
-        body = "Permissions stay tied to the features that need them. This keeps first launch useful even when you skip local files or notification controls.",
-        details = listOf(
-            "Music library access is only needed for device audio scanning.",
-            "Notifications are optional, but they improve lock screen and ongoing playback controls.",
-            "Both can be changed later from Android settings if you skip them here."
-        )
-    ) {
-        PermissionCard(
-            icon = Icons.Rounded.Album,
-            title = "Music library access",
-            subtitle = if (loadLocalSongs) {
-                "Needed only if you want Koda to scan songs stored on this device."
-            } else {
-                "Not required right now because local device audio is turned off."
-            },
-            granted = storagePermissionGranted || !loadLocalSongs,
-            actionLabel = if (storagePermissionGranted || !loadLocalSongs) "Ready" else "Allow access",
-            onAction = onRequestStoragePermission,
-            actionEnabled = loadLocalSongs && !storagePermissionGranted
-        )
-
-        PermissionCard(
-            icon = Icons.Rounded.NotificationsActive,
-            title = "Playback notifications",
-            subtitle = "Optional, but useful for lock screen controls and ongoing playback status.",
-            granted = notificationPermissionGranted,
-            actionLabel = if (notificationPermissionGranted) "Ready" else "Enable",
-            onAction = onRequestNotificationPermission,
-            actionEnabled = !notificationPermissionGranted
-        )
-    }
-}
-
-@Composable
-private fun CompatibilityPage(
+    onRequestNotificationPermission: () -> Unit,
     manualScanEnabled: Boolean,
     onManualScanEnabledToggle: (Boolean) -> Unit
 ) {
-    OnboardingPage(
-        icon = Icons.Rounded.PhoneAndroid,
-        iconShape = MaterialShapes.Boom,
-        title = "Compatibility scanning",
-        body = "This is an escape hatch for devices where Android's normal media index misses songs. It is useful, but it can ask for broader file access.",
-        details = listOf(
-            "Leave it off when your music library appears normally.",
-            "Turn it on for devices that hide music from MediaStore, especially some Xiaomi, Redmi, Poco, or HyperOS builds.",
-            "If Android opens an All Files Access screen, that is only for this high compatibility scan path."
-        )
+    OnboardingPageScaffold(
+        icon = Icons.Rounded.Tune,
+        iconShape = MaterialShapes.Pill,
+        title = "Final touches",
+        body = "A few optional extras. All of this lives in Settings if you change your mind later."
     ) {
-        ToggleCard(
+        SettingSwitchRow(
+            icon = Icons.Rounded.GraphicEq,
+            title = "Crossfade",
+            subtitle = "Blend songs into each other during playback",
+            checked = crossfadeEnabled,
+            onCheckedChange = onCrossfadeEnabledToggle
+        )
+
+        PermissionRow(
+            icon = Icons.Rounded.NotificationsActive,
+            title = "Playback notifications",
+            subtitle = if (notificationPermissionGranted) {
+                "Lock screen controls are ready."
+            } else {
+                "Enables lock screen and background controls."
+            },
+            granted = notificationPermissionGranted,
+            actionLabel = "Enable",
+            onAction = onRequestNotificationPermission
+        )
+
+        SettingSwitchRow(
             icon = Icons.Rounded.PhoneAndroid,
-            title = "High compatibility scanning",
-            subtitle = "Use a broader scan when normal library discovery misses songs.",
+            title = "High compatibility scan",
+            subtitle = "Only for devices that hide music from the system index, like some HyperOS builds",
             checked = manualScanEnabled,
             onCheckedChange = onManualScanEnabledToggle
+        )
+    }
+}
+
+// ---------------- Building blocks ----------------
+
+@Composable
+private fun OnboardingPageScaffold(
+    icon: ImageVector,
+    iconShape: RoundedPolygon,
+    title: String,
+    body: String,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(bottom = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(18.dp)
+    ) {
+        ShapeIconBadge(icon = icon, shape = iconShape)
+
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.headlineLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = body,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        content()
+    }
+}
+
+/** Hero for the welcome page: a shape morphing between two expressive forms. */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun MorphingHero(icon: ImageVector) {
+    val transition = rememberInfiniteTransition(label = "heroMorph")
+    val morphProgress by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(4200, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "morphProgress"
+    )
+    val rotation by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(45000, easing = LinearEasing)
+        ),
+        label = "heroRotation"
+    )
+    val morph = remember { Morph(MaterialShapes.Cookie9Sided, MaterialShapes.SoftBurst) }
+
+    Box(contentAlignment = Alignment.Center) {
+        Box(
+            modifier = Modifier
+                .size(132.dp)
+                .graphicsLayer { rotationZ = rotation }
+                .clip(MorphShape(morph, morphProgress))
+                .background(MaterialTheme.colorScheme.primaryContainer)
+        )
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onPrimaryContainer,
+            modifier = Modifier.size(56.dp)
+        )
+    }
+}
+
+/** Page icon inside a slowly rotating expressive shape. */
+@Composable
+private fun ShapeIconBadge(
+    icon: ImageVector,
+    shape: RoundedPolygon,
+    size: Dp = 76.dp
+) {
+    val transition = rememberInfiniteTransition(label = "badgeSpin")
+    val rotation by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(60000, easing = LinearEasing)
+        ),
+        label = "badgeRotation"
+    )
+
+    Box(contentAlignment = Alignment.Center) {
+        Box(
+            modifier = Modifier
+                .size(size)
+                .graphicsLayer { rotationZ = rotation }
+                .clip(PolygonShape(shape))
+                .background(MaterialTheme.colorScheme.primaryContainer)
+        )
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onPrimaryContainer,
+            modifier = Modifier.size(size * 0.42f)
+        )
+    }
+}
+
+@Composable
+private fun FeatureRow(
+    icon: ImageVector,
+    shape: RoundedPolygon,
+    title: String,
+    subtitle: String
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(44.dp)
+                .clip(PolygonShape(shape))
+                .background(MaterialTheme.colorScheme.secondaryContainer),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                modifier = Modifier.size(22.dp)
+            )
+        }
+        Column {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun SettingSwitchRow(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Surface(
+        shape = RoundedCornerShape(24.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = Modifier.fillMaxWidth(),
+        onClick = { onCheckedChange(!checked) }
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 18.dp, vertical = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(46.dp)
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(MaterialTheme.colorScheme.secondaryContainer),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+            }
+            Spacer(modifier = Modifier.width(16.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Switch(
+                checked = checked,
+                onCheckedChange = onCheckedChange
+            )
+        }
+    }
+}
+
+@Composable
+private fun PermissionRow(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    granted: Boolean,
+    actionLabel: String,
+    onAction: () -> Unit
+) {
+    Surface(
+        shape = RoundedCornerShape(24.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 18.dp, vertical = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(46.dp)
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(
+                        if (granted) MaterialTheme.colorScheme.primaryContainer
+                        else MaterialTheme.colorScheme.secondaryContainer
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = if (granted) Icons.Rounded.Check else icon,
+                    contentDescription = null,
+                    tint = if (granted) MaterialTheme.colorScheme.onPrimaryContainer
+                    else MaterialTheme.colorScheme.onSecondaryContainer
+                )
+            }
+            Spacer(modifier = Modifier.width(16.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            if (granted) {
+                Icon(
+                    imageVector = Icons.Rounded.CheckCircle,
+                    contentDescription = "Granted",
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            } else {
+                FilledTonalButton(onClick = onAction) {
+                    Text(actionLabel)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChoiceCard(
+    title: String,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Surface(
+        shape = RoundedCornerShape(24.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(18.dp)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(bottom = 12.dp)
+            )
+            content()
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun <T> ConnectedChoiceGroup(
+    options: List<Pair<T, String>>,
+    selected: T,
+    onSelect: (T) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween)
+    ) {
+        options.forEachIndexed { index, (value, label) ->
+            val shapes = when (index) {
+                0 -> ButtonGroupDefaults.connectedLeadingButtonShapes()
+                options.lastIndex -> ButtonGroupDefaults.connectedTrailingButtonShapes()
+                else -> ButtonGroupDefaults.connectedMiddleButtonShapes()
+            }
+            ToggleButton(
+                checked = selected == value,
+                onCheckedChange = { onSelect(value) },
+                modifier = Modifier.weight(1f),
+                shapes = shapes,
+                colors = ToggleButtonDefaults.toggleButtonColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                    checkedContainerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onSurface,
+                    checkedContentColor = MaterialTheme.colorScheme.onPrimary
+                )
+            ) {
+                Text(
+                    text = label,
+                    fontWeight = if (selected == value) FontWeight.Bold else FontWeight.Medium
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HintText(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(horizontal = 4.dp)
+    )
+}
+
+// ---------------- Backdrop & shapes ----------------
+
+@Composable
+private fun OnboardingBackdrop() {
+    val transition = rememberInfiniteTransition(label = "onboardingBackdrop")
+    val driftA by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(11000, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "driftA"
+    )
+    val driftB by transition.animateFloat(
+        initialValue = 1f,
+        targetValue = 0f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(15000, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "driftB"
+    )
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Box(
+            modifier = Modifier
+                .padding(start = (24 + driftA * 50).dp, top = (70 + driftB * 40).dp)
+                .size(190.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.08f))
+        )
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(end = (12 + driftB * 40).dp, bottom = (170 + driftA * 50).dp)
+                .size(230.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.tertiary.copy(alpha = 0.08f))
         )
     }
 }
@@ -607,7 +1080,7 @@ private class PolygonShape(private val polygon: RoundedPolygon) : Shape {
         density: Density
     ): Outline {
         val path = polygon.toPath().asComposePath()
-        val matrix = androidx.compose.ui.graphics.Matrix()
+        val matrix = Matrix()
         val bounds = polygon.calculateBounds()
         val boundsWidth = bounds[2] - bounds[0]
         val boundsHeight = bounds[3] - bounds[1]
@@ -619,343 +1092,24 @@ private class PolygonShape(private val polygon: RoundedPolygon) : Shape {
     }
 }
 
-@Composable
-private fun OnboardingPage(
-    icon: ImageVector,
-    iconShape: RoundedPolygon,
-    title: String,
-    body: String,
-    details: List<String>,
-    content: @Composable ColumnScope.() -> Unit
-) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(bottom = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
-        Card(
-            shape = RoundedCornerShape(34.dp),
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
-            )
-        ) {
-            Column(
-                modifier = Modifier.padding(22.dp),
-                verticalArrangement = Arrangement.spacedBy(14.dp)
-            ) {
-                StaticShapeIcon(
-                    icon = icon,
-                    shape = iconShape
-                )
+private class MorphShape(
+    private val morph: Morph,
+    private val progress: Float
+) : Shape {
+    override fun createOutline(
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density
+    ): Outline {
+        val path = morph.toPath(progress).asComposePath()
+        val matrix = Matrix()
+        val bounds = morph.calculateBounds()
+        val boundsWidth = bounds[2] - bounds[0]
+        val boundsHeight = bounds[3] - bounds[1]
 
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.headlineSmall,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
-                Text(
-                    text = body,
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
-
-        Card(
-            shape = RoundedCornerShape(28.dp),
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceContainer
-            )
-        ) {
-            Column(
-                modifier = Modifier.padding(18.dp),
-                verticalArrangement = Arrangement.spacedBy(10.dp)
-            ) {
-                details.forEach { detail ->
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.Top
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .padding(top = 8.dp)
-                                .size(7.dp)
-                                .clip(CircleShape)
-                                .background(MaterialTheme.colorScheme.primary)
-                        )
-                        Spacer(modifier = Modifier.width(12.dp))
-                        Text(
-                            text = detail,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            style = MaterialTheme.typography.bodyLarge,
-                            modifier = Modifier.weight(1f)
-                        )
-                    }
-                }
-            }
-        }
-
-        content()
-    }
-}
-
-@Composable
-private fun StaticShapeIcon(
-    icon: ImageVector,
-    shape: RoundedPolygon
-) {
-    Box(
-        modifier = Modifier
-            .size(66.dp)
-            .clip(PolygonShape(shape))
-            .background(MaterialTheme.colorScheme.primaryContainer),
-        contentAlignment = Alignment.Center
-    ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onPrimaryContainer,
-            modifier = Modifier.size(32.dp)
-        )
-    }
-}
-
-@Composable
-private fun ThemeSelector(
-    currentThemeMode: ThemeMode,
-    onThemeModeChange: (ThemeMode) -> Unit
-) {
-    Surface(
-        shape = RoundedCornerShape(30.dp),
-        color = MaterialTheme.colorScheme.surfaceContainer
-    ) {
-        Column(
-            modifier = Modifier.padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(18.dp)
-        ) {
-            Text("Color mode", fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onSurface)
-            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                val options = listOf(
-                    ThemeMode.SYSTEM to "System",
-                    ThemeMode.DARK to "Dark",
-                    ThemeMode.LIGHT to "Light"
-                )
-                options.forEachIndexed { index, (mode, label) ->
-                    SegmentedButton(
-                        selected = currentThemeMode == mode,
-                        onClick = { onThemeModeChange(mode) },
-                        shape = androidx.compose.material3.SegmentedButtonDefaults.itemShape(
-                            index = index,
-                            count = options.size
-                        ),
-                        icon = {}
-                    ) {
-                        Text(label)
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun PlayerStyleSelector(
-    playerStyle: PlayerStyle,
-    onPlayerStyleChange: (PlayerStyle) -> Unit
-) {
-    Surface(
-        shape = RoundedCornerShape(30.dp),
-        color = MaterialTheme.colorScheme.surfaceContainer
-    ) {
-        Column(
-            modifier = Modifier.padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(18.dp)
-        ) {
-            Text("Player style", fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onSurface)
-            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                val options = listOf(
-                    PlayerStyle.CLASSIC to "Classic",
-                    PlayerStyle.GESTURE to "Gesture"
-                )
-                options.forEachIndexed { index, (style, label) ->
-                    SegmentedButton(
-                        selected = playerStyle == style,
-                        onClick = { onPlayerStyleChange(style) },
-                        shape = androidx.compose.material3.SegmentedButtonDefaults.itemShape(
-                            index = index,
-                            count = options.size
-                        ),
-                        icon = {}
-                    ) {
-                        Text(label)
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun ToggleCard(
-    icon: ImageVector,
-    title: String,
-    subtitle: String,
-    checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit
-) {
-    Card(
-        shape = RoundedCornerShape(28.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainer
-        )
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(18.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Box(
-                modifier = Modifier
-                    .size(52.dp)
-                    .clip(RoundedCornerShape(18.dp))
-                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.14f)),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary
-                )
-            }
-            Spacer(modifier = Modifier.width(16.dp))
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = title,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    fontWeight = FontWeight.SemiBold
-                )
-                Spacer(modifier = Modifier.height(3.dp))
-                Text(
-                    text = subtitle,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    style = MaterialTheme.typography.bodyLarge
-                )
-            }
-            Spacer(modifier = Modifier.width(12.dp))
-            Switch(
-                checked = checked,
-                onCheckedChange = onCheckedChange,
-                colors = SwitchDefaults.colors(
-                    checkedThumbColor = Color.White,
-                    checkedTrackColor = MaterialTheme.colorScheme.primary
-                )
-            )
-        }
-    }
-}
-
-@Composable
-private fun PermissionCard(
-    icon: ImageVector,
-    title: String,
-    subtitle: String,
-    granted: Boolean,
-    actionLabel: String,
-    onAction: () -> Unit,
-    actionEnabled: Boolean
-) {
-    Card(
-        shape = RoundedCornerShape(28.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainer
-        )
-    ) {
-        Column(
-            modifier = Modifier.padding(18.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Box(
-                    modifier = Modifier
-                        .size(52.dp)
-                        .clip(RoundedCornerShape(18.dp))
-                        .background(
-                            if (granted) Color(0xFF3D8B40).copy(alpha = 0.16f)
-                            else MaterialTheme.colorScheme.secondaryContainer
-                        ),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Icon(
-                        imageVector = if (granted) Icons.Rounded.CheckCircle else icon,
-                        contentDescription = null,
-                        tint = if (granted) Color(0xFF3D8B40) else MaterialTheme.colorScheme.onSecondaryContainer
-                    )
-                }
-                Spacer(modifier = Modifier.width(16.dp))
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(title, color = MaterialTheme.colorScheme.onSurface, fontWeight = FontWeight.SemiBold)
-                    Text(subtitle, color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodyLarge)
-                }
-            }
-            OutlinedButton(
-                onClick = onAction,
-                enabled = actionEnabled,
-                shape = RoundedCornerShape(18.dp)
-            ) {
-                Text(actionLabel)
-            }
-        }
-    }
-}
-
-@Composable
-private fun AnimatedBackdrop() {
-    val transition = rememberInfiniteTransition(label = "background")
-    val driftA by transition.animateFloat(
-        initialValue = 0f,
-        targetValue = 1f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(9000, easing = LinearEasing),
-            repeatMode = RepeatMode.Reverse
-        ),
-        label = "driftA"
-    )
-    val driftB by transition.animateFloat(
-        initialValue = 1f,
-        targetValue = 0f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(12000, easing = LinearEasing),
-            repeatMode = RepeatMode.Reverse
-        ),
-        label = "driftB"
-    )
-
-    Box(modifier = Modifier.fillMaxSize()) {
-        Box(
-            modifier = Modifier
-                .padding(start = (20 + driftA * 60).dp, top = (60 + driftB * 30).dp)
-                .size(180.dp)
-                .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.10f))
-        )
-        Box(
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(end = (10 + driftB * 50).dp, bottom = (160 + driftA * 40).dp)
-                .size(220.dp)
-                .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.tertiary.copy(alpha = 0.10f))
-        )
-        Box(
-            modifier = Modifier
-                .align(Alignment.CenterEnd)
-                .padding(end = (driftA * 30).dp)
-                .size(100.dp)
-                .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.secondary.copy(alpha = 0.08f))
-        )
+        matrix.scale(size.width / boundsWidth, size.height / boundsHeight)
+        matrix.translate(-bounds[0], -bounds[1])
+        path.transform(matrix)
+        return Outline.Generic(path)
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.Comment
 import androidx.compose.material.icons.automirrored.rounded.Logout
 import androidx.compose.material.icons.rounded.AccountCircle
 import androidx.compose.material.icons.rounded.Add
@@ -174,6 +175,8 @@ fun SettingsScreen(
     onPlayerStyleChange: (PlayerStyle) -> Unit,
     saveVideoHistory: Boolean,
     onSaveVideoHistoryToggle: (Boolean) -> Unit,
+    timedCommentsEnabled: Boolean,
+    onTimedCommentsToggle: (Boolean) -> Unit,
     excludedFolders: Set<String>,
     onAddExcludedFolder: (String) -> Unit,
     onRemoveExcludedFolder: (String) -> Unit,
@@ -636,6 +639,16 @@ fun SettingsScreen(
                             textColor = textColor,
                             secondaryTextColor = secondaryTextColor,
                             accentColor = Color(0xFFFF0000) // YouTube red
+                        )
+
+                        SettingsDivider()
+
+                        ExpressiveTimedCommentsToggleItem(
+                            enabled = timedCommentsEnabled,
+                            onToggle = onTimedCommentsToggle,
+                            textColor = textColor,
+                            secondaryTextColor = secondaryTextColor,
+                            accentColor = accentColor
                         )
                     }
                 }
@@ -1260,6 +1273,86 @@ private fun ExpressiveVideoModeToggleItem(
                 }
             }
         }
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun ExpressiveTimedCommentsToggleItem(
+    enabled: Boolean,
+    onToggle: (Boolean) -> Unit,
+    textColor: Color,
+    secondaryTextColor: Color,
+    accentColor: Color
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.97f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
+        label = "scale"
+    )
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .scale(scale)
+            .clip(RoundedCornerShape(18.dp))
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null
+            ) { onToggle(!enabled) }
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // Icon
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .clip(RoundedCornerShape(14.dp))
+                .background(accentColor.copy(alpha = 0.12f)),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Rounded.Comment,
+                contentDescription = null,
+                tint = accentColor,
+                modifier = Modifier.size(26.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        // Text
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = "Timed Comments",
+                color = textColor,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = if (enabled) "Timestamped comments briefly appear over videos" else "Adds a comments button to the video player",
+                color = secondaryTextColor,
+                fontSize = 13.sp
+            )
+        }
+
+        // Switch
+        Switch(
+            checked = enabled,
+            onCheckedChange = onToggle,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = Color.White,
+                checkedTrackColor = accentColor,
+                uncheckedThumbColor = Color.White,
+                uncheckedTrackColor = secondaryTextColor.copy(alpha = 0.3f),
+                uncheckedBorderColor = Color.Transparent,
+                checkedBorderColor = Color.Transparent
+            )
+        )
     }
 }
 

--- a/app/src/main/java/com/ivor/ivormusic/ui/theme/ThemeViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/theme/ThemeViewModel.kt
@@ -21,6 +21,7 @@ class ThemeViewModel(application: Application) : AndroidViewModel(application) {
     val videoMode: StateFlow<Boolean> = themePreferences.videoMode
     val playerStyle: StateFlow<PlayerStyle> = themePreferences.playerStyle
     val saveVideoHistory: StateFlow<Boolean> = themePreferences.saveVideoHistory
+    val timedCommentsEnabled: StateFlow<Boolean> = themePreferences.timedCommentsEnabled
     val excludedFolders: StateFlow<Set<String>> = themePreferences.excludedFolders
     
     // Cache & Crossfade
@@ -73,6 +74,10 @@ class ThemeViewModel(application: Application) : AndroidViewModel(application) {
     
     fun toggleSaveVideoHistory() {
         themePreferences.toggleSaveVideoHistory()
+    }
+
+    fun setTimedCommentsEnabled(enabled: Boolean) {
+        themePreferences.setTimedCommentsEnabled(enabled)
     }
     
     fun addExcludedFolder(folderPath: String) {

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/TimedCommentsOverlay.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/TimedCommentsOverlay.kt
@@ -1,0 +1,162 @@
+package com.ivor.ivormusic.ui.video
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.ivor.ivormusic.data.TimedComment
+import java.util.Locale
+
+/** How long a timed comment stays on screen after its timestamp passes. */
+private const val TIMED_COMMENT_DISPLAY_MS = 6_000L
+
+/**
+ * Non-intrusive overlay that surfaces comments referencing the current
+ * playback position. A comment appears when playback reaches the timestamp
+ * mentioned in its text, stays visible for a few seconds and fades away.
+ */
+@Composable
+fun TimedCommentsOverlay(
+    timedComments: List<TimedComment>,
+    positionMs: Long,
+    modifier: Modifier = Modifier
+) {
+    // Most recent comment whose timestamp has passed within the display window.
+    // timedComments is sorted by timeMs, so lastOrNull picks the latest one.
+    val active = timedComments.lastOrNull {
+        positionMs >= it.timeMs && positionMs - it.timeMs < TIMED_COMMENT_DISPLAY_MS
+    }
+
+    AnimatedContent(
+        targetState = active,
+        transitionSpec = {
+            (fadeIn(tween(350)) + slideInVertically(tween(350)) { it / 3 })
+                .togetherWith(fadeOut(tween(500)))
+        },
+        contentKey = { it?.comment?.commentId },
+        label = "timedComment",
+        modifier = modifier
+    ) { timedComment ->
+        if (timedComment != null) {
+            TimedCommentCard(timedComment)
+        } else {
+            Spacer(Modifier.size(0.dp))
+        }
+    }
+}
+
+@Composable
+private fun TimedCommentCard(timedComment: TimedComment) {
+    val comment = timedComment.comment
+    Surface(
+        shape = RoundedCornerShape(20.dp),
+        color = Color.Black.copy(alpha = 0.6f),
+        contentColor = Color.White,
+        modifier = Modifier.widthIn(max = 360.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            if (comment.authorAvatarUrl != null) {
+                AsyncImage(
+                    model = comment.authorAvatarUrl,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(28.dp)
+                        .clip(CircleShape),
+                    contentScale = ContentScale.Crop
+                )
+            } else {
+                Box(
+                    modifier = Modifier
+                        .size(28.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.primaryContainer),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = comment.author.removePrefix("@").take(1).uppercase(),
+                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+
+            Column {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text(
+                        text = comment.author,
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = Color.White.copy(alpha = 0.85f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Surface(
+                        shape = CircleShape,
+                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.85f),
+                        contentColor = MaterialTheme.colorScheme.onPrimary
+                    ) {
+                        Text(
+                            text = formatTimestamp(timedComment.timeMs),
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.padding(horizontal = 7.dp, vertical = 1.dp)
+                        )
+                    }
+                }
+
+                Spacer(Modifier.height(3.dp))
+
+                Text(
+                    text = comment.text,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.White,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+    }
+}
+
+private fun formatTimestamp(millis: Long): String {
+    val seconds = millis / 1000
+    val h = seconds / 3600
+    val m = (seconds % 3600) / 60
+    val s = seconds % 60
+    return if (h > 0) String.format(Locale.US, "%d:%02d:%02d", h, m, s)
+    else String.format(Locale.US, "%d:%02d", m, s)
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoHomeContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoHomeContent.kt
@@ -338,8 +338,8 @@ fun VideoCard(
                         )
                 )
                 
-                // Duration badge
-                if (!video.isLive) {
+                // Duration badge (skip entirely when the duration is unknown)
+                if (!video.isLive && video.duration > 0) {
                     Surface(
                         modifier = Modifier
                             .align(Alignment.BottomEnd)
@@ -355,7 +355,7 @@ fun VideoCard(
                             modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
                         )
                     }
-                } else {
+                } else if (video.isLive) {
                     // Live badge
                     Surface(
                         modifier = Modifier

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
@@ -78,6 +78,13 @@ fun VideoPlayerContent(
 
     if (currentVideo == null || exoPlayer == null) return
 
+    // Double-tap seek helper: jump relative to the live playhead, clamped to the clip.
+    fun seekBy(deltaMs: Long) {
+        val target = (exoPlayer.currentPosition + deltaMs)
+            .coerceIn(0L, if (exoPlayer.duration > 0) exoPlayer.duration else Long.MAX_VALUE)
+        exoPlayer.seekTo(target)
+    }
+
     LaunchedEffect(exoPlayer, currentVideo) {
         while (isActive) {
             if (exoPlayer.duration > 0) {
@@ -178,6 +185,8 @@ fun VideoPlayerContent(
                 videoTitle = currentVideo.title,
                 onPlayPause = { viewModel.togglePlayPause() },
                 onSeek = { newProgress -> exoPlayer.seekTo((newProgress * duration).toLong()) },
+                onSeekBackward = { seekBy(-10_000L) },
+                onSeekForward = { seekBy(10_000L) },
                 onBack = { isFullscreen = false },
                 onFullscreenToggle = { isFullscreen = false },
                 onSettings = { showQualitySheet = true },
@@ -229,6 +238,8 @@ fun VideoPlayerContent(
                         videoTitle = currentVideo.title,
                         onPlayPause = { viewModel.togglePlayPause() },
                         onSeek = { newProgress -> exoPlayer.seekTo((newProgress * duration).toLong()) },
+                        onSeekBackward = { seekBy(-10_000L) },
+                        onSeekForward = { seekBy(10_000L) },
                         onBack = onBackClick,
                         onFullscreenToggle = { isFullscreen = true },
                         onSettings = { showQualitySheet = true },

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
@@ -3,6 +3,7 @@ package com.ivor.ivormusic.ui.video
 import android.app.Activity
 import android.content.pm.ActivityInfo
 import androidx.annotation.OptIn
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -33,7 +34,8 @@ import kotlinx.coroutines.isActive
 fun VideoPlayerContent(
     viewModel: VideoPlayerViewModel,
     onBackClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    timedCommentsFeatureEnabled: Boolean = false
 ) {
     val context = LocalContext.current
     val activity = context as? Activity
@@ -56,10 +58,13 @@ fun VideoPlayerContent(
     val isLoadingMoreComments by viewModel.isLoadingMoreComments.collectAsState()
     val commentReplies by viewModel.replies.collectAsState()
     val loadingReplyIds by viewModel.loadingReplyIds.collectAsState()
-    
+    val timedComments by viewModel.timedComments.collectAsState()
+
     // Local UI State
     var showControls by remember { mutableStateOf(false) }
     var isFullscreen by remember { mutableStateOf(false) }
+    // Timed comments overlay toggle; persists across videos while the player is open
+    var timedCommentsActive by remember { mutableStateOf(false) }
     
     // Progress polling (ViewModel doesn't poll, so we do it here or update ViewModel to poll)
     // Ideally ViewModel should emit progress, but for smoother slider we often poll in UI or VM. 
@@ -89,6 +94,15 @@ fun VideoPlayerContent(
         if (showControls && isPlaying) {
             delay(4000)
             showControls = false
+        }
+    }
+
+    // Fetch the first page of comments once the overlay is active and the
+    // comments entry token has arrived (engagement loads asynchronously)
+    val commentsToken = engagement?.commentsToken
+    LaunchedEffect(timedCommentsActive, commentsToken) {
+        if (timedCommentsFeatureEnabled && timedCommentsActive && commentsToken != null) {
+            viewModel.ensureCommentsLoaded()
         }
     }
     
@@ -169,8 +183,21 @@ fun VideoPlayerContent(
                 onSettings = { showQualitySheet = true },
                 onLoopToggle = { viewModel.toggleLooping() },
                 isAutoPlayEnabled = isAutoPlayEnabled,
-                onAutoPlayToggle = { viewModel.toggleAutoPlay() }
+                onAutoPlayToggle = { viewModel.toggleAutoPlay() },
+                showTimedCommentsButton = timedCommentsFeatureEnabled,
+                timedCommentsActive = timedCommentsActive,
+                onTimedCommentsToggle = { timedCommentsActive = !timedCommentsActive }
             )
+
+                if (timedCommentsFeatureEnabled && timedCommentsActive) {
+                    TimedCommentsOverlay(
+                        timedComments = timedComments,
+                        positionMs = currentPosition,
+                        modifier = Modifier
+                            .align(Alignment.BottomStart)
+                            .padding(start = 24.dp, end = 24.dp, bottom = 104.dp)
+                    )
+                }
             }
         } else {
             // Portrait Layout
@@ -207,8 +234,26 @@ fun VideoPlayerContent(
                         onSettings = { showQualitySheet = true },
                         onLoopToggle = { viewModel.toggleLooping() },
                         isAutoPlayEnabled = isAutoPlayEnabled,
-                        onAutoPlayToggle = { viewModel.toggleAutoPlay() }
+                        onAutoPlayToggle = { viewModel.toggleAutoPlay() },
+                        showTimedCommentsButton = timedCommentsFeatureEnabled,
+                        timedCommentsActive = timedCommentsActive,
+                        onTimedCommentsToggle = { timedCommentsActive = !timedCommentsActive }
                     )
+
+                    if (timedCommentsFeatureEnabled && timedCommentsActive) {
+                        // Keep the card clear of the seek bar while controls are up
+                        val overlayBottomPadding by animateDpAsState(
+                            targetValue = if (showControls) 64.dp else 12.dp,
+                            label = "timedCommentsPadding"
+                        )
+                        TimedCommentsOverlay(
+                            timedComments = timedComments,
+                            positionMs = currentPosition,
+                            modifier = Modifier
+                                .align(Alignment.BottomStart)
+                                .padding(start = 12.dp, end = 12.dp, bottom = overlayBottomPadding)
+                        )
+                    }
                 }
                 
                 // Info Area

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerOverlay.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerOverlay.kt
@@ -35,7 +35,8 @@ import com.ivor.ivormusic.R
 @androidx.annotation.OptIn(UnstableApi::class)
 @Composable
 fun VideoPlayerOverlay(
-    viewModel: VideoPlayerViewModel
+    viewModel: VideoPlayerViewModel,
+    timedCommentsEnabled: Boolean = false
 ) {
     val isExpanded by viewModel.isExpanded.collectAsState()
     val currentVideo by viewModel.currentVideo.collectAsState()
@@ -213,9 +214,10 @@ fun VideoPlayerOverlay(
                  // Full Screen Content
                  VideoPlayerContent(
                      viewModel = viewModel,
-                     onBackClick = { 
-                         viewModel.setExpanded(false) 
-                     }
+                     onBackClick = {
+                         viewModel.setExpanded(false)
+                     },
+                     timedCommentsFeatureEnabled = timedCommentsEnabled
                  )
              } else {
                  // Mini Player Content

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerOverlay.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerOverlay.kt
@@ -67,7 +67,7 @@ fun VideoPlayerOverlay(
     val pipPlayAction = "$packageName.PIP_PLAY"
     val pipPauseAction = "$packageName.PIP_PAUSE"
     
-    LaunchedEffect(currentVideo, isPlaying) {
+    LaunchedEffect(currentVideo, isPlaying, isExpanded) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && activity != null) {
              val videoId = currentVideo?.videoId ?: return@LaunchedEffect
              // Use collision-resistant request codes: masked hashcode OR'd with action bit
@@ -99,7 +99,10 @@ fun VideoPlayerOverlay(
                 .setActions(actions)
                 
              if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                 paramsBuilder.setAutoEnterEnabled(true)
+                 // Only auto-enter PiP while the full player is on screen.
+                 // Auto-entering from the mini player captures the whole app UI
+                 // into the PiP window instead of just the video surface.
+                 paramsBuilder.setAutoEnterEnabled(isExpanded)
              }
              
              try {

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -122,7 +122,10 @@ fun FullscreenPlayerContent(
     onFullscreenToggle: () -> Unit,
     onSettings: () -> Unit,
     onLoopToggle: () -> Unit,
-    onAutoPlayToggle: () -> Unit
+    onAutoPlayToggle: () -> Unit,
+    showTimedCommentsButton: Boolean = false,
+    timedCommentsActive: Boolean = false,
+    onTimedCommentsToggle: () -> Unit = {}
 ) {
     // Stable shapes to prevent "square flash"
     val stableShapes = IconButtonDefaults.shapes()
@@ -232,6 +235,22 @@ fun FullscreenPlayerContent(
                         )
                     }
 
+                    if (showTimedCommentsButton) {
+                        FilledTonalIconButton(
+                            onClick = onTimedCommentsToggle,
+                            colors = IconButtonDefaults.filledTonalIconButtonColors(
+                                containerColor = if (timedCommentsActive) MaterialTheme.colorScheme.primary else Color.Black.copy(0.5f),
+                                contentColor = if (timedCommentsActive) MaterialTheme.colorScheme.onPrimary else Color.White
+                            ),
+                            shapes = stableShapes
+                        ) {
+                            Icon(
+                                Icons.AutoMirrored.Rounded.Comment,
+                                contentDescription = "Timed comments"
+                            )
+                        }
+                    }
+
                     FilledIconButton(
                         onClick = onSettings,
                         colors = IconButtonDefaults.filledIconButtonColors(
@@ -323,7 +342,10 @@ fun PortraitPlayerContent(
     onFullscreenToggle: () -> Unit,
     onSettings: () -> Unit,
     onLoopToggle: () -> Unit,
-    onAutoPlayToggle: () -> Unit
+    onAutoPlayToggle: () -> Unit,
+    showTimedCommentsButton: Boolean = false,
+    timedCommentsActive: Boolean = false,
+    onTimedCommentsToggle: () -> Unit = {}
 ) {
     // Stable shapes
     val stableShapes = IconButtonDefaults.shapes()
@@ -415,6 +437,21 @@ fun PortraitPlayerContent(
                                 if (isLooping) Icons.Rounded.RepeatOne else Icons.Rounded.Repeat,
                                 contentDescription = "Loop"
                             )
+                        }
+                        if (showTimedCommentsButton) {
+                            FilledTonalIconButton(
+                                onClick = onTimedCommentsToggle,
+                                colors = IconButtonDefaults.filledTonalIconButtonColors(
+                                    containerColor = if (timedCommentsActive) MaterialTheme.colorScheme.primary else Color.Black.copy(0.5f),
+                                    contentColor = if (timedCommentsActive) MaterialTheme.colorScheme.onPrimary else Color.White
+                                ),
+                                shapes = stableShapes
+                            ) {
+                                Icon(
+                                    Icons.AutoMirrored.Rounded.Comment,
+                                    contentDescription = "Timed comments"
+                                )
+                            }
                         }
                         FilledIconButton(
                             onClick = onSettings,

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -75,6 +75,7 @@ import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -306,14 +307,9 @@ fun FullscreenPlayerContent(
                     ) {
                         Text(formatDuration(currentPosition), color = Color.White, style = MaterialTheme.typography.labelLarge)
                         
-                        Slider(
-                            value = progress,
-                            onValueChange = onSeek,
-                            colors = SliderDefaults.colors(
-                                thumbColor = MaterialTheme.colorScheme.primary,
-                                activeTrackColor = MaterialTheme.colorScheme.primary,
-                                inactiveTrackColor = Color.White.copy(0.3f)
-                            ),
+                        PlayerSeekBar(
+                            progress = progress,
+                            onSeek = onSeek,
                             modifier = Modifier.weight(1f)
                         )
                         
@@ -500,14 +496,9 @@ fun PortraitPlayerContent(
                     ) {
                         Text(formatDuration(currentPosition), color = Color.White, style = MaterialTheme.typography.labelMedium)
                         
-                        Slider(
-                            value = progress,
-                            onValueChange = onSeek,
-                            colors = SliderDefaults.colors(
-                                thumbColor = MaterialTheme.colorScheme.primary,
-                                activeTrackColor = MaterialTheme.colorScheme.primary,
-                                inactiveTrackColor = Color.White.copy(0.3f)
-                            ),
+                        PlayerSeekBar(
+                            progress = progress,
+                            onSeek = onSeek,
                             modifier = Modifier.weight(1f)
                         )
                         
@@ -517,6 +508,41 @@ fun PortraitPlayerContent(
             }
         }
     }
+}
+
+/**
+ * Scrubbing seek bar. While the user drags, the thumb follows a local value and
+ * the player is NOT touched, so we don't kick off a buffer/fetch on every pixel.
+ * The actual seek fires once, on release (onValueChangeFinished). The 500ms
+ * progress poll from the parent is ignored during the drag to avoid the thumb
+ * fighting the finger.
+ */
+@Composable
+private fun PlayerSeekBar(
+    progress: Float,
+    onSeek: (Float) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var isScrubbing by remember { mutableStateOf(false) }
+    var scrubValue by remember { mutableFloatStateOf(0f) }
+
+    Slider(
+        value = if (isScrubbing) scrubValue else progress.coerceIn(0f, 1f),
+        onValueChange = {
+            isScrubbing = true
+            scrubValue = it
+        },
+        onValueChangeFinished = {
+            onSeek(scrubValue)
+            isScrubbing = false
+        },
+        colors = SliderDefaults.colors(
+            thumbColor = MaterialTheme.colorScheme.primary,
+            activeTrackColor = MaterialTheme.colorScheme.primary,
+            inactiveTrackColor = Color.White.copy(0.3f)
+        ),
+        modifier = modifier
+    )
 }
 
 /** Seconds jumped per double-tap on either edge of the video surface. */

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -546,7 +546,7 @@ fun VideoInfoSection(
 
             Text(
                 text = buildString {
-                    if (video.viewCount.isNotEmpty()) append("${video.viewCount} views")
+                    if (video.viewCount.isNotEmpty()) append(video.viewCount)
                     if (!video.uploadedDate.isNullOrEmpty()) append(" • ${video.uploadedDate}")
                 },
                 style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -10,10 +10,12 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -39,12 +41,14 @@ import androidx.compose.material.icons.outlined.ThumbUp
 import androidx.compose.material.icons.rounded.Autorenew
 import androidx.compose.material.icons.rounded.Error
 import androidx.compose.material.icons.rounded.ExpandMore
+import androidx.compose.material.icons.rounded.Forward10
 import androidx.compose.material.icons.rounded.Fullscreen
 import androidx.compose.material.icons.rounded.FullscreenExit
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.Repeat
 import androidx.compose.material.icons.rounded.RepeatOne
+import androidx.compose.material.icons.rounded.Replay10
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.ThumbDown
 import androidx.compose.material.icons.rounded.ThumbUp
@@ -69,13 +73,16 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -91,6 +98,7 @@ import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.LikeStatus
 import com.ivor.ivormusic.data.VideoEngagement
 import com.ivor.ivormusic.data.VideoItem
+import kotlinx.coroutines.delay
 import java.util.Locale
 
 // VideoPlayerScreen function removed.
@@ -118,6 +126,8 @@ fun FullscreenPlayerContent(
     videoTitle: String,
     onPlayPause: () -> Unit,
     onSeek: (Float) -> Unit,
+    onSeekBackward: () -> Unit,
+    onSeekForward: () -> Unit,
     onBack: () -> Unit,
     onFullscreenToggle: () -> Unit,
     onSettings: () -> Unit,
@@ -130,14 +140,10 @@ fun FullscreenPlayerContent(
     // Stable shapes to prevent "square flash"
     val stableShapes = IconButtonDefaults.shapes()
 
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color.Black)
-            .clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null
-            ) { onToggleControls() }
+    PlayerGestureSurface(
+        onToggleControls = onToggleControls,
+        onSeekBackward = onSeekBackward,
+        onSeekForward = onSeekForward
     ) {
         // Video View
         AndroidView(
@@ -338,6 +344,8 @@ fun PortraitPlayerContent(
     videoTitle: String,
     onPlayPause: () -> Unit,
     onSeek: (Float) -> Unit,
+    onSeekBackward: () -> Unit,
+    onSeekForward: () -> Unit,
     onBack: () -> Unit,
     onFullscreenToggle: () -> Unit,
     onSettings: () -> Unit,
@@ -350,14 +358,10 @@ fun PortraitPlayerContent(
     // Stable shapes
     val stableShapes = IconButtonDefaults.shapes()
 
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color.Black)
-            .clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null
-            ) { onToggleControls() }
+    PlayerGestureSurface(
+        onToggleControls = onToggleControls,
+        onSeekBackward = onSeekBackward,
+        onSeekForward = onSeekForward
     ) {
         AndroidView(
             factory = { ctx ->
@@ -510,6 +514,111 @@ fun PortraitPlayerContent(
                         Text(formatDuration(duration), color = Color.White, style = MaterialTheme.typography.labelMedium)
                     }
                 }
+            }
+        }
+    }
+}
+
+/** Seconds jumped per double-tap on either edge of the video surface. */
+private const val DOUBLE_TAP_SEEK_SECONDS = 10
+
+/**
+ * Wraps the video surface with tap gestures: single tap toggles the controls,
+ * a double tap on the left rewinds and on the right fast-forwards (YouTube-style),
+ * with an animated badge that accumulates when tapped repeatedly.
+ */
+@Composable
+private fun PlayerGestureSurface(
+    onToggleControls: () -> Unit,
+    onSeekBackward: () -> Unit,
+    onSeekForward: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable BoxScope.() -> Unit
+) {
+    // side: -1 rewind, +1 forward, 0 hidden. seconds accumulates on rapid taps.
+    var side by remember { mutableIntStateOf(0) }
+    var seconds by remember { mutableIntStateOf(0) }
+    var pulse by remember { mutableIntStateOf(0) }
+
+    // Hide the badge a short while after the last tap. Re-runs (and so resets
+    // the timer) every double tap because it is keyed on `pulse`.
+    LaunchedEffect(pulse) {
+        if (side != 0) {
+            delay(650)
+            side = 0
+            seconds = 0
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.Black)
+            .pointerInput(Unit) {
+                detectTapGestures(
+                    onTap = { onToggleControls() },
+                    onDoubleTap = { offset ->
+                        val tappedSide = if (offset.x < size.width / 2f) -1 else 1
+                        seconds = if (tappedSide == side) seconds + DOUBLE_TAP_SEEK_SECONDS else DOUBLE_TAP_SEEK_SECONDS
+                        side = tappedSide
+                        pulse++
+                        if (tappedSide < 0) onSeekBackward() else onSeekForward()
+                    }
+                )
+            }
+    ) {
+        content()
+
+        SeekFeedbackBadge(
+            visible = side < 0,
+            seconds = seconds,
+            forward = false,
+            modifier = Modifier.align(Alignment.CenterStart)
+        )
+        SeekFeedbackBadge(
+            visible = side > 0,
+            seconds = seconds,
+            forward = true,
+            modifier = Modifier.align(Alignment.CenterEnd)
+        )
+    }
+}
+
+@Composable
+private fun SeekFeedbackBadge(
+    visible: Boolean,
+    seconds: Int,
+    forward: Boolean,
+    modifier: Modifier = Modifier
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(),
+        exit = fadeOut(),
+        modifier = modifier
+            .fillMaxHeight()
+            .fillMaxWidth(0.5f)
+    ) {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+                modifier = Modifier
+                    .clip(CircleShape)
+                    .background(Color.Black.copy(alpha = 0.3f))
+                    .padding(horizontal = 20.dp, vertical = 16.dp)
+            ) {
+                Icon(
+                    if (forward) Icons.Rounded.Forward10 else Icons.Rounded.Replay10,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(40.dp)
+                )
+                Text(
+                    text = "$seconds seconds",
+                    color = Color.White,
+                    style = MaterialTheme.typography.labelLarge
+                )
             }
         }
     }

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
@@ -8,6 +8,7 @@ import androidx.media3.common.MimeTypes
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.MergingMediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
@@ -216,8 +217,9 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
                                 isDASH = false,
                                 audioUrl = null
                             )
-                            val mediaItem = MediaItem.fromUri(streamUrl)
-                            _exoPlayer?.setMediaItem(mediaItem)
+                            val source = ProgressiveMediaSource.Factory(dataSourceFactoryFor(streamUrl))
+                                .createMediaSource(MediaItem.fromUri(streamUrl))
+                            _exoPlayer?.setMediaSource(source)
                             _exoPlayer?.prepare()
                             _exoPlayer?.play() // FORCE PLAY
                             _isLoading.value = false
@@ -276,28 +278,43 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         }
     }
 
+    /**
+     * Data source factory whose User-Agent matches the client that issued the
+     * stream URL. YouTube binds googlevideo URLs to the issuing client via the
+     * `?c=` param and answers 403 when the playback UA does not match.
+     */
+    private fun dataSourceFactoryFor(url: String): DefaultDataSource.Factory {
+        val userAgent = YouTubeRepository.uaForPlaybackUri(android.net.Uri.parse(url))
+        val httpFactory = DefaultHttpDataSource.Factory()
+            .setUserAgent(userAgent)
+            .setAllowCrossProtocolRedirects(true)
+        return DefaultDataSource.Factory(context, httpFactory)
+    }
+
     private fun loadQuality(quality: VideoQuality) {
         _currentQuality.value = quality
         val mediaItemBuilder = MediaItem.Builder().setUri(quality.url)
-        
+
         if (quality.isDASH) {
             // DASH streams are adaptive - use directly without merging
             mediaItemBuilder.setMimeType(MimeTypes.APPLICATION_MPD)
             _exoPlayer?.setMediaItem(mediaItemBuilder.build())
         } else {
+            val dataSourceFactory = dataSourceFactoryFor(quality.url)
             val audioUrl = quality.audioUrl
             if (audioUrl != null) {
                 // Non-DASH with separate audio - use MergingMediaSource
-                val dataSourceFactory = DefaultDataSource.Factory(context)
                 val videoSource = ProgressiveMediaSource.Factory(dataSourceFactory)
                     .createMediaSource(MediaItem.fromUri(quality.url))
                 val audioSource = ProgressiveMediaSource.Factory(dataSourceFactory)
                     .createMediaSource(MediaItem.fromUri(audioUrl))
-                
+
                 val mergingSource = MergingMediaSource(videoSource, audioSource)
                 _exoPlayer?.setMediaSource(mergingSource)
             } else {
-                _exoPlayer?.setMediaItem(mediaItemBuilder.build())
+                val source = ProgressiveMediaSource.Factory(dataSourceFactory)
+                    .createMediaSource(mediaItemBuilder.build())
+                _exoPlayer?.setMediaSource(source)
             }
         }
         _exoPlayer?.prepare()

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
@@ -13,14 +13,18 @@ import androidx.media3.exoplayer.source.MergingMediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import com.ivor.ivormusic.data.CommentItem
 import com.ivor.ivormusic.data.LikeStatus
+import com.ivor.ivormusic.data.TimedComment
 import com.ivor.ivormusic.data.VideoEngagement
 import com.ivor.ivormusic.data.VideoItem
 import com.ivor.ivormusic.data.VideoQuality
 import com.ivor.ivormusic.data.YouTubeRepository
 import com.ivor.ivormusic.data.ThemePreferences
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 
@@ -87,6 +91,16 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
 
     private val _comments = MutableStateFlow<List<CommentItem>>(emptyList())
     val comments: StateFlow<List<CommentItem>> = _comments.asStateFlow()
+
+    // Comments that mention a playback timestamp, sorted by that time.
+    // Drives the timed comments overlay in the video player.
+    val timedComments: StateFlow<List<TimedComment>> = _comments
+        .map { list ->
+            list.mapNotNull { comment ->
+                parseFirstTimestampMs(comment.text)?.let { TimedComment(comment, it) }
+            }.sortedBy { it.timeMs }
+        }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     private val _isCommentsLoading = MutableStateFlow(false)
     val isCommentsLoading: StateFlow<Boolean> = _isCommentsLoading.asStateFlow()
@@ -385,6 +399,20 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
 
     // ---------------- Comments ----------------
 
+    /**
+     * Extract the first playback timestamp mentioned in a comment ("1:23",
+     * "12:05" or "1:02:33") as milliseconds, or null when none is present.
+     */
+    private fun parseFirstTimestampMs(text: String): Long? {
+        val match = TIMESTAMP_REGEX.find(text) ?: return null
+        val hours = match.groupValues[1].toLongOrNull() ?: 0L
+        val minutes = match.groupValues[2].toLongOrNull() ?: return null
+        val seconds = match.groupValues[3].toLongOrNull() ?: return null
+        if (seconds >= 60) return null
+        if (match.groupValues[1].isNotEmpty() && minutes >= 60) return null
+        return ((hours * 60 + minutes) * 60 + seconds) * 1000L
+    }
+
     /** Load the first page of comments if not already loaded for this video. */
     fun ensureCommentsLoaded() {
         val video = _currentVideo.value ?: return
@@ -445,6 +473,10 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
                 _loadingReplyIds.value = _loadingReplyIds.value - comment.commentId
             }
         }
+    }
+
+    companion object {
+        private val TIMESTAMP_REGEX = Regex("""(?<!\d)(?:(\d{1,2}):)?(\d{1,2}):(\d{2})(?!\d)""")
     }
 
     override fun onCleared() {


### PR DESCRIPTION
Timed comments: a new default-off setting adds a comments button to the
video player (portrait and fullscreen). When active, comments that
mention a timestamp fade in over the video as playback passes that
moment and fade away without interrupting the experience.

Onboarding: rebuilt around Material 3 Expressive with a morphing shape
hero, wavy progress indicator, connected toggle button groups, skip
action, and six focused steps instead of nine.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01McsA6byEiLn4Lhc7M2DTS9