### PR TITLE
Fix library playlists; add comment writing, subscriptions tab, notifications, video history sync

### DIFF
--- a/app/src/main/java/com/ivor/ivormusic/data/SubscriptionItem.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/SubscriptionItem.kt
@@ -1,0 +1,25 @@
+package com.ivor.ivormusic.data
+
+/**
+ * A channel the logged-in user is subscribed to, parsed from the FEchannels
+ * browse response (channelRenderer items).
+ */
+data class SubscribedChannel(
+    val channelId: String,
+    val name: String,
+    val avatarUrl: String?,
+    val subscriberCountText: String?  // e.g. "701K subscribers"
+)
+
+/**
+ * One entry of the user's notification inbox, parsed from
+ * notification/get_notification_menu (notificationRenderer items).
+ */
+data class NotificationItem(
+    val message: String,             // e.g. "penguinz0 uploaded: ..."
+    val sentTime: String,            // e.g. "3 hours ago"
+    val channelAvatarUrl: String?,
+    val videoThumbnailUrl: String?,
+    val videoId: String?,            // null for non-video notifications
+    val isRead: Boolean
+)

--- a/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
@@ -256,6 +256,14 @@ class ThemePreferences(context: Context) {
     }
     
     /**
+     * Fresh read of the save-history preference straight from SharedPreferences.
+     * ViewModels hold their own ThemePreferences instances, so their StateFlow
+     * copy goes stale when the toggle is flipped through another instance
+     * (e.g. the settings screen) — use this at decision time instead.
+     */
+    fun isSaveVideoHistoryEnabled(): Boolean = getSaveVideoHistoryPreference()
+
+    /**
      * Save video history preference and update the flow.
      */
     fun setSaveVideoHistory(enabled: Boolean) {

--- a/app/src/main/java/com/ivor/ivormusic/data/VideoEngagement.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/VideoEngagement.kt
@@ -34,15 +34,18 @@ data class CommentItem(
     val isHearted: Boolean,
     val isCreator: Boolean,
     val isVerified: Boolean,
-    val repliesToken: String?        // continuation token to load replies
+    val repliesToken: String?,       // continuation token to load replies
+    val replyParams: String? = null  // createReplyParams for posting a reply to this comment
 )
 
 /**
  * One page of comments plus the token for the next page (null = last page).
+ * createCommentParams (top-level pages only) enables posting a new comment.
  */
 data class CommentsPage(
     val comments: List<CommentItem>,
-    val nextPageToken: String?
+    val nextPageToken: String?,
+    val createCommentParams: String? = null
 )
 
 /**

--- a/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
@@ -83,6 +83,9 @@ class YouTubeRepository(private val context: Context) {
         private const val WEB_REMIX_VERSION = "1.20260114.03.00"
         private const val WEB_VERSION = "2.20260114.08.00"
 
+        // browse params selecting a channel's Videos tab (protobuf: "videos")
+        private const val CHANNEL_VIDEOS_TAB_PARAMS = "EgZ2aWRlb3PyBgQKAjoA"
+
         // ANDROID_VR is the recommended client for audio extraction in 2026:
         //  - Does NOT require a PO Token (unlike WEB / ANDROID / IOS / MWEB).
         //  - Returns direct, unobfuscated stream URLs (no signatureCipher to decrypt).
@@ -3395,6 +3398,7 @@ class YouTubeRepository(private val context: Context) {
             // 1. Collect entity payloads: commentId -> payload, toolbar states by entity key
             val entities = mutableMapOf<String, org.json.JSONObject>()
             val toolbarStates = mutableMapOf<String, org.json.JSONObject>()
+            val replyParamsList = mutableListOf<String>()
             val mutations = root.optJSONObject("frameworkUpdates")
                 ?.optJSONObject("entityBatchUpdate")
                 ?.optJSONArray("mutations")
@@ -3409,8 +3413,29 @@ class YouTubeRepository(private val context: Context) {
                         val key = state.optString("key")
                         if (key.isNotBlank()) toolbarStates[key] = state
                     }
+                    // Reply-box params live in the toolbar surface entity, one per comment
+                    payload.optJSONObject("engagementToolbarSurfaceEntityPayload")?.let { surface ->
+                        val replyEndpoints = mutableListOf<org.json.JSONObject>()
+                        findObjectsByKey(surface, "createCommentReplyEndpoint", replyEndpoints)
+                        replyEndpoints.firstOrNull()?.optString("createReplyParams")
+                            ?.takeIf { it.isNotBlank() }?.let { replyParamsList.add(it) }
+                    }
                 }
             }
+            // Match reply params to their comment: the decoded protobuf embeds the commentId
+            val replyParamsByCommentId = mutableMapOf<String, String>()
+            for (params in replyParamsList) {
+                val decoded = decodeInnerTubeParams(params) ?: continue
+                entities.keys.firstOrNull { decoded.contains(it) }?.let { id ->
+                    replyParamsByCommentId[id] = params
+                }
+            }
+
+            // Params for posting a new top-level comment (present on first pages only)
+            val createEndpoints = mutableListOf<org.json.JSONObject>()
+            findObjectsByKey(root, "createCommentEndpoint", createEndpoints)
+            val createCommentParams = createEndpoints.firstOrNull()
+                ?.optString("createCommentParams")?.takeIf { it.isNotBlank() }
 
             // 2. Walk continuationItems in order to keep YouTube's comment ordering
             val comments = mutableListOf<CommentItem>()
@@ -3437,7 +3462,12 @@ class YouTubeRepository(private val context: Context) {
                             findContinuationTokens(replies, tokens)
                             repliesToken = tokens.firstOrNull()
                         }
-                        comments.add(parseCommentEntity(id, entity, viewModel, toolbarStates, repliesToken))
+                        comments.add(
+                            parseCommentEntity(
+                                id, entity, viewModel, toolbarStates, repliesToken,
+                                replyParamsByCommentId[id]
+                            )
+                        )
                     } else if (item.has("continuationItemRenderer")) {
                         val tokens = mutableListOf<String>()
                         findContinuationTokens(item.getJSONObject("continuationItemRenderer"), tokens)
@@ -3446,11 +3476,23 @@ class YouTubeRepository(private val context: Context) {
                 }
             }
 
-            CommentsPage(comments, nextToken)
+            CommentsPage(comments, nextToken, createCommentParams)
         } catch (e: Exception) {
             android.util.Log.e("YouTubeRepo", "getCommentsPage failed", e)
             null
         }
+    }
+
+    /**
+     * Decode a URL-encoded, URL-safe base64 InnerTube params blob into a
+     * string for substring matching (embedded ids are plain ASCII).
+     */
+    private fun decodeInnerTubeParams(params: String): String? = try {
+        val unescaped = java.net.URLDecoder.decode(params, "UTF-8")
+        val bytes = android.util.Base64.decode(unescaped, android.util.Base64.URL_SAFE)
+        String(bytes, Charsets.ISO_8859_1)
+    } catch (e: Exception) {
+        null
     }
 
     private fun parseCommentEntity(
@@ -3458,7 +3500,8 @@ class YouTubeRepository(private val context: Context) {
         entity: org.json.JSONObject,
         viewModel: org.json.JSONObject,
         toolbarStates: Map<String, org.json.JSONObject>,
-        repliesToken: String?
+        repliesToken: String?,
+        replyParams: String? = null
     ): CommentItem {
         val props = entity.optJSONObject("properties")
         val author = entity.optJSONObject("author")
@@ -3478,7 +3521,8 @@ class YouTubeRepository(private val context: Context) {
             isHearted = heartState == "TOOLBAR_HEART_STATE_HEARTED",
             isCreator = author?.optBoolean("isCreator", false) ?: false,
             isVerified = author?.optBoolean("isVerified", false) ?: false,
-            repliesToken = repliesToken
+            repliesToken = repliesToken,
+            replyParams = replyParams
         )
     }
 
@@ -3510,5 +3554,275 @@ class YouTubeRepository(private val context: Context) {
             .put("context", webContext())
             .put("channelIds", org.json.JSONArray().put(channelId))
         postWatchApi(endpoint, body) != null
+    }
+
+    /**
+     * Post a new top-level comment. createCommentParams comes from the first
+     * comments page (CommentsPage.createCommentParams). Returns the created
+     * comment parsed from the response, or null on failure. Requires login.
+     */
+    suspend fun createComment(createCommentParams: String, text: String): CommentItem? =
+        withContext(Dispatchers.IO) {
+            if (!sessionManager.isLoggedIn()) return@withContext null
+            val body = org.json.JSONObject()
+                .put("context", webContext())
+                .put("commentText", text)
+                .put("createCommentParams", createCommentParams)
+            parseCreatedComment(postWatchApi("comment/create_comment", body))
+        }
+
+    /**
+     * Post a reply to a comment. createReplyParams comes from the parent
+     * comment (CommentItem.replyParams). Requires login.
+     */
+    suspend fun createCommentReply(createReplyParams: String, text: String): CommentItem? =
+        withContext(Dispatchers.IO) {
+            if (!sessionManager.isLoggedIn()) return@withContext null
+            val body = org.json.JSONObject()
+                .put("context", webContext())
+                .put("commentText", text)
+                .put("createReplyParams", createReplyParams)
+            parseCreatedComment(postWatchApi("comment/create_comment_reply", body))
+        }
+
+    /**
+     * Parse the comment entity out of a create_comment / create_comment_reply
+     * response. Returns null unless the actionResult reports success.
+     */
+    private fun parseCreatedComment(raw: String?): CommentItem? {
+        if (raw == null) return null
+        return try {
+            val root = org.json.JSONObject(raw)
+            val results = mutableListOf<org.json.JSONObject>()
+            findObjectsByKey(root, "actionResult", results)
+            if (results.none { it.optString("status") == "STATUS_SUCCEEDED" }) return null
+
+            val entities = mutableListOf<org.json.JSONObject>()
+            findObjectsByKey(root, "commentEntityPayload", entities)
+            val entity = entities.firstOrNull() ?: return null
+            val id = entity.optJSONObject("properties")?.optString("commentId")
+                ?.takeIf { it.isNotBlank() } ?: return null
+
+            val replyEndpoints = mutableListOf<org.json.JSONObject>()
+            findObjectsByKey(root, "createCommentReplyEndpoint", replyEndpoints)
+            val replyParams = replyEndpoints.firstOrNull()
+                ?.optString("createReplyParams")?.takeIf { it.isNotBlank() }
+
+            parseCommentEntity(
+                id, entity,
+                viewModel = org.json.JSONObject(),
+                toolbarStates = emptyMap(),
+                repliesToken = null,
+                replyParams = replyParams
+            )
+        } catch (e: Exception) {
+            android.util.Log.e("YouTubeRepo", "parseCreatedComment failed", e)
+            null
+        }
+    }
+
+    /**
+     * Record a regular (non-music) video playback into the user's YouTube
+     * watch history. Mirrors reportPlayback but uses the WEB client against
+     * www.youtube.com: the WEB_REMIX/music flow does not register plain
+     * videos. Requires login.
+     */
+    suspend fun reportVideoPlayback(videoId: String) = withContext(Dispatchers.IO) {
+        if (!sessionManager.isLoggedIn()) return@withContext
+        try {
+            val cpn = generateCpn()
+            val raw = postWatchApi(
+                "player",
+                org.json.JSONObject()
+                    .put("context", webContext())
+                    .put("videoId", videoId)
+                    .put("cpn", cpn)
+            ) ?: return@withContext
+            val baseUrl = org.json.JSONObject(raw)
+                .optJSONObject("playbackTracking")
+                ?.optJSONObject("videostatsPlaybackUrl")
+                ?.optString("baseUrl")
+            if (baseUrl.isNullOrEmpty()) {
+                android.util.Log.w("YouTubeRepo", "No videostatsPlaybackUrl for $videoId")
+                return@withContext
+            }
+            val trackingUrl = buildString {
+                append(baseUrl)
+                if (!baseUrl.contains("cpn=")) {
+                    append(if (baseUrl.contains("?")) "&" else "?")
+                    append("cpn=$cpn")
+                }
+                append("&ver=2&c=WEB")
+            }
+            val cookies = sessionManager.getCookies() ?: return@withContext
+            val builder = okhttp3.Request.Builder()
+                .url(trackingUrl)
+                .get()
+                .addHeader("User-Agent", BROWSER_USER_AGENT)
+                .addHeader("Origin", "https://www.youtube.com")
+                .addHeader("Referer", "https://www.youtube.com/watch?v=$videoId")
+                .addHeader("Cookie", cookies)
+            YouTubeAuthUtils.getAuthorizationHeader(cookies, "https://www.youtube.com")?.let {
+                builder.addHeader("Authorization", it)
+                builder.addHeader("X-Goog-AuthUser", "0")
+            }
+            okHttpClient.newCall(builder.build()).execute().use { response ->
+                if (response.isSuccessful) {
+                    android.util.Log.d("YouTubeRepo", "Video history sync SUCCESS for $videoId")
+                } else {
+                    android.util.Log.w("YouTubeRepo", "Video history sync failed: ${response.code}")
+                }
+            }
+        } catch (e: Exception) {
+            android.util.Log.e("YouTubeRepo", "Error in reportVideoPlayback", e)
+        }
+    }
+
+    /**
+     * The user's subscriptions feed (FEsubscriptions): latest uploads from
+     * all subscribed channels, newest first. Requires login.
+     */
+    suspend fun getSubscriptionsFeed(): List<VideoItem> = withContext(Dispatchers.IO) {
+        if (!sessionManager.isLoggedIn()) return@withContext emptyList()
+        try {
+            val raw = postWatchApi(
+                "browse",
+                org.json.JSONObject().put("context", webContext()).put("browseId", "FEsubscriptions")
+            ) ?: return@withContext emptyList()
+            parseVideosFromYouTubeJson(raw)
+        } catch (e: Exception) {
+            android.util.Log.e("YouTubeRepo", "getSubscriptionsFeed failed", e)
+            emptyList()
+        }
+    }
+
+    /**
+     * All channels the user is subscribed to, from the FEchannels browse
+     * feed (channelRenderer items), following continuations. Requires login.
+     */
+    suspend fun getSubscribedChannels(): List<SubscribedChannel> = withContext(Dispatchers.IO) {
+        if (!sessionManager.isLoggedIn()) return@withContext emptyList()
+        try {
+            val channels = mutableListOf<SubscribedChannel>()
+            var response = postWatchApi(
+                "browse",
+                org.json.JSONObject().put("context", webContext()).put("browseId", "FEchannels")
+            )
+            var pages = 0
+            while (response != null && pages < 10) {
+                val root = org.json.JSONObject(response)
+                val renderers = mutableListOf<org.json.JSONObject>()
+                findObjectsByKey(root, "channelRenderer", renderers)
+                for (renderer in renderers) {
+                    val channelId = renderer.optString("channelId").takeIf { it.isNotBlank() } ?: continue
+                    val name = renderer.optJSONObject("title")?.optString("simpleText")
+                        ?.takeIf { it.isNotBlank() } ?: continue
+                    val thumbs = renderer.optJSONObject("thumbnail")?.optJSONArray("thumbnails")
+                    var avatarUrl = thumbs?.optJSONObject((thumbs.length() - 1).coerceAtLeast(0))
+                        ?.optString("url")?.takeIf { it.isNotBlank() }
+                    if (avatarUrl?.startsWith("//") == true) avatarUrl = "https:$avatarUrl"
+                    // InnerTube quirk: on FEchannels the subscriber count arrives in
+                    // videoCountText; subscriberCountText carries the @handle.
+                    val subscriberCount = renderer.optJSONObject("videoCountText")
+                        ?.optString("simpleText")?.takeIf { it.isNotBlank() }
+                    channels.add(SubscribedChannel(channelId, name, avatarUrl, subscriberCount))
+                }
+                val token = if (renderers.isNotEmpty()) extractContinuationToken(response) else null
+                response = token?.let {
+                    postWatchApi(
+                        "browse",
+                        org.json.JSONObject().put("context", webContext()).put("continuation", it)
+                    )
+                }
+                pages++
+            }
+            channels.distinctBy { it.channelId }
+        } catch (e: Exception) {
+            android.util.Log.e("YouTubeRepo", "getSubscribedChannels failed", e)
+            emptyList()
+        }
+    }
+
+    /**
+     * Latest uploads of a channel (Videos tab browse). Channel-page lockups
+     * omit the channel row, so the caller's channel identity is stitched in.
+     */
+    suspend fun getChannelVideos(channel: SubscribedChannel): List<VideoItem> = withContext(Dispatchers.IO) {
+        try {
+            val raw = postWatchApi(
+                "browse",
+                org.json.JSONObject()
+                    .put("context", webContext())
+                    .put("browseId", channel.channelId)
+                    .put("params", CHANNEL_VIDEOS_TAB_PARAMS)
+            ) ?: return@withContext emptyList()
+            val root = org.json.JSONObject(raw)
+            val richItems = mutableListOf<org.json.JSONObject>()
+            findObjectsByKey(root, "richItemRenderer", richItems)
+            richItems.mapNotNull { item ->
+                val content = item.optJSONObject("content") ?: return@mapNotNull null
+                val parsed = parseLockupViewModel(content.optJSONObject("lockupViewModel"))
+                    ?: parseVideoRenderer(content.optJSONObject("videoRenderer"))
+                    ?: return@mapNotNull null
+                // On the channel page the first metadata row is "N views • date",
+                // which the generic parser reads as the channel name.
+                val viewCount = if (parsed.viewCount.isBlank() &&
+                    (parsed.channelName.contains("view", ignoreCase = true) ||
+                        parsed.channelName.contains("watching", ignoreCase = true))
+                ) parsed.channelName else parsed.viewCount
+                parsed.copy(
+                    channelName = channel.name,
+                    channelId = channel.channelId,
+                    channelIconUrl = channel.avatarUrl ?: parsed.channelIconUrl,
+                    viewCount = viewCount
+                )
+            }.distinctBy { it.videoId }
+        } catch (e: Exception) {
+            android.util.Log.e("YouTubeRepo", "getChannelVideos failed", e)
+            emptyList()
+        }
+    }
+
+    /**
+     * The user's notification inbox (new uploads from subscribed channels,
+     * replies, etc.). First page only. Requires login.
+     */
+    suspend fun getNotifications(): List<NotificationItem> = withContext(Dispatchers.IO) {
+        if (!sessionManager.isLoggedIn()) return@withContext emptyList()
+        try {
+            val raw = postWatchApi(
+                "notification/get_notification_menu",
+                org.json.JSONObject()
+                    .put("context", webContext())
+                    .put("notificationsMenuRequestType", "NOTIFICATIONS_MENU_REQUEST_TYPE_INBOX")
+            ) ?: return@withContext emptyList()
+            val root = org.json.JSONObject(raw)
+            val renderers = mutableListOf<org.json.JSONObject>()
+            findObjectsByKey(root, "notificationRenderer", renderers)
+            renderers.mapNotNull { renderer ->
+                val message = renderer.optJSONObject("shortMessage")?.optString("simpleText")
+                    ?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                fun lastThumb(key: String): String? {
+                    val thumbs = renderer.optJSONObject(key)?.optJSONArray("thumbnails") ?: return null
+                    var url = thumbs.optJSONObject((thumbs.length() - 1).coerceAtLeast(0))
+                        ?.optString("url")?.takeIf { it.isNotBlank() }
+                    if (url?.startsWith("//") == true) url = "https:$url"
+                    return url
+                }
+                NotificationItem(
+                    message = message,
+                    sentTime = renderer.optJSONObject("sentTimeText")?.optString("simpleText").orEmpty(),
+                    channelAvatarUrl = lastThumb("thumbnail"),
+                    videoThumbnailUrl = lastThumb("videoThumbnail"),
+                    videoId = renderer.optJSONObject("navigationEndpoint")
+                        ?.optJSONObject("watchEndpoint")?.optString("videoId")
+                        ?.takeIf { it.isNotBlank() },
+                    isRead = renderer.optBoolean("read", false)
+                )
+            }
+        } catch (e: Exception) {
+            android.util.Log.e("YouTubeRepo", "getNotifications failed", e)
+            emptyList()
+        }
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
@@ -869,13 +869,8 @@ class YouTubeRepository(private val context: Context) {
         if (!sessionManager.isLoggedIn()) return@withContext emptyList()
         
         try {
-            // Fetch Library (Liked Playlists)
-            // Note: FEmusic_liked_playlists gets playlists you've saved/liked
-            // FEmusic_library_landing might be better but harder to parse
-            val jsonResponse = fetchInternalApi("FEmusic_liked_playlists")
-            
             val playlists = mutableListOf<PlaylistDisplayItem>()
-            
+
             // Synthesized "Supermix" and "Likes" always useful to have
             playlists.add(PlaylistDisplayItem(
                 name = "My Supermix",
@@ -884,16 +879,31 @@ class YouTubeRepository(private val context: Context) {
                 thumbnailUrl = "https://www.gstatic.com/youtube/media/ytm/images/pbg/liked_music_@576.png"
             ))
             playlists.add(PlaylistDisplayItem(
-                name = "Your Likes", 
-                url = "https://music.youtube.com/playlist?list=LM", 
+                name = "Your Likes",
+                url = "https://music.youtube.com/playlist?list=LM",
                 uploaderName = "You"
             ))
 
-            // Add parsed playlists
-            playlists.addAll(parsePlaylistsFromInternalJson(jsonResponse))
-            
-            playlists
+            // Fetch Library (Liked Playlists), following grid continuations so
+            // large libraries come back in full rather than just the first page.
+            // Note: FEmusic_liked_playlists gets playlists you've saved/liked
+            var json = fetchInternalApi("FEmusic_liked_playlists")
+            var pageCount = 0
+            val maxPages = 20
+            while (json.isNotEmpty() && pageCount < maxPages) {
+                val parsed = parsePlaylistsFromInternalJson(json)
+                playlists.addAll(parsed)
+                pageCount++
+                android.util.Log.d("YouTubeRepo", "Library playlists page $pageCount: ${parsed.size} items")
+                if (parsed.isEmpty()) break
+                val token = extractContinuationToken(json) ?: break
+                json = fetchContinuation(token)
+            }
+
+            // The library grid can include "Your Likes" (VLLM) which we already synthesized
+            playlists.distinctBy { it.id }
         } catch (e: Exception) {
+            android.util.Log.e("YouTubeRepo", "Error fetching user playlists", e)
             emptyList()
         }
     }
@@ -1560,6 +1570,12 @@ class YouTubeRepository(private val context: Context) {
             ?.optJSONArray("contents")
             ?.let { return it }
 
+        // Grid continuation (library playlist/album pages)
+        root.optJSONObject("continuationContents")
+            ?.optJSONObject("gridContinuation")
+            ?.optJSONArray("items")
+            ?.let { return it }
+
         return null
     }
 
@@ -1605,11 +1621,35 @@ class YouTubeRepository(private val context: Context) {
             return items
         }
         
-        // 4. Direct Item (if the "shelf" is actually just an item in a continuation list)
+        // 4. gridRenderer (Library pages: grid of playlists/albums)
+        val grid = shelfWrapper.optJSONObject("gridRenderer")
+        if (grid != null) {
+            val gridItems = grid.optJSONArray("items")
+            if (gridItems != null) {
+                for (j in 0 until gridItems.length()) {
+                    gridItems.optJSONObject(j)?.let { items.add(it) }
+                }
+            }
+            return items
+        }
+
+        // 5. itemSectionRenderer wraps another shelf (e.g. the library grid)
+        val itemSection = shelfWrapper.optJSONObject("itemSectionRenderer")
+        if (itemSection != null) {
+            val contents = itemSection.optJSONArray("contents")
+            if (contents != null) {
+                for (j in 0 until contents.length()) {
+                    contents.optJSONObject(j)?.let { items.addAll(parseItemsFromShelf(it)) }
+                }
+            }
+            return items
+        }
+
+        // 6. Direct Item (if the "shelf" is actually just an item in a continuation list)
         if (shelfWrapper.has("musicResponsiveListItemRenderer") || shelfWrapper.has("musicTwoRowItemRenderer")) {
             items.add(shelfWrapper)
         }
-        
+
         return items
     }
 

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeScreen.kt
@@ -32,8 +32,12 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Subscriptions
+import androidx.compose.material.icons.outlined.History
 import androidx.compose.material.icons.outlined.LibraryMusic
 import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material.icons.outlined.Subscriptions
 import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material.icons.rounded.People
 import androidx.compose.material.icons.rounded.Home
@@ -213,6 +217,11 @@ fun HomeScreen(
         selectedTab = 0
     }
 
+    // The Subscriptions/History tabs (2/3) only exist in video mode
+    LaunchedEffect(videoMode) {
+        if (!videoMode && selectedTab > 2) selectedTab = 0
+    }
+
     // Auth Dialog State
     var showAuthDialog by remember { mutableStateOf(false) }
     var showAccountSheet by remember { mutableStateOf(false) }
@@ -348,7 +357,7 @@ fun HomeScreen(
                     )
                     2 -> {
                         if (videoMode) {
-                             com.ivor.ivormusic.ui.video.VideoHistoryContent(
+                            com.ivor.ivormusic.ui.video.SubscriptionsContent(
                                 viewModel = viewModel,
                                 onVideoClick = { video ->
                                     onNavigateToVideoPlayer(video)
@@ -379,6 +388,20 @@ fun HomeScreen(
                                 initialArtist = viewedArtistFromPlayer,
                                 onInitialArtistConsumed = { viewedArtistFromPlayer = null },
                                 onStatsClick = onNavigateToStats
+                            )
+                        }
+                    }
+                    3 -> {
+                        // Video mode only: watch history moved here so tab 2
+                        // can host Subscriptions
+                        if (videoMode) {
+                            com.ivor.ivormusic.ui.video.VideoHistoryContent(
+                                viewModel = viewModel,
+                                onVideoClick = { video ->
+                                    onNavigateToVideoPlayer(video)
+                                },
+                                onLoginClick = { showAuthDialog = true },
+                                contentPadding = PaddingValues(bottom = 160.dp)
                             )
                         }
                     }
@@ -423,7 +446,12 @@ fun HomeScreen(
                 .navigationBarsPadding()
                 .padding(bottom = 20.dp),
             content = {
-                val tabs = listOf(
+                val tabs = if (videoMode) listOf(
+                    Triple(0, "Home", Pair(Icons.Rounded.Home, Icons.Outlined.Home)),
+                    Triple(1, "Search", Pair(Icons.Filled.Search, Icons.Outlined.Search)),
+                    Triple(2, "Subs", Pair(Icons.Filled.Subscriptions, Icons.Outlined.Subscriptions)),
+                    Triple(3, "History", Pair(Icons.Filled.History, Icons.Outlined.History))
+                ) else listOf(
                     Triple(0, "Home", Pair(Icons.Rounded.Home, Icons.Outlined.Home)),
                     Triple(1, "Search", Pair(Icons.Filled.Search, Icons.Outlined.Search)),
                     Triple(2, "Library", Pair(Icons.Filled.LibraryMusic, Icons.Outlined.LibraryMusic))

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
@@ -135,8 +135,75 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     private val _isVideoLoading = MutableStateFlow(false)
     val isVideoLoading: StateFlow<Boolean> = _isVideoLoading.asStateFlow()
 
+    // Subscriptions tab state
+    private val _subscribedChannels = MutableStateFlow<List<com.ivor.ivormusic.data.SubscribedChannel>>(emptyList())
+    val subscribedChannels: StateFlow<List<com.ivor.ivormusic.data.SubscribedChannel>> = _subscribedChannels.asStateFlow()
+
+    private val _isSubscriptionsLoading = MutableStateFlow(false)
+    val isSubscriptionsLoading: StateFlow<Boolean> = _isSubscriptionsLoading.asStateFlow()
+
+    private val _subscriptionFeed = MutableStateFlow<List<VideoItem>>(emptyList())
+    val subscriptionFeed: StateFlow<List<VideoItem>> = _subscriptionFeed.asStateFlow()
+
+    private val _isSubscriptionFeedLoading = MutableStateFlow(false)
+    val isSubscriptionFeedLoading: StateFlow<Boolean> = _isSubscriptionFeedLoading.asStateFlow()
+
+    // Notifications state
+    private val _notifications = MutableStateFlow<List<com.ivor.ivormusic.data.NotificationItem>>(emptyList())
+    val notifications: StateFlow<List<com.ivor.ivormusic.data.NotificationItem>> = _notifications.asStateFlow()
+
+    private val _isNotificationsLoading = MutableStateFlow(false)
+    val isNotificationsLoading: StateFlow<Boolean> = _isNotificationsLoading.asStateFlow()
+
     init {
         checkYouTubeConnection()
+    }
+
+    /** Load the subscribed channels list (FEchannels). Requires login. */
+    fun loadSubscriptions(force: Boolean = false) {
+        if (_isSubscriptionsLoading.value) return
+        if (_subscribedChannels.value.isNotEmpty() && !force) return
+        viewModelScope.launch {
+            _isSubscriptionsLoading.value = true
+            try {
+                _subscribedChannels.value = youtubeRepository.getSubscribedChannels()
+            } finally {
+                _isSubscriptionsLoading.value = false
+            }
+        }
+    }
+
+    /** Load the subscriptions video feed (latest uploads, newest first). Requires login. */
+    fun loadSubscriptionFeed(force: Boolean = false) {
+        if (_isSubscriptionFeedLoading.value) return
+        if (_subscriptionFeed.value.isNotEmpty() && !force) return
+        viewModelScope.launch {
+            _isSubscriptionFeedLoading.value = true
+            try {
+                _subscriptionFeed.value = youtubeRepository.getSubscriptionsFeed()
+            } finally {
+                _isSubscriptionFeedLoading.value = false
+            }
+        }
+    }
+
+    /** Latest uploads of one subscribed channel (for the channel drill-in view). */
+    suspend fun getChannelVideos(channel: com.ivor.ivormusic.data.SubscribedChannel): List<VideoItem> {
+        return youtubeRepository.getChannelVideos(channel)
+    }
+
+    /** Load the notification inbox. Requires login. */
+    fun loadNotifications(force: Boolean = false) {
+        if (_isNotificationsLoading.value) return
+        if (_notifications.value.isNotEmpty() && !force) return
+        viewModelScope.launch {
+            _isNotificationsLoading.value = true
+            try {
+                _notifications.value = youtubeRepository.getNotifications()
+            } finally {
+                _isNotificationsLoading.value = false
+            }
+        }
     }
     
     // --- Download Actions ---

--- a/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
@@ -772,6 +772,7 @@ fun PlaylistsGrid(
             ExpressivePlaylistCard(
                 name = playlist.name ?: "Untitled",
                 count = playlist.itemCount,
+                subtitle = if (playlist.itemCount < 0) playlist.uploaderName.ifBlank { "Playlist" } else null,
                 thumbnailUrl = playlist.thumbnailUrl,
                 description = playlist.description,
                 isEditable = isLocalPlaylist,

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/AddToPlaylistSheet.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/AddToPlaylistSheet.kt
@@ -138,7 +138,10 @@ fun AddToPlaylistSheet(
                             )
                         },
                         supportingContent = {
-                            Text("${playlist.itemCount} songs")
+                            Text(
+                                if (playlist.itemCount >= 0) "${playlist.itemCount} songs"
+                                else playlist.uploaderName.ifBlank { "Playlist" }
+                            )
                         },
                         leadingContent = {
                             Surface(

--- a/app/src/main/java/com/ivor/ivormusic/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/search/SearchScreen.kt
@@ -21,7 +21,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
@@ -37,8 +40,16 @@ import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.TravelExplore
 import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material.icons.rounded.Album
+import androidx.compose.material.icons.rounded.LiveTv
+import androidx.compose.material.icons.rounded.Movie
+import androidx.compose.material.icons.rounded.Newspaper
+import androidx.compose.material.icons.rounded.Podcasts
 import androidx.compose.material.icons.rounded.QueueMusic
+import androidx.compose.material.icons.rounded.School
+import androidx.compose.material.icons.rounded.Science
 import androidx.compose.material.icons.rounded.SmartDisplay
+import androidx.compose.material.icons.rounded.SportsBasketball
+import androidx.compose.material.icons.rounded.SportsEsports
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -96,6 +107,19 @@ import com.ivor.ivormusic.ui.video.VideoCard
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
+// Quick-search topics shown on the video mode explore state
+private val VIDEO_EXPLORE_TOPICS = listOf(
+    "Gaming" to Icons.Rounded.SportsEsports,
+    "Music" to Icons.Rounded.MusicNote,
+    "News" to Icons.Rounded.Newspaper,
+    "Live" to Icons.Rounded.LiveTv,
+    "Podcasts" to Icons.Rounded.Podcasts,
+    "Movies" to Icons.Rounded.Movie,
+    "Tech" to Icons.Rounded.Science,
+    "Sports" to Icons.Rounded.SportsBasketball,
+    "Learning" to Icons.Rounded.School
+)
+
 /**
  * Segmented list shape helper for Expressive design
  */
@@ -151,6 +175,14 @@ fun SearchScreen(
     // Search history and focus state
     val searchHistory by viewModel.searchHistory.collectAsState()
     var isSearchFocused by remember { mutableStateOf(false) }
+
+    // Video mode browse state: trending feed doubles as the explore list
+    val trendingVideos by viewModel.trendingVideos.collectAsState()
+    LaunchedEffect(videoMode) {
+        if (videoMode && trendingVideos.isEmpty()) {
+            viewModel.loadTrendingVideos()
+        }
+    }
     
     // Theme colors from MaterialTheme
     val backgroundColor = MaterialTheme.colorScheme.background
@@ -224,12 +256,14 @@ fun SearchScreen(
                     query = query,
                     onQueryChange = { query = it },
                     onFocusChanged = { isSearchFocused = it },
-                    onSearch = { 
+                    onSearch = {
                         if (it.isNotBlank()) {
                             viewModel.addToSearchHistory(it)
                             focusManager.clearFocus()
                         }
                     },
+                    placeholderText = if (videoMode) "Search videos, channels..."
+                    else "Search songs, artists, albums...",
                     primaryColor = primaryColor,
                     primaryContainerColor = primaryContainerColor,
                     tertiaryContainerColor = tertiaryContainerColor,
@@ -301,6 +335,92 @@ fun SearchScreen(
                     }
                 }
                 
+                // Video mode browse: explore topics + trending instead of the music library
+                videoMode && query.isEmpty() -> {
+                    item {
+                        Text(
+                            "Explore",
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.Bold,
+                            color = textColor,
+                            modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp)
+                        )
+                    }
+
+                    // Topic chips: one tap starts a search
+                    item {
+                        LazyRow(
+                            contentPadding = PaddingValues(horizontal = 20.dp),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            items(VIDEO_EXPLORE_TOPICS) { (topic, icon) ->
+                                Surface(
+                                    onClick = {
+                                        query = topic
+                                        focusManager.clearFocus()
+                                    },
+                                    shape = CircleShape,
+                                    color = cardColor,
+                                    tonalElevation = 1.dp
+                                ) {
+                                    Row(
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp)
+                                    ) {
+                                        Icon(
+                                            icon,
+                                            contentDescription = null,
+                                            tint = primaryColor,
+                                            modifier = Modifier.size(16.dp)
+                                        )
+                                        Text(
+                                            topic,
+                                            style = MaterialTheme.typography.labelLarge,
+                                            color = textColor
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    item {
+                        Text(
+                            "Trending now",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = textColor,
+                            modifier = Modifier.padding(horizontal = 20.dp)
+                                .padding(top = 20.dp, bottom = 4.dp)
+                        )
+                    }
+
+                    if (trendingVideos.isEmpty()) {
+                        item {
+                            Box(
+                                modifier = Modifier.fillMaxWidth().height(160.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                LoadingIndicator(
+                                    modifier = Modifier.size(40.dp),
+                                    color = primaryColor
+                                )
+                            }
+                        }
+                    } else {
+                        items(trendingVideos) { video ->
+                            CompactVideoRow(
+                                video = video,
+                                onClick = { onVideoClick(video) },
+                                cardColor = cardColor,
+                                textColor = textColor,
+                                secondaryTextColor = secondaryTextColor
+                            )
+                        }
+                    }
+                }
+
                 query.isEmpty() -> {
                     // Browse section when no search
                     item {
@@ -312,10 +432,10 @@ fun SearchScreen(
                             modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp)
                         )
                     }
-                    
+
                     val displaySongs = songs.take(visibleLocalCount)
                     val hasMoreLocal = songs.size > visibleLocalCount
-                    
+
                     itemsIndexed(displaySongs) { index, song ->
                         SearchSongCard(
                             song = song,
@@ -334,7 +454,7 @@ fun SearchScreen(
                             )
                         }
                     }
-                    
+
                     // Show more button for local browse
                     if (hasMoreLocal) {
                         item {
@@ -804,6 +924,7 @@ private fun SearchHeroHeader(
     onQueryChange: (String) -> Unit,
     onFocusChanged: (Boolean) -> Unit,
     onSearch: (String) -> Unit,
+    placeholderText: String,
     primaryColor: Color,
     primaryContainerColor: Color,
     tertiaryContainerColor: Color,
@@ -850,8 +971,8 @@ private fun SearchHeroHeader(
                 OutlinedTextField(
                     value = query,
                     onValueChange = onQueryChange,
-                    placeholder = { 
-                        Text("Search songs, artists, albums...", color = secondaryTextColor) 
+                    placeholder = {
+                        Text(placeholderText, color = secondaryTextColor)
                     },
                     leadingIcon = {
                         Icon(
@@ -1375,6 +1496,110 @@ fun SearchHistoryList(
                         )
                     }
                 }
+            }
+        }
+    }
+}
+
+/**
+ * Compact video row for the video mode explore list: thumbnail on the
+ * left, title/channel/views on the right. Denser than VideoCard so the
+ * browse state reads as a list, not a feed.
+ */
+@Composable
+private fun CompactVideoRow(
+    video: VideoItem,
+    onClick: () -> Unit,
+    cardColor: Color,
+    textColor: Color,
+    secondaryTextColor: Color
+) {
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(16.dp),
+        color = cardColor,
+        tonalElevation = 1.dp,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .width(140.dp)
+                    .aspectRatio(16f / 9f)
+                    .clip(RoundedCornerShape(10.dp))
+            ) {
+                AsyncImage(
+                    model = video.thumbnailUrl,
+                    contentDescription = video.title,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
+                )
+                if (video.isLive) {
+                    Surface(
+                        modifier = Modifier
+                            .align(Alignment.BottomEnd)
+                            .padding(4.dp),
+                        shape = RoundedCornerShape(4.dp),
+                        color = Color(0xFFFF0000)
+                    ) {
+                        Text(
+                            text = "LIVE",
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Bold,
+                            color = Color.White,
+                            modifier = Modifier.padding(horizontal = 4.dp, vertical = 1.dp)
+                        )
+                    }
+                } else if (video.duration > 0) {
+                    Surface(
+                        modifier = Modifier
+                            .align(Alignment.BottomEnd)
+                            .padding(4.dp),
+                        shape = RoundedCornerShape(4.dp),
+                        color = Color.Black.copy(alpha = 0.8f)
+                    ) {
+                        Text(
+                            text = video.formattedDuration,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = Color.White,
+                            modifier = Modifier.padding(horizontal = 4.dp, vertical = 1.dp)
+                        )
+                    }
+                }
+            }
+
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(top = 2.dp, end = 4.dp)
+            ) {
+                Text(
+                    text = video.title,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = textColor,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = buildString {
+                        append(video.channelName)
+                        if (video.viewCount.isNotEmpty()) {
+                            append(" • ")
+                            append(video.viewCount)
+                        }
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = secondaryTextColor,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
             }
         }
     }

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/CommentsSheet.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/CommentsSheet.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -17,6 +19,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.Send
+import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.Favorite
 import androidx.compose.material.icons.rounded.PushPin
 import androidx.compose.material.icons.rounded.ThumbUp
@@ -24,9 +28,11 @@ import androidx.compose.material.icons.rounded.Verified
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -34,19 +40,23 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.CommentItem
 
 /**
  * Bottom sheet showing the comments of the current video, with infinite
- * scroll pagination and expandable replies.
+ * scroll pagination, expandable replies and a composer for writing
+ * comments and replies (login required).
  */
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -57,8 +67,12 @@ fun CommentsSheet(
     isLoading: Boolean,
     isLoadingMore: Boolean,
     commentsAvailable: Boolean,
+    canComment: Boolean,
+    isPosting: Boolean,
     onLoadMore: () -> Unit,
     onLoadReplies: (CommentItem) -> Unit,
+    onPostComment: (String) -> Unit,
+    onPostReply: (CommentItem, String) -> Unit,
     onDismiss: () -> Unit
 ) {
     // Opens half-height (YouTube style), draggable to full
@@ -77,13 +91,20 @@ fun CommentsSheet(
         if (shouldLoadMore) onLoadMore()
     }
 
+    // The comment being replied to; null = composing a top-level comment
+    var replyTarget by remember { mutableStateOf<CommentItem?>(null) }
+
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         containerColor = MaterialTheme.colorScheme.surfaceContainer,
         contentColor = MaterialTheme.colorScheme.onSurface
     ) {
-        Column(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .imePadding()
+        ) {
             Text(
                 text = "Comments",
                 style = MaterialTheme.typography.headlineSmall,
@@ -91,90 +112,212 @@ fun CommentsSheet(
                 modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
             )
 
-            when {
-                isLoading -> {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(48.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        LoadingIndicator(color = MaterialTheme.colorScheme.primary)
+            Box(modifier = Modifier.weight(1f)) {
+                when {
+                    isLoading -> {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(48.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            LoadingIndicator(color = MaterialTheme.colorScheme.primary)
+                        }
                     }
-                }
-                comments.isEmpty() -> {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(48.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text(
-                            text = if (commentsAvailable) "No comments yet" else "Comments are unavailable for this video",
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
+                    comments.isEmpty() -> {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(48.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = if (commentsAvailable) "No comments yet" else "Comments are unavailable for this video",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
                     }
-                }
-                else -> {
-                    LazyColumn(
-                        state = listState,
-                        modifier = Modifier.fillMaxSize(),
-                        contentPadding = androidx.compose.foundation.layout.PaddingValues(
-                            start = 24.dp, end = 24.dp, bottom = 48.dp
-                        ),
-                        verticalArrangement = Arrangement.spacedBy(20.dp)
-                    ) {
-                        items(comments.size, key = { comments[it].commentId }) { index ->
-                            val comment = comments[index]
-                            Column {
-                                CommentRow(comment = comment)
+                    else -> {
+                        LazyColumn(
+                            state = listState,
+                            modifier = Modifier.fillMaxSize(),
+                            contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                                start = 24.dp, end = 24.dp, bottom = 24.dp
+                            ),
+                            verticalArrangement = Arrangement.spacedBy(20.dp)
+                        ) {
+                            items(comments.size, key = { comments[it].commentId }) { index ->
+                                val comment = comments[index]
+                                Column {
+                                    CommentRow(comment = comment)
 
-                                // Replies
-                                val commentReplies = replies[comment.commentId]
-                                val isLoadingReplies = comment.commentId in loadingReplyIds
-                                if (comment.repliesToken != null && commentReplies == null) {
-                                    Text(
-                                        text = if (isLoadingReplies) "Loading replies…"
-                                        else "View replies" + if (comment.replyCount.isNotEmpty()) " (${comment.replyCount})" else "",
-                                        style = MaterialTheme.typography.labelLarge,
-                                        color = MaterialTheme.colorScheme.primary,
-                                        fontWeight = FontWeight.Bold,
-                                        modifier = Modifier
-                                            .padding(start = 48.dp, top = 8.dp)
-                                            .clip(CircleShape)
-                                            .clickable(enabled = !isLoadingReplies) { onLoadReplies(comment) }
-                                            .padding(horizontal = 8.dp, vertical = 4.dp)
-                                    )
-                                }
-                                if (!commentReplies.isNullOrEmpty()) {
-                                    Column(
-                                        modifier = Modifier.padding(start = 40.dp, top = 12.dp),
-                                        verticalArrangement = Arrangement.spacedBy(16.dp)
-                                    ) {
-                                        commentReplies.forEach { reply ->
-                                            CommentRow(comment = reply, isReply = true)
+                                    // Reply affordance (needs login + reply params)
+                                    if (canComment && comment.replyParams != null) {
+                                        Text(
+                                            text = "Reply",
+                                            style = MaterialTheme.typography.labelLarge,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            fontWeight = FontWeight.Bold,
+                                            modifier = Modifier
+                                                .padding(start = 48.dp, top = 4.dp)
+                                                .clip(CircleShape)
+                                                .clickable { replyTarget = comment }
+                                                .padding(horizontal = 8.dp, vertical = 4.dp)
+                                        )
+                                    }
+
+                                    // Replies
+                                    val commentReplies = replies[comment.commentId]
+                                    val isLoadingReplies = comment.commentId in loadingReplyIds
+                                    if (comment.repliesToken != null && commentReplies == null) {
+                                        Text(
+                                            text = if (isLoadingReplies) "Loading replies…"
+                                            else "View replies" + if (comment.replyCount.isNotEmpty()) " (${comment.replyCount})" else "",
+                                            style = MaterialTheme.typography.labelLarge,
+                                            color = MaterialTheme.colorScheme.primary,
+                                            fontWeight = FontWeight.Bold,
+                                            modifier = Modifier
+                                                .padding(start = 48.dp, top = 4.dp)
+                                                .clip(CircleShape)
+                                                .clickable(enabled = !isLoadingReplies) { onLoadReplies(comment) }
+                                                .padding(horizontal = 8.dp, vertical = 4.dp)
+                                        )
+                                    }
+                                    if (!commentReplies.isNullOrEmpty()) {
+                                        Column(
+                                            modifier = Modifier.padding(start = 40.dp, top = 12.dp),
+                                            verticalArrangement = Arrangement.spacedBy(16.dp)
+                                        ) {
+                                            commentReplies.forEach { reply ->
+                                                CommentRow(comment = reply, isReply = true)
+                                            }
                                         }
                                     }
                                 }
                             }
-                        }
 
-                        if (isLoadingMore) {
-                            item(key = "loading-more") {
-                                Box(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(16.dp),
-                                    contentAlignment = Alignment.Center
-                                ) {
-                                    LoadingIndicator(
-                                        modifier = Modifier.size(32.dp),
-                                        color = MaterialTheme.colorScheme.primary
-                                    )
+                            if (isLoadingMore) {
+                                item(key = "loading-more") {
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(16.dp),
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        LoadingIndicator(
+                                            modifier = Modifier.size(32.dp),
+                                            color = MaterialTheme.colorScheme.primary
+                                        )
+                                    }
                                 }
                             }
                         }
+                    }
+                }
+            }
+
+            if (canComment) {
+                CommentComposer(
+                    replyTarget = replyTarget,
+                    isPosting = isPosting,
+                    onCancelReply = { replyTarget = null },
+                    onSend = { text ->
+                        val target = replyTarget
+                        if (target != null) onPostReply(target, text) else onPostComment(text)
+                        replyTarget = null
+                    }
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Input row pinned under the comments list. Shows a "Replying to" banner
+ * when a reply target is active.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun CommentComposer(
+    replyTarget: CommentItem?,
+    isPosting: Boolean,
+    onCancelReply: () -> Unit,
+    onSend: (String) -> Unit
+) {
+    var text by remember { mutableStateOf("") }
+
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = Modifier
+            .fillMaxWidth()
+            .navigationBarsPadding()
+    ) {
+        Column {
+            if (replyTarget != null) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 16.dp, end = 4.dp, top = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "Replying to ${replyTarget.author}",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f)
+                    )
+                    IconButton(onClick = onCancelReply) {
+                        Icon(
+                            Icons.Rounded.Close,
+                            contentDescription = "Cancel reply",
+                            modifier = Modifier.size(18.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                OutlinedTextField(
+                    value = text,
+                    onValueChange = { text = it },
+                    modifier = Modifier.weight(1f),
+                    placeholder = {
+                        Text(if (replyTarget != null) "Add a reply…" else "Add a comment…")
+                    },
+                    shape = CircleShape,
+                    maxLines = 4,
+                    enabled = !isPosting
+                )
+                if (isPosting) {
+                    LoadingIndicator(
+                        modifier = Modifier.size(32.dp),
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                } else {
+                    IconButton(
+                        onClick = {
+                            if (text.isNotBlank()) {
+                                onSend(text)
+                                text = ""
+                            }
+                        },
+                        enabled = text.isNotBlank()
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Rounded.Send,
+                            contentDescription = "Post",
+                            tint = if (text.isNotBlank()) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.onSurfaceVariant
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/NotificationsSheet.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/NotificationsSheet.kt
@@ -1,0 +1,198 @@
+package com.ivor.ivormusic.ui.video
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.NotificationsNone
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.ivor.ivormusic.data.NotificationItem
+
+/**
+ * Bottom sheet listing the user's notification inbox: new uploads from
+ * subscribed channels, replies, mentions. Tapping a video notification
+ * plays that video.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun NotificationsSheet(
+    notifications: List<NotificationItem>,
+    isLoading: Boolean,
+    onNotificationClick: (NotificationItem) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        contentColor = MaterialTheme.colorScheme.onSurface
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            Text(
+                text = "Notifications",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
+            )
+
+            when {
+                isLoading && notifications.isEmpty() -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(48.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        LoadingIndicator(color = MaterialTheme.colorScheme.primary)
+                    }
+                }
+                notifications.isEmpty() -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(48.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Icon(
+                                imageVector = Icons.Rounded.NotificationsNone,
+                                contentDescription = null,
+                                modifier = Modifier.size(56.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                            )
+                            Spacer(Modifier.height(12.dp))
+                            Text(
+                                text = "No notifications yet",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+                else -> {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                            start = 16.dp, end = 16.dp, bottom = 48.dp
+                        ),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        items(notifications) { notification ->
+                            NotificationRow(
+                                notification = notification,
+                                onClick = { onNotificationClick(notification) }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun NotificationRow(
+    notification: NotificationItem,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .clickable(enabled = notification.videoId != null, onClick = onClick)
+            .padding(horizontal = 8.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        // Unread dot
+        Box(
+            modifier = Modifier
+                .size(8.dp)
+                .clip(CircleShape)
+                .background(
+                    if (!notification.isRead) MaterialTheme.colorScheme.primary
+                    else androidx.compose.ui.graphics.Color.Transparent
+                )
+        )
+
+        // Channel avatar
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+        ) {
+            if (notification.channelAvatarUrl != null) {
+                AsyncImage(
+                    model = notification.channelAvatarUrl,
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
+                )
+            }
+        }
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = notification.message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis
+            )
+            if (notification.sentTime.isNotBlank()) {
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text = notification.sentTime,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        if (notification.videoThumbnailUrl != null) {
+            AsyncImage(
+                model = notification.videoThumbnailUrl,
+                contentDescription = null,
+                modifier = Modifier
+                    .width(96.dp)
+                    .aspectRatio(16f / 9f)
+                    .clip(RoundedCornerShape(8.dp)),
+                contentScale = ContentScale.Crop
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/SubscriptionsContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/SubscriptionsContent.kt
@@ -1,0 +1,574 @@
+package com.ivor.ivormusic.ui.video
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.ArrowForward
+import androidx.compose.material.icons.rounded.Login
+import androidx.compose.material.icons.rounded.Subscriptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.ivor.ivormusic.data.SubscribedChannel
+import com.ivor.ivormusic.data.VideoItem
+import com.ivor.ivormusic.ui.components.ExpressivePullToRefresh
+import com.ivor.ivormusic.ui.home.HomeViewModel
+
+/**
+ * Subscriptions tab for Video Mode. Default view is the subscriptions feed
+ * (latest uploads across all subscribed channels) topped by a horizontal
+ * rail of channel avatars; an "All channels" entry opens the full channel
+ * list, and tapping any channel drills into its latest uploads.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun SubscriptionsContent(
+    viewModel: HomeViewModel,
+    onVideoClick: (VideoItem) -> Unit,
+    onLoginClick: () -> Unit,
+    contentPadding: PaddingValues
+) {
+    val feed by viewModel.subscriptionFeed.collectAsState()
+    val isFeedLoading by viewModel.isSubscriptionFeedLoading.collectAsState()
+    val channels by viewModel.subscribedChannels.collectAsState()
+    val isChannelsLoading by viewModel.isSubscriptionsLoading.collectAsState()
+    val isYouTubeConnected by viewModel.isYouTubeConnected.collectAsState()
+    val backgroundColor = MaterialTheme.colorScheme.background
+
+    // Internal navigation: feed -> (channel list) -> channel uploads
+    var showChannelList by remember { mutableStateOf(false) }
+    var selectedChannel by remember { mutableStateOf<SubscribedChannel?>(null) }
+    var channelVideos by remember { mutableStateOf<List<VideoItem>>(emptyList()) }
+    var isChannelLoading by remember { mutableStateOf(false) }
+
+    LaunchedEffect(isYouTubeConnected) {
+        if (isYouTubeConnected) {
+            viewModel.loadSubscriptionFeed()
+            viewModel.loadSubscriptions()
+        }
+    }
+
+    val currentChannel = selectedChannel
+    LaunchedEffect(currentChannel) {
+        if (currentChannel != null) {
+            isChannelLoading = true
+            channelVideos = viewModel.getChannelVideos(currentChannel)
+            isChannelLoading = false
+        } else {
+            channelVideos = emptyList()
+        }
+    }
+
+    BackHandler(enabled = selectedChannel != null || showChannelList) {
+        if (selectedChannel != null) selectedChannel = null else showChannelList = false
+    }
+
+    // Animation state
+    var isVisible by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { isVisible = true }
+
+    if (!isYouTubeConnected) {
+        SubscriptionsLoginWall(
+            onLoginClick = onLoginClick,
+            contentPadding = contentPadding,
+            modifier = Modifier
+                .fillMaxSize()
+                .background(backgroundColor)
+                .windowInsetsPadding(WindowInsets.statusBars)
+        )
+        return
+    }
+
+    when {
+        // Channel drill-in: latest uploads of the selected channel
+        currentChannel != null -> {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(backgroundColor)
+                    .windowInsetsPadding(WindowInsets.statusBars),
+                contentPadding = PaddingValues(bottom = contentPadding.calculateBottomPadding()),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                item {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 8.dp)
+                            .padding(top = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        IconButton(onClick = { selectedChannel = null }) {
+                            Icon(
+                                Icons.AutoMirrored.Rounded.ArrowBack,
+                                contentDescription = "Back",
+                                tint = MaterialTheme.colorScheme.onBackground
+                            )
+                        }
+                        ChannelAvatar(channel = currentChannel, size = 40.dp)
+                        Spacer(Modifier.width(12.dp))
+                        Column {
+                            Text(
+                                text = currentChannel.name,
+                                style = MaterialTheme.typography.titleLarge,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onBackground,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            if (currentChannel.subscriberCountText != null) {
+                                Text(
+                                    text = currentChannel.subscriberCountText,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+                }
+
+                if (isChannelLoading) {
+                    item {
+                        Box(
+                            Modifier.fillMaxWidth().height(200.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            LoadingIndicator(
+                                modifier = Modifier.size(48.dp),
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    }
+                } else if (channelVideos.isEmpty()) {
+                    item {
+                        Box(
+                            modifier = Modifier.fillMaxWidth().padding(32.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text("No videos found", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
+                    }
+                } else {
+                    items(channelVideos) { video ->
+                        VideoCard(
+                            video = video,
+                            onClick = { onVideoClick(video) },
+                            modifier = Modifier.padding(horizontal = 16.dp)
+                        )
+                    }
+                }
+
+                item { Spacer(modifier = Modifier.height(32.dp)) }
+            }
+        }
+
+        // Full channel list
+        showChannelList -> {
+            ExpressivePullToRefresh(
+                isRefreshing = isChannelsLoading,
+                onRefresh = { viewModel.loadSubscriptions(force = true) },
+                modifier = Modifier.fillMaxSize()
+            ) {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(backgroundColor)
+                        .windowInsetsPadding(WindowInsets.statusBars),
+                    contentPadding = PaddingValues(bottom = contentPadding.calculateBottomPadding()),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    item {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 8.dp)
+                                .padding(top = 8.dp, bottom = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            IconButton(onClick = { showChannelList = false }) {
+                                Icon(
+                                    Icons.AutoMirrored.Rounded.ArrowBack,
+                                    contentDescription = "Back",
+                                    tint = MaterialTheme.colorScheme.onBackground
+                                )
+                            }
+                            Column {
+                                Text(
+                                    text = "All channels",
+                                    style = MaterialTheme.typography.headlineSmall,
+                                    fontWeight = FontWeight.Bold,
+                                    color = MaterialTheme.colorScheme.onBackground
+                                )
+                                Text(
+                                    text = "${channels.size} subscriptions",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+
+                    if (isChannelsLoading && channels.isEmpty()) {
+                        item {
+                            Box(
+                                Modifier.fillMaxWidth().height(200.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                LoadingIndicator(
+                                    modifier = Modifier.size(48.dp),
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        }
+                    } else if (channels.isEmpty()) {
+                        item {
+                            Box(
+                                modifier = Modifier.fillMaxWidth().padding(32.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(
+                                    "No subscriptions found",
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    } else {
+                        items(channels, key = { it.channelId }) { channel ->
+                            ChannelRow(
+                                channel = channel,
+                                onClick = { selectedChannel = channel },
+                                modifier = Modifier.padding(horizontal = 16.dp)
+                            )
+                        }
+                    }
+
+                    item { Spacer(modifier = Modifier.height(32.dp)) }
+                }
+            }
+        }
+
+        // Default: subscriptions feed with the channel avatar rail
+        else -> {
+            ExpressivePullToRefresh(
+                isRefreshing = isFeedLoading,
+                onRefresh = {
+                    viewModel.loadSubscriptionFeed(force = true)
+                    viewModel.loadSubscriptions(force = true)
+                },
+                modifier = Modifier.fillMaxSize()
+            ) {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(backgroundColor)
+                        .windowInsetsPadding(WindowInsets.statusBars),
+                    contentPadding = PaddingValues(bottom = contentPadding.calculateBottomPadding()),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    item {
+                        AnimatedVisibility(
+                            visible = isVisible,
+                            enter = fadeIn() + slideInVertically(
+                                initialOffsetY = { -40 },
+                                animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
+                            )
+                        ) {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 20.dp)
+                                    .padding(top = 16.dp)
+                            ) {
+                                Text(
+                                    text = "Subscriptions",
+                                    style = MaterialTheme.typography.headlineSmall,
+                                    fontWeight = FontWeight.Bold,
+                                    color = MaterialTheme.colorScheme.onBackground
+                                )
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Text(
+                                    text = "Latest from channels you follow",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+
+                    // Channel avatar rail with the All-channels entry
+                    if (channels.isNotEmpty()) {
+                        item {
+                            LazyRow(
+                                contentPadding = PaddingValues(horizontal = 16.dp),
+                                horizontalArrangement = Arrangement.spacedBy(14.dp)
+                            ) {
+                                items(channels.take(20), key = { it.channelId }) { channel ->
+                                    Column(
+                                        horizontalAlignment = Alignment.CenterHorizontally,
+                                        modifier = Modifier
+                                            .clip(RoundedCornerShape(12.dp))
+                                            .clickable { selectedChannel = channel }
+                                            .padding(4.dp)
+                                            .width(64.dp)
+                                    ) {
+                                        ChannelAvatar(channel = channel, size = 56.dp)
+                                        Spacer(Modifier.height(4.dp))
+                                        Text(
+                                            text = channel.name,
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis
+                                        )
+                                    }
+                                }
+                                item(key = "all-channels") {
+                                    Column(
+                                        horizontalAlignment = Alignment.CenterHorizontally,
+                                        modifier = Modifier
+                                            .clip(RoundedCornerShape(12.dp))
+                                            .clickable { showChannelList = true }
+                                            .padding(4.dp)
+                                            .width(64.dp)
+                                    ) {
+                                        Box(
+                                            modifier = Modifier
+                                                .size(56.dp)
+                                                .clip(CircleShape)
+                                                .background(MaterialTheme.colorScheme.primaryContainer),
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            Icon(
+                                                Icons.AutoMirrored.Rounded.ArrowForward,
+                                                contentDescription = "All channels",
+                                                tint = MaterialTheme.colorScheme.onPrimaryContainer
+                                            )
+                                        }
+                                        Spacer(Modifier.height(4.dp))
+                                        Text(
+                                            text = "All",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            maxLines = 1
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if (isFeedLoading && feed.isEmpty()) {
+                        item {
+                            Box(
+                                Modifier.fillMaxWidth().height(200.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                LoadingIndicator(
+                                    modifier = Modifier.size(48.dp),
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        }
+                    } else if (feed.isEmpty()) {
+                        item {
+                            Box(
+                                modifier = Modifier.fillMaxWidth().padding(32.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(
+                                    "No recent uploads found",
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    } else {
+                        items(feed, key = { it.videoId }) { video ->
+                            VideoCard(
+                                video = video,
+                                onClick = { onVideoClick(video) },
+                                modifier = Modifier.padding(horizontal = 16.dp)
+                            )
+                        }
+                    }
+
+                    item { Spacer(modifier = Modifier.height(32.dp)) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SubscriptionsLoginWall(
+    onLoginClick: () -> Unit,
+    contentPadding: PaddingValues,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier.padding(contentPadding),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier.padding(32.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.Subscriptions,
+                contentDescription = null,
+                modifier = Modifier.size(80.dp),
+                tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f)
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                text = "Subscriptions",
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Log in to see the latest videos from the channels you are subscribed to.",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+            Button(
+                onClick = onLoginClick,
+                modifier = Modifier.fillMaxWidth().height(50.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                )
+            ) {
+                Icon(Icons.Rounded.Login, null)
+                Spacer(Modifier.width(8.dp))
+                Text("Log in to YouTube")
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChannelRow(
+    channel: SubscribedChannel,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        tonalElevation = 1.dp
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            ChannelAvatar(channel = channel, size = 48.dp)
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = channel.name,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (channel.subscriberCountText != null) {
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = channel.subscriberCountText,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChannelAvatar(channel: SubscribedChannel, size: androidx.compose.ui.unit.Dp) {
+    Box(
+        modifier = Modifier
+            .size(size)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+        contentAlignment = Alignment.Center
+    ) {
+        if (channel.avatarUrl != null) {
+            AsyncImage(
+                model = channel.avatarUrl,
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
+            )
+        } else {
+            Text(
+                text = channel.name.take(1).uppercase(),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoHomeContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoHomeContent.kt
@@ -33,6 +33,7 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.rounded.Download
+import androidx.compose.material.icons.rounded.Notifications
 import androidx.compose.material.icons.rounded.PlayCircle
 import androidx.compose.material.icons.rounded.VideoLibrary
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -87,11 +88,41 @@ fun VideoHomeContent(
     val backgroundColor = MaterialTheme.colorScheme.background
     val textColor = MaterialTheme.colorScheme.onBackground
     val isYouTubeConnected by viewModel.isYouTubeConnected.collectAsState()
-    
+
+    // Notifications sheet state
+    var showNotificationsSheet by remember { mutableStateOf(false) }
+    val notifications by viewModel.notifications.collectAsState()
+    val isNotificationsLoading by viewModel.isNotificationsLoading.collectAsState()
+
     // Animation state for staggered entry
     var isVisible by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) {
         isVisible = true
+    }
+
+    if (showNotificationsSheet) {
+        NotificationsSheet(
+            notifications = notifications,
+            isLoading = isNotificationsLoading,
+            onNotificationClick = { notification ->
+                val videoId = notification.videoId
+                if (videoId != null) {
+                    showNotificationsSheet = false
+                    onVideoClick(
+                        VideoItem(
+                            videoId = videoId,
+                            title = notification.message,
+                            channelName = "",
+                            channelIconUrl = notification.channelAvatarUrl,
+                            thumbnailUrl = notification.videoThumbnailUrl,
+                            duration = 0L,
+                            viewCount = ""
+                        )
+                    )
+                }
+            },
+            onDismiss = { showNotificationsSheet = false }
+        )
     }
 
     ExpressivePullToRefresh(
@@ -124,6 +155,14 @@ fun VideoHomeContent(
                         onProfileClick = onProfileClick,
                         onSettingsClick = onSettingsClick,
                         onDownloadsClick = onDownloadsClick,
+                        onNotificationsClick = {
+                            if (isYouTubeConnected) {
+                                viewModel.loadNotifications(force = true)
+                                showNotificationsSheet = true
+                            } else {
+                                onProfileClick()
+                            }
+                        },
                         viewModel = viewModel
                     )
                 }
@@ -195,6 +234,7 @@ private fun VideoTopBarSection(
     onProfileClick: () -> Unit,
     onSettingsClick: () -> Unit,
     onDownloadsClick: () -> Unit,
+    onNotificationsClick: () -> Unit,
     viewModel: HomeViewModel
 ) {
     val surfaceColor = MaterialTheme.colorScheme.surfaceContainer
@@ -242,6 +282,23 @@ private fun VideoTopBarSection(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
+            // Notifications Button
+            IconButton(
+                onClick = onNotificationsClick,
+                shapes = IconButtonDefaults.shapes(),
+                colors = IconButtonDefaults.iconButtonColors(
+                    containerColor = containerColor,
+                    contentColor = iconColor
+                ),
+                modifier = Modifier.size(44.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Notifications,
+                    contentDescription = "Notifications",
+                    modifier = Modifier.size(22.dp)
+                )
+            }
+
             // Downloads Button
             Box {
                 IconButton(

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
@@ -59,6 +59,8 @@ fun VideoPlayerContent(
     val commentReplies by viewModel.replies.collectAsState()
     val loadingReplyIds by viewModel.loadingReplyIds.collectAsState()
     val timedComments by viewModel.timedComments.collectAsState()
+    val canComment by viewModel.canComment.collectAsState()
+    val isPostingComment by viewModel.isPostingComment.collectAsState()
 
     // Local UI State
     var showControls by remember { mutableStateOf(false) }
@@ -298,8 +300,12 @@ fun VideoPlayerContent(
             isLoading = isCommentsLoading,
             isLoadingMore = isLoadingMoreComments,
             commentsAvailable = engagement?.commentsToken != null,
+            canComment = canComment,
+            isPosting = isPostingComment,
             onLoadMore = { viewModel.loadMoreComments() },
             onLoadReplies = { viewModel.loadReplies(it) },
+            onPostComment = { viewModel.postComment(it) },
+            onPostReply = { parent, text -> viewModel.postReply(parent, text) },
             onDismiss = { showCommentsSheet = false }
         )
     }

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
@@ -119,6 +119,18 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
     private var commentsNextToken: String? = null
     private var commentsLoadedForVideoId: String? = null
 
+    // Params for posting a new top-level comment; arrives with the first comments page
+    private val _createCommentParams = MutableStateFlow<String?>(null)
+
+    /** Whether posting a comment is possible (logged in + params available). */
+    val canComment: StateFlow<Boolean> = kotlinx.coroutines.flow.combine(
+        _isLoggedIn, _createCommentParams
+    ) { loggedIn, params -> loggedIn && params != null }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    private val _isPostingComment = MutableStateFlow(false)
+    val isPostingComment: StateFlow<Boolean> = _isPostingComment.asStateFlow()
+
     init {
         // Initialize ExoPlayer
         _exoPlayer = ExoPlayer.Builder(context).build().apply {
@@ -173,6 +185,7 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         _loadingReplyIds.value = emptySet()
         commentsNextToken = null
         commentsLoadedForVideoId = null
+        _createCommentParams.value = null
         _isLoggedIn.value = youtubeRepository.isLoggedIn()
 
         // Load like/subscribe state and the comments entry token in parallel
@@ -268,12 +281,23 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         playbackReportJob?.cancel()
         playbackReportJob = viewModelScope.launch {
             kotlinx.coroutines.delay(10000)
-            if (_isPlaying.value && themePreferences.saveVideoHistory.value) {
+            // A stream still buffering (or briefly paused) at the 10s mark must
+            // not lose its report — wait up to a minute for playback to run.
+            var waitedMs = 0
+            while (!_isPlaying.value && waitedMs < 60_000) {
+                kotlinx.coroutines.delay(1000)
+                waitedMs += 1000
+            }
+            // Fresh pref read: the settings screen toggles through its own
+            // ThemePreferences instance, so this VM's StateFlow copy is stale.
+            if (_isPlaying.value && themePreferences.isSaveVideoHistoryEnabled()) {
                 // Local history: works without login and feeds recommendations.
                 // Use the current video state — Phase 2 may have enriched it.
                 val watched = _currentVideo.value?.takeIf { it.videoId == video.videoId } ?: video
                 videoHistoryRepository.addVideo(watched)
-                youtubeRepository.reportPlayback(video.videoId)
+                // WEB client flow: the music (WEB_REMIX) reporter does not
+                // register plain videos in YouTube watch history
+                youtubeRepository.reportVideoPlayback(video.videoId)
             }
         }
     }
@@ -444,6 +468,7 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
                     _comments.value = page.comments
                     commentsNextToken = page.nextPageToken
                     commentsLoadedForVideoId = video.videoId
+                    _createCommentParams.value = page.createCommentParams
                 }
             } finally {
                 _isCommentsLoading.value = false
@@ -488,6 +513,59 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
                 }
             } finally {
                 _loadingReplyIds.value = _loadingReplyIds.value - comment.commentId
+            }
+        }
+    }
+
+    /**
+     * Post a new top-level comment on the current video. The created comment
+     * is prepended to the list on success. Requires login.
+     */
+    fun postComment(text: String) {
+        val video = _currentVideo.value ?: return
+        val params = _createCommentParams.value ?: return
+        val trimmed = text.trim()
+        if (trimmed.isEmpty() || _isPostingComment.value) return
+        _isPostingComment.value = true
+        viewModelScope.launch {
+            try {
+                val created = youtubeRepository.createComment(params, trimmed)
+                if (created != null && _currentVideo.value?.videoId == video.videoId) {
+                    _comments.value = listOf(created) + _comments.value
+                }
+            } finally {
+                _isPostingComment.value = false
+            }
+        }
+    }
+
+    /**
+     * Post a reply to a top-level comment. The reply is appended to that
+     * comment's visible replies on success. Requires login.
+     */
+    fun postReply(parent: CommentItem, text: String) {
+        val video = _currentVideo.value ?: return
+        val params = parent.replyParams ?: return
+        val trimmed = text.trim()
+        if (trimmed.isEmpty() || _isPostingComment.value) return
+        _isPostingComment.value = true
+        viewModelScope.launch {
+            try {
+                val created = youtubeRepository.createCommentReply(params, trimmed)
+                if (created != null && _currentVideo.value?.videoId == video.videoId) {
+                    val existing = _replies.value[parent.commentId]
+                    if (existing != null || parent.repliesToken == null) {
+                        // Replies already visible (or none exist yet): append inline
+                        _replies.value = _replies.value +
+                            (parent.commentId to (existing ?: emptyList()) + created)
+                    } else {
+                        // Replies exist but are collapsed: fetch the thread so the
+                        // older replies are not hidden behind the local insert
+                        loadReplies(parent)
+                    }
+                }
+            } finally {
+                _isPostingComment.value = false
             }
         }
     }


### PR DESCRIPTION
This PR grew from the playlist fix into the 4.0 video-mode feature batch.

## Fixes #42 — Library playlists not loading
FEmusic_liked_playlists returns the library as a gridRenderer wrapped in an itemSectionRenderer, neither of which parseItemsFromShelf handled. Parse both, follow gridContinuation pages, dedupe against the synthesized Supermix/Likes entries, and show the uploader instead of "-1 songs" when the count is unknown.

## Closes #44 — Write comments
- Composer pinned under the comments sheet with reply targeting, gated on login
- `comment/create_comment` / `comment/create_comment_reply` InnerTube endpoints; createCommentParams parsed from the comments page header, per-comment reply params from engagementToolbarSurfaceEntityPayload mutations
- Posted comments/replies appear in the sheet immediately (verified live end to end)

## Closes #45 — Subscriptions tab
- Video mode nav now has 4 tabs: Home, Search, Subs, History (music mode unchanged)
- Subs opens on the FEsubscriptions feed (latest uploads) topped by a channel avatar rail; the "All" entry opens the full channel list (FEchannels, paginated), and any channel drills into its uploads

## Closes #46 — Notifications
- Bell on the video home top bar opens the notification inbox (notification/get_notification_menu) with unread dots, thumbnails and timestamps; tapping a notification plays the video

## Video watch history fixes
- reportPlayback only registered music: the WEB_REMIX/music flow ignores plain videos — videos now report through the WEB client on www.youtube.com (verified they land in youtube.com/feed/history)
- The save-history toggle was read from a stale per-ViewModel StateFlow; it is now read fresh at decision time
- Reports are no longer dropped when the stream is still buffering at the 10s mark

## Search screen (video mode)
- Empty state shows an Explore view (quick-search topic chips + compact Trending list) instead of the music library browse; placeholder reads "Search videos, channels..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BLmPDT89CYKrg38LHBzTjQ