### PR TITLE
Add animated music/video mode toggle to the Home screen

### DIFF
--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -228,6 +228,7 @@ fun MusicApp(
                     excludedFolders = excludedFolders,
                     ambientBackground = ambientBackground,
                     videoMode = videoMode,
+                    onVideoModeToggle = onVideoModeToggle,
                     playerStyle = playerStyle,
                     manualScan = manualScanEnabled
                 )

--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -53,6 +53,7 @@ class MainActivity : ComponentActivity() {
             val loadLocalSongs by themeViewModel.loadLocalSongs.collectAsState()
             val ambientBackground by themeViewModel.ambientBackground.collectAsState()
             val videoMode by themeViewModel.videoMode.collectAsState()
+            val homeModeToggleEnabled by themeViewModel.homeModeToggleEnabled.collectAsState()
             val playerStyle by themeViewModel.playerStyle.collectAsState()
             val saveVideoHistory by themeViewModel.saveVideoHistory.collectAsState()
             val timedCommentsEnabled by themeViewModel.timedCommentsEnabled.collectAsState()
@@ -91,6 +92,8 @@ class MainActivity : ComponentActivity() {
                         onAmbientBackgroundToggle = { themeViewModel.setAmbientBackground(it) },
                         videoMode = videoMode,
                         onVideoModeToggle = { themeViewModel.setVideoMode(it) },
+                        homeModeToggleEnabled = homeModeToggleEnabled,
+                        onHomeModeToggleEnabledChange = { themeViewModel.setHomeModeToggleEnabled(it) },
                         playerStyle = playerStyle,
                         onPlayerStyleChange = { themeViewModel.setPlayerStyle(it) },
                         saveVideoHistory = saveVideoHistory,
@@ -135,6 +138,8 @@ fun MusicApp(
     onAmbientBackgroundToggle: (Boolean) -> Unit,
     videoMode: Boolean,
     onVideoModeToggle: (Boolean) -> Unit,
+    homeModeToggleEnabled: Boolean,
+    onHomeModeToggleEnabledChange: (Boolean) -> Unit,
     playerStyle: PlayerStyle,
     onPlayerStyleChange: (PlayerStyle) -> Unit,
     saveVideoHistory: Boolean,
@@ -192,6 +197,8 @@ fun MusicApp(
                     onAmbientBackgroundToggle = onAmbientBackgroundToggle,
                     videoMode = videoMode,
                     onVideoModeToggle = onVideoModeToggle,
+                    homeModeToggleEnabled = homeModeToggleEnabled,
+                    onHomeModeToggleEnabledChange = onHomeModeToggleEnabledChange,
                     playerStyle = playerStyle,
                     onPlayerStyleChange = onPlayerStyleChange,
                     crossfadeEnabled = crossfadeEnabled,
@@ -229,6 +236,7 @@ fun MusicApp(
                     ambientBackground = ambientBackground,
                     videoMode = videoMode,
                     onVideoModeToggle = onVideoModeToggle,
+                    showModeToggle = homeModeToggleEnabled,
                     playerStyle = playerStyle,
                     manualScan = manualScanEnabled
                 )
@@ -249,6 +257,8 @@ fun MusicApp(
                     onAmbientBackgroundToggle = onAmbientBackgroundToggle,
                     videoMode = videoMode,
                     onVideoModeToggle = onVideoModeToggle,
+                    homeModeToggleEnabled = homeModeToggleEnabled,
+                    onHomeModeToggleChange = onHomeModeToggleEnabledChange,
                     playerStyle = playerStyle,
                     onPlayerStyleChange = onPlayerStyleChange,
                     saveVideoHistory = saveVideoHistory,

--- a/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
@@ -27,7 +27,10 @@ class ThemePreferences(context: Context) {
     
     private val _videoMode = MutableStateFlow(getVideoModePreference())
     val videoMode: StateFlow<Boolean> = _videoMode.asStateFlow()
-    
+
+    private val _homeModeToggleEnabled = MutableStateFlow(getHomeModeToggleEnabledPreference())
+    val homeModeToggleEnabled: StateFlow<Boolean> = _homeModeToggleEnabled.asStateFlow()
+
     private val _playerStyle = MutableStateFlow(getPlayerStylePreference())
     val playerStyle: StateFlow<PlayerStyle> = _playerStyle.asStateFlow()
     
@@ -70,6 +73,7 @@ class ThemePreferences(context: Context) {
         private const val KEY_LOAD_LOCAL_SONGS = "load_local_songs"
         private const val KEY_AMBIENT_BACKGROUND = "ambient_background"
         private const val KEY_VIDEO_MODE = "video_mode"
+        private const val KEY_HOME_MODE_TOGGLE_ENABLED = "home_mode_toggle_enabled"
         private const val KEY_PLAYER_STYLE = "player_style"
         private const val KEY_SAVE_VIDEO_HISTORY = "save_video_history"
         private const val KEY_TIMED_COMMENTS_ENABLED = "timed_comments_enabled"
@@ -227,7 +231,23 @@ class ThemePreferences(context: Context) {
     fun toggleVideoMode() {
         setVideoMode(!_videoMode.value)
     }
-    
+
+    /**
+     * Get the stored home mode toggle preference. Defaults to true (the
+     * music/video switch is shown in the Home screen top bar).
+     */
+    private fun getHomeModeToggleEnabledPreference(): Boolean {
+        return prefs.getBoolean(KEY_HOME_MODE_TOGGLE_ENABLED, true)
+    }
+
+    /**
+     * Save home mode toggle preference and update the flow.
+     */
+    fun setHomeModeToggleEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_HOME_MODE_TOGGLE_ENABLED, enabled).apply()
+        _homeModeToggleEnabled.value = enabled
+    }
+
     /**
      * Get the stored player style preference. Defaults to CLASSIC.
      */

--- a/app/src/main/java/com/ivor/ivormusic/ui/components/MusicVideoToggle.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/components/MusicVideoToggle.kt
@@ -1,0 +1,183 @@
+package com.ivor.ivormusic.ui.components
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.VideoLibrary
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+
+/**
+ * Thumb animation for [MusicVideoToggle], hoisted out of the toggle itself.
+ *
+ * Flipping the mode swaps the whole home content (music top bar vs video top bar),
+ * which destroys and recreates the toggle mid-transition. Both top bars render a
+ * toggle bound to the same instance of this state, so the thumb keeps sliding
+ * across the content swap instead of snapping to its final position.
+ */
+@Stable
+class MusicVideoToggleState(initialVideoMode: Boolean) {
+    internal val fastEdge = Animatable(if (initialVideoMode) 1f else 0f)
+    internal val slowEdge = Animatable(if (initialVideoMode) 1f else 0f)
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun rememberMusicVideoToggleState(videoMode: Boolean): MusicVideoToggleState {
+    val state = remember { MusicVideoToggleState(videoMode) }
+    val fastSpec = MaterialTheme.motionScheme.fastSpatialSpec<Float>()
+    val defaultSpec = MaterialTheme.motionScheme.defaultSpatialSpec<Float>()
+    LaunchedEffect(videoMode) {
+        val target = if (videoMode) 1f else 0f
+        // The leading edge races ahead on a fast spring while the trailing edge
+        // follows on the default one, stretching the thumb like liquid mid-flight.
+        launch { state.fastEdge.animateTo(target, fastSpec) }
+        launch { state.slowEdge.animateTo(target, defaultSpec) }
+    }
+    return state
+}
+
+/**
+ * Pill-shaped music/video mode switch matching the 44dp top bar icon buttons.
+ * A primary-container thumb slides (and stretches) between the two segments
+ * with expressive spring motion; the active icon pops in with a bounce.
+ */
+@Composable
+fun MusicVideoToggle(
+    videoMode: Boolean,
+    onVideoModeChange: (Boolean) -> Unit,
+    state: MusicVideoToggleState,
+    modifier: Modifier = Modifier
+) {
+    val haptics = LocalHapticFeedback.current
+    val segmentWidth = 38.dp
+    val segmentHeight = 36.dp
+
+    Surface(
+        modifier = modifier.height(44.dp),
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.surfaceContainerHigh
+    ) {
+        Box(modifier = Modifier.padding(4.dp)) {
+            // Overshoot is clamped so the stretched thumb squashes against the
+            // track ends instead of poking outside them.
+            val start = minOf(state.fastEdge.value, state.slowEdge.value).coerceAtLeast(0f)
+            val end = maxOf(state.fastEdge.value, state.slowEdge.value).coerceAtMost(1f)
+            Box(
+                modifier = Modifier
+                    .offset(x = segmentWidth * start)
+                    .width(segmentWidth * (1f + end - start))
+                    .height(segmentHeight)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primaryContainer)
+            )
+            Row {
+                ToggleSegment(
+                    icon = Icons.Rounded.MusicNote,
+                    contentDescription = "Switch to music mode",
+                    selected = !videoMode,
+                    segmentWidth = segmentWidth,
+                    segmentHeight = segmentHeight,
+                    onClick = {
+                        if (videoMode) {
+                            haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                            onVideoModeChange(false)
+                        }
+                    }
+                )
+                ToggleSegment(
+                    icon = Icons.Rounded.VideoLibrary,
+                    contentDescription = "Switch to video mode",
+                    selected = videoMode,
+                    segmentWidth = segmentWidth,
+                    segmentHeight = segmentHeight,
+                    onClick = {
+                        if (!videoMode) {
+                            haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                            onVideoModeChange(true)
+                        }
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ToggleSegment(
+    icon: ImageVector,
+    contentDescription: String,
+    selected: Boolean,
+    segmentWidth: Dp,
+    segmentHeight: Dp,
+    onClick: () -> Unit
+) {
+    val tint by animateColorAsState(
+        targetValue = if (selected) MaterialTheme.colorScheme.onPrimaryContainer
+        else MaterialTheme.colorScheme.onSurfaceVariant,
+        animationSpec = tween(durationMillis = 200),
+        label = "segmentTint"
+    )
+    val scale by animateFloatAsState(
+        targetValue = if (selected) 1f else 0.8f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMedium
+        ),
+        label = "segmentScale"
+    )
+
+    Box(
+        modifier = Modifier
+            .size(width = segmentWidth, height = segmentHeight)
+            .clip(CircleShape)
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = onClick
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDescription,
+            tint = tint,
+            modifier = Modifier
+                .size(20.dp)
+                .scale(scale)
+        )
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeScreen.kt
@@ -149,6 +149,7 @@ fun HomeScreen(
     ambientBackground: Boolean = true,
     videoMode: Boolean = false,
     onVideoModeToggle: (Boolean) -> Unit = {},
+    showModeToggle: Boolean = true,
     playerStyle: PlayerStyle = PlayerStyle.CLASSIC,
     manualScan: Boolean = false
 ) {
@@ -331,6 +332,7 @@ fun HomeScreen(
                                     viewModel = viewModel,
                                     videoMode = videoMode,
                                     onVideoModeToggle = onVideoModeToggle,
+                                    showModeToggle = showModeToggle,
                                     modeToggleState = modeToggleState
                                 )
                             }
@@ -365,6 +367,7 @@ fun HomeScreen(
                                     manualScan = manualScan,
                                     videoMode = videoMode,
                                     onVideoModeToggle = onVideoModeToggle,
+                                    showModeToggle = showModeToggle,
                                     modeToggleState = modeToggleState
                                 )
                             }
@@ -740,6 +743,7 @@ fun YourMixContent(
     manualScan: Boolean = false,
     videoMode: Boolean = false,
     onVideoModeToggle: (Boolean) -> Unit = {},
+    showModeToggle: Boolean = true,
     modeToggleState: MusicVideoToggleState = rememberMusicVideoToggleState(videoMode)
 ) {
     val backgroundColor = MaterialTheme.colorScheme.background
@@ -766,7 +770,7 @@ fun YourMixContent(
                     alpha = if (visible) 1f else 0f
                     translationY = if (visible) 0f else -20f
                 }.animateContentSize()) {
-                    TopBarSection(onProfileClick = onProfileClick, onSettingsClick = onSettingsClick, onDownloadsClick = onDownloadsClick, isDarkMode = isDarkMode, viewModel = viewModel, videoMode = videoMode, onVideoModeToggle = onVideoModeToggle, modeToggleState = modeToggleState)
+                    TopBarSection(onProfileClick = onProfileClick, onSettingsClick = onSettingsClick, onDownloadsClick = onDownloadsClick, isDarkMode = isDarkMode, viewModel = viewModel, videoMode = videoMode, onVideoModeToggle = onVideoModeToggle, showModeToggle = showModeToggle, modeToggleState = modeToggleState)
                 }
             }
             
@@ -833,6 +837,7 @@ fun TopBarSection(
     viewModel: HomeViewModel,
     videoMode: Boolean = false,
     onVideoModeToggle: (Boolean) -> Unit = {},
+    showModeToggle: Boolean = true,
     modeToggleState: MusicVideoToggleState = rememberMusicVideoToggleState(videoMode)
 ) {
     val surfaceColor = MaterialTheme.colorScheme.surfaceContainer
@@ -927,12 +932,15 @@ fun TopBarSection(
             }
 
             // Music/Video mode switch, anchored in the corner so it stays put
-            // when the home content swaps between modes
-            MusicVideoToggle(
-                videoMode = videoMode,
-                onVideoModeChange = onVideoModeToggle,
-                state = modeToggleState
-            )
+            // when the home content swaps between modes. Can be hidden from
+            // Settings (Home Screen Mode Toggle).
+            if (showModeToggle) {
+                MusicVideoToggle(
+                    videoMode = videoMode,
+                    onVideoModeChange = onVideoModeToggle,
+                    state = modeToggleState
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeScreen.kt
@@ -105,6 +105,9 @@ import com.google.accompanist.permissions.rememberPermissionState
 import com.ivor.ivormusic.data.Song
 import com.ivor.ivormusic.data.PlayerStyle
 import com.ivor.ivormusic.ui.components.FloatingPillNavBar
+import com.ivor.ivormusic.ui.components.MusicVideoToggle
+import com.ivor.ivormusic.ui.components.MusicVideoToggleState
+import com.ivor.ivormusic.ui.components.rememberMusicVideoToggleState
 import com.ivor.ivormusic.ui.player.PlayerViewModel
 import com.ivor.ivormusic.ui.player.ExpandablePlayer
 import com.ivor.ivormusic.ui.player.PlayerSheetContent
@@ -145,6 +148,7 @@ fun HomeScreen(
     excludedFolders: Set<String> = emptySet(),
     ambientBackground: Boolean = true,
     videoMode: Boolean = false,
+    onVideoModeToggle: (Boolean) -> Unit = {},
     playerStyle: PlayerStyle = PlayerStyle.CLASSIC,
     manualScan: Boolean = false
 ) {
@@ -211,6 +215,10 @@ fun HomeScreen(
     }
 
     var selectedTab by remember { mutableIntStateOf(0) }
+
+    // Lives outside the mode-swapped content so the thumb keeps animating
+    // while the music/video home content cross-fades underneath it
+    val modeToggleState = rememberMusicVideoToggleState(videoMode)
 
     // Handle back button to return to Home tab if on Search or Library
     BackHandler(enabled = selectedTab != 0) {
@@ -284,54 +292,82 @@ fun HomeScreen(
             ) { targetTab ->
                 when (targetTab) {
                     0 -> {
-                        // Video Mode: Show video content
-                        if (videoMode) {
-                            VideoHomeContent(
-                                videos = trendingVideos,
-                                isLoading = isVideoLoading,
-                                onVideoClick = { video ->
-                                    // Navigate to video player screen
-                                    onNavigateToVideoPlayer(video)
-                                },
-                                onProfileClick = onProfileClick,
-                                onSettingsClick = onNavigateToSettings,
-                                onDownloadsClick = onNavigateToDownloads,
-                                onRefresh = { viewModel.refreshVideos() },
-                                isDarkMode = isDarkMode,
-                                contentPadding = PaddingValues(bottom = 160.dp),
-                                viewModel = viewModel
-                            )
-                        } 
-                        // Music Mode: Show original content
-                        else if (isLoading && songs.isEmpty()) {
-                             Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                                LoadingIndicator(
-                                    modifier = Modifier.size(48.dp),
-                                    color = MaterialTheme.colorScheme.primary
+                        // Mode swap morphs the page while the hoisted toggle
+                        // thumb keeps sliding above it. Spec is read here because
+                        // motionScheme is composable and transitionSpec is not.
+                        val modeScaleSpec = MaterialTheme.motionScheme.fastSpatialSpec<Float>()
+                        androidx.compose.animation.AnimatedContent(
+                            targetState = videoMode,
+                            label = "ModeTransition",
+                            transitionSpec = {
+                                (androidx.compose.animation.fadeIn(
+                                    androidx.compose.animation.core.tween(durationMillis = 260, delayMillis = 60)
+                                ) + androidx.compose.animation.scaleIn(
+                                    initialScale = 0.92f,
+                                    animationSpec = modeScaleSpec
+                                )) togetherWith (androidx.compose.animation.fadeOut(
+                                    androidx.compose.animation.core.tween(durationMillis = 160)
+                                ) + androidx.compose.animation.scaleOut(
+                                    targetScale = 1.05f,
+                                    animationSpec = androidx.compose.animation.core.tween(durationMillis = 220)
+                                ))
+                            }
+                        ) { videoModeContent ->
+                            // Video Mode: Show video content
+                            if (videoModeContent) {
+                                VideoHomeContent(
+                                    videos = trendingVideos,
+                                    isLoading = isVideoLoading,
+                                    onVideoClick = { video ->
+                                        // Navigate to video player screen
+                                        onNavigateToVideoPlayer(video)
+                                    },
+                                    onProfileClick = onProfileClick,
+                                    onSettingsClick = onNavigateToSettings,
+                                    onDownloadsClick = onNavigateToDownloads,
+                                    onRefresh = { viewModel.refreshVideos() },
+                                    isDarkMode = isDarkMode,
+                                    contentPadding = PaddingValues(bottom = 160.dp),
+                                    viewModel = viewModel,
+                                    videoMode = videoMode,
+                                    onVideoModeToggle = onVideoModeToggle,
+                                    modeToggleState = modeToggleState
                                 )
                             }
-                        } else {
-                            YourMixContent(
-                                songs = songs,
-                                onSongClick = { song ->
-                                    playerViewModel.playQueue(songs, song)
-                                    showPlayerSheet = true
-                                },
-                                onPlayClick = {
-                                    if (songs.isNotEmpty()) {
-                                        playerViewModel.playQueue(songs)
+                            // Music Mode: Show original content
+                            else if (isLoading && songs.isEmpty()) {
+                                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                                    LoadingIndicator(
+                                        modifier = Modifier.size(48.dp),
+                                        color = MaterialTheme.colorScheme.primary
+                                    )
+                                }
+                            } else {
+                                YourMixContent(
+                                    songs = songs,
+                                    onSongClick = { song ->
+                                        playerViewModel.playQueue(songs, song)
                                         showPlayerSheet = true
-                                    }
-                                },
-                                onProfileClick = onProfileClick,
-                                onSettingsClick = onNavigateToSettings,
-                                onDownloadsClick = onNavigateToDownloads,
-                                isDarkMode = isDarkMode,
-                                contentPadding = PaddingValues(bottom = 160.dp), // Space for navbar + miniplayer
-                                viewModel = viewModel,
-                                excludedFolders = excludedFolders,
-                                manualScan = manualScan
-                            )
+                                    },
+                                    onPlayClick = {
+                                        if (songs.isNotEmpty()) {
+                                            playerViewModel.playQueue(songs)
+                                            showPlayerSheet = true
+                                        }
+                                    },
+                                    onProfileClick = onProfileClick,
+                                    onSettingsClick = onNavigateToSettings,
+                                    onDownloadsClick = onNavigateToDownloads,
+                                    isDarkMode = isDarkMode,
+                                    contentPadding = PaddingValues(bottom = 160.dp), // Space for navbar + miniplayer
+                                    viewModel = viewModel,
+                                    excludedFolders = excludedFolders,
+                                    manualScan = manualScan,
+                                    videoMode = videoMode,
+                                    onVideoModeToggle = onVideoModeToggle,
+                                    modeToggleState = modeToggleState
+                                )
+                            }
                         }
                     }
                     1 -> SearchContent(
@@ -701,7 +737,10 @@ fun YourMixContent(
     contentPadding: PaddingValues,
     viewModel: HomeViewModel,
     excludedFolders: Set<String> = emptySet(),
-    manualScan: Boolean = false
+    manualScan: Boolean = false,
+    videoMode: Boolean = false,
+    onVideoModeToggle: (Boolean) -> Unit = {},
+    modeToggleState: MusicVideoToggleState = rememberMusicVideoToggleState(videoMode)
 ) {
     val backgroundColor = MaterialTheme.colorScheme.background
     val textColor = MaterialTheme.colorScheme.onBackground
@@ -727,7 +766,7 @@ fun YourMixContent(
                     alpha = if (visible) 1f else 0f
                     translationY = if (visible) 0f else -20f
                 }.animateContentSize()) {
-                    TopBarSection(onProfileClick = onProfileClick, onSettingsClick = onSettingsClick, onDownloadsClick = onDownloadsClick, isDarkMode = isDarkMode, viewModel = viewModel)
+                    TopBarSection(onProfileClick = onProfileClick, onSettingsClick = onSettingsClick, onDownloadsClick = onDownloadsClick, isDarkMode = isDarkMode, viewModel = viewModel, videoMode = videoMode, onVideoModeToggle = onVideoModeToggle, modeToggleState = modeToggleState)
                 }
             }
             
@@ -791,7 +830,10 @@ fun TopBarSection(
     onSettingsClick: () -> Unit,
     onDownloadsClick: () -> Unit = {},
     isDarkMode: Boolean,
-    viewModel: HomeViewModel
+    viewModel: HomeViewModel,
+    videoMode: Boolean = false,
+    onVideoModeToggle: (Boolean) -> Unit = {},
+    modeToggleState: MusicVideoToggleState = rememberMusicVideoToggleState(videoMode)
 ) {
     val surfaceColor = MaterialTheme.colorScheme.surfaceContainer
     val iconColor = MaterialTheme.colorScheme.onSurface
@@ -883,6 +925,14 @@ fun TopBarSection(
                     modifier = Modifier.size(22.dp)
                 )
             }
+
+            // Music/Video mode switch, anchored in the corner so it stays put
+            // when the home content swaps between modes
+            MusicVideoToggle(
+                videoMode = videoMode,
+                onVideoModeChange = onVideoModeToggle,
+                state = modeToggleState
+            )
         }
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/onboarding/OnboardingScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material.icons.rounded.NotificationsActive
 import androidx.compose.material.icons.rounded.Palette
 import androidx.compose.material.icons.rounded.PhoneAndroid
+import androidx.compose.material.icons.rounded.ToggleOn
 import androidx.compose.material.icons.rounded.Tune
 import androidx.compose.material.icons.rounded.Videocam
 import androidx.compose.material.icons.rounded.Wallpaper
@@ -128,6 +129,8 @@ fun OnboardingScreen(
     onAmbientBackgroundToggle: (Boolean) -> Unit,
     videoMode: Boolean,
     onVideoModeToggle: (Boolean) -> Unit,
+    homeModeToggleEnabled: Boolean = true,
+    onHomeModeToggleEnabledChange: (Boolean) -> Unit = {},
     playerStyle: PlayerStyle,
     onPlayerStyleChange: (PlayerStyle) -> Unit,
     crossfadeEnabled: Boolean,
@@ -268,7 +271,9 @@ fun OnboardingScreen(
                         )
                         3 -> VideoModePage(
                             videoMode = videoMode,
-                            onVideoModeToggle = onVideoModeToggle
+                            onVideoModeToggle = onVideoModeToggle,
+                            homeModeToggleEnabled = homeModeToggleEnabled,
+                            onHomeModeToggleEnabledChange = onHomeModeToggleEnabledChange
                         )
                         4 -> LookAndFeelPage(
                             currentThemeMode = currentThemeMode,
@@ -562,7 +567,9 @@ private fun YouTubePage(
 @Composable
 private fun VideoModePage(
     videoMode: Boolean,
-    onVideoModeToggle: (Boolean) -> Unit
+    onVideoModeToggle: (Boolean) -> Unit,
+    homeModeToggleEnabled: Boolean,
+    onHomeModeToggleEnabledChange: (Boolean) -> Unit
 ) {
     OnboardingPageScaffold(
         icon = Icons.Rounded.Videocam,
@@ -576,6 +583,14 @@ private fun VideoModePage(
             subtitle = "Video home, video search and watch history",
             checked = videoMode,
             onCheckedChange = onVideoModeToggle
+        )
+
+        SettingSwitchRow(
+            icon = Icons.Rounded.ToggleOn,
+            title = "Home screen switch",
+            subtitle = "Quick music/video toggle in the Home top bar",
+            checked = homeModeToggleEnabled,
+            onCheckedChange = onHomeModeToggleEnabledChange
         )
 
         HintText("Off keeps a cleaner, music-first layout. The video player stays available either way.")

--- a/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.material.icons.rounded.PlayCircle
 import androidx.compose.material.icons.rounded.Security
 import androidx.compose.material.icons.rounded.FlashOn
 import androidx.compose.material.icons.rounded.SwipeRight
+import androidx.compose.material.icons.rounded.ToggleOn
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -171,6 +172,8 @@ fun SettingsScreen(
     onAmbientBackgroundToggle: (Boolean) -> Unit,
     videoMode: Boolean,
     onVideoModeToggle: (Boolean) -> Unit,
+    homeModeToggleEnabled: Boolean = true,
+    onHomeModeToggleChange: (Boolean) -> Unit = {},
     playerStyle: PlayerStyle,
     onPlayerStyleChange: (PlayerStyle) -> Unit,
     saveVideoHistory: Boolean,
@@ -639,6 +642,16 @@ fun SettingsScreen(
                             textColor = textColor,
                             secondaryTextColor = secondaryTextColor,
                             accentColor = Color(0xFFFF0000) // YouTube red
+                        )
+
+                        SettingsDivider()
+
+                        ExpressiveHomeModeToggleItem(
+                            enabled = homeModeToggleEnabled,
+                            onToggle = onHomeModeToggleChange,
+                            textColor = textColor,
+                            secondaryTextColor = secondaryTextColor,
+                            accentColor = accentColor
                         )
 
                         SettingsDivider()
@@ -1273,6 +1286,86 @@ private fun ExpressiveVideoModeToggleItem(
                 }
             }
         }
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun ExpressiveHomeModeToggleItem(
+    enabled: Boolean,
+    onToggle: (Boolean) -> Unit,
+    textColor: Color,
+    secondaryTextColor: Color,
+    accentColor: Color
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.97f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
+        label = "scale"
+    )
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .scale(scale)
+            .clip(RoundedCornerShape(18.dp))
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null
+            ) { onToggle(!enabled) }
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // Icon
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .clip(RoundedCornerShape(14.dp))
+                .background(accentColor.copy(alpha = 0.12f)),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.ToggleOn,
+                contentDescription = null,
+                tint = accentColor,
+                modifier = Modifier.size(26.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        // Text
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = "Home Screen Mode Toggle",
+                color = textColor,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = if (enabled) "Music/video switch shown in the Home top bar" else "Switch modes from Settings only",
+                color = secondaryTextColor,
+                fontSize = 13.sp
+            )
+        }
+
+        // Switch
+        Switch(
+            checked = enabled,
+            onCheckedChange = onToggle,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = Color.White,
+                checkedTrackColor = accentColor,
+                uncheckedThumbColor = Color.White,
+                uncheckedTrackColor = secondaryTextColor.copy(alpha = 0.3f),
+                uncheckedBorderColor = Color.Transparent,
+                checkedBorderColor = Color.Transparent
+            )
+        )
     }
 }
 

--- a/app/src/main/java/com/ivor/ivormusic/ui/theme/ThemeViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/theme/ThemeViewModel.kt
@@ -19,6 +19,7 @@ class ThemeViewModel(application: Application) : AndroidViewModel(application) {
     val loadLocalSongs: StateFlow<Boolean> = themePreferences.loadLocalSongs
     val ambientBackground: StateFlow<Boolean> = themePreferences.ambientBackground
     val videoMode: StateFlow<Boolean> = themePreferences.videoMode
+    val homeModeToggleEnabled: StateFlow<Boolean> = themePreferences.homeModeToggleEnabled
     val playerStyle: StateFlow<PlayerStyle> = themePreferences.playerStyle
     val saveVideoHistory: StateFlow<Boolean> = themePreferences.saveVideoHistory
     val timedCommentsEnabled: StateFlow<Boolean> = themePreferences.timedCommentsEnabled
@@ -63,7 +64,11 @@ class ThemeViewModel(application: Application) : AndroidViewModel(application) {
     fun toggleVideoMode() {
         themePreferences.toggleVideoMode()
     }
-    
+
+    fun setHomeModeToggleEnabled(enabled: Boolean) {
+        themePreferences.setHomeModeToggleEnabled(enabled)
+    }
+
     fun setPlayerStyle(style: PlayerStyle) {
         themePreferences.setPlayerStyle(style)
     }

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoHomeContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoHomeContent.kt
@@ -89,6 +89,7 @@ fun VideoHomeContent(
     viewModel: HomeViewModel,
     videoMode: Boolean = true,
     onVideoModeToggle: (Boolean) -> Unit = {},
+    showModeToggle: Boolean = true,
     modeToggleState: MusicVideoToggleState = rememberMusicVideoToggleState(videoMode)
 ) {
     val backgroundColor = MaterialTheme.colorScheme.background
@@ -172,6 +173,7 @@ fun VideoHomeContent(
                         viewModel = viewModel,
                         videoMode = videoMode,
                         onVideoModeToggle = onVideoModeToggle,
+                        showModeToggle = showModeToggle,
                         modeToggleState = modeToggleState
                     )
                 }
@@ -247,6 +249,7 @@ private fun VideoTopBarSection(
     viewModel: HomeViewModel,
     videoMode: Boolean = true,
     onVideoModeToggle: (Boolean) -> Unit = {},
+    showModeToggle: Boolean = true,
     modeToggleState: MusicVideoToggleState = rememberMusicVideoToggleState(videoMode)
 ) {
     val surfaceColor = MaterialTheme.colorScheme.surfaceContainer
@@ -357,12 +360,15 @@ private fun VideoTopBarSection(
             }
 
             // Music/Video mode switch, anchored in the corner so it stays put
-            // when the home content swaps between modes
-            MusicVideoToggle(
-                videoMode = videoMode,
-                onVideoModeChange = onVideoModeToggle,
-                state = modeToggleState
-            )
+            // when the home content swaps between modes. Can be hidden from
+            // Settings (Home Screen Mode Toggle).
+            if (showModeToggle) {
+                MusicVideoToggle(
+                    videoMode = videoMode,
+                    onVideoModeChange = onVideoModeToggle,
+                    state = modeToggleState
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoHomeContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoHomeContent.kt
@@ -65,6 +65,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.VideoItem
+import com.ivor.ivormusic.ui.components.MusicVideoToggle
+import com.ivor.ivormusic.ui.components.MusicVideoToggleState
+import com.ivor.ivormusic.ui.components.rememberMusicVideoToggleState
 import com.ivor.ivormusic.ui.home.HomeViewModel
 
 /**
@@ -83,7 +86,10 @@ fun VideoHomeContent(
     onRefresh: () -> Unit,
     isDarkMode: Boolean,
     contentPadding: PaddingValues,
-    viewModel: HomeViewModel
+    viewModel: HomeViewModel,
+    videoMode: Boolean = true,
+    onVideoModeToggle: (Boolean) -> Unit = {},
+    modeToggleState: MusicVideoToggleState = rememberMusicVideoToggleState(videoMode)
 ) {
     val backgroundColor = MaterialTheme.colorScheme.background
     val textColor = MaterialTheme.colorScheme.onBackground
@@ -163,7 +169,10 @@ fun VideoHomeContent(
                                 onProfileClick()
                             }
                         },
-                        viewModel = viewModel
+                        viewModel = viewModel,
+                        videoMode = videoMode,
+                        onVideoModeToggle = onVideoModeToggle,
+                        modeToggleState = modeToggleState
                     )
                 }
                 
@@ -235,7 +244,10 @@ private fun VideoTopBarSection(
     onSettingsClick: () -> Unit,
     onDownloadsClick: () -> Unit,
     onNotificationsClick: () -> Unit,
-    viewModel: HomeViewModel
+    viewModel: HomeViewModel,
+    videoMode: Boolean = true,
+    onVideoModeToggle: (Boolean) -> Unit = {},
+    modeToggleState: MusicVideoToggleState = rememberMusicVideoToggleState(videoMode)
 ) {
     val surfaceColor = MaterialTheme.colorScheme.surfaceContainer
     val iconColor = MaterialTheme.colorScheme.onSurface
@@ -343,6 +355,14 @@ private fun VideoTopBarSection(
                     modifier = Modifier.size(22.dp)
                 )
             }
+
+            // Music/Video mode switch, anchored in the corner so it stays put
+            // when the home content swaps between modes
+            MusicVideoToggle(
+                videoMode = videoMode,
+                onVideoModeChange = onVideoModeToggle,
+                state = modeToggleState
+            )
         }
     }
 }


### PR DESCRIPTION
## What

Adds a pill-shaped music/video mode switch directly on the Home screen, anchored in the top-right corner of both the music (`TopBarSection`) and video (`VideoTopBarSection`) top bars. Switching modes no longer requires a trip to Settings. A new **Home Screen Mode Toggle** preference (Settings + onboarding, default on) controls whether the pill is shown.

## The toggle

- **Look**: 44dp-tall pill on `surfaceContainerHigh`, matching the neighboring top bar icon buttons exactly. Uses the same `MusicNote` / `VideoLibrary` icon pair as the Settings mode switch, with a `primaryContainer` thumb (the floating navbar's selection language).
- **Liquid thumb animation**: the thumb's leading edge moves on the M3 Expressive `fastSpatialSpec()` spring while the trailing edge follows on `defaultSpatialSpec()`, so the pill visibly stretches mid-flight and snaps back with a bounce. Overshoot is clamped so it squashes against the track ends instead of escaping them.
- **Icon pops**: the newly active icon scales in with a `DampingRatioMediumBouncy` spring; tints crossfade.
- **Haptics** on every mode change.

## The tricky part: surviving the content swap

Flipping the mode swaps the entire home content (music vs video composables), which would destroy the toggle mid-animation and recreate it already settled — the slide would never be visible. So:

- The thumb animation lives in a `MusicVideoToggleState` remembered at `HomeScreen` level (outside the swap). Both top bars bind to the same instance and place the toggle at the identical corner position, so the thumb keeps sliding seamlessly across the swap and reads as one persistent element.
- The music/video content switch is now wrapped in an `AnimatedContent` fade + scale morph (spring scale-in via `fastSpatialSpec`), instead of cutting instantly — the page morphs underneath the moving thumb.

## The setting

- **New preference** `home_mode_toggle_enabled` in `ThemePreferences` (default **on**), exposed through `ThemeViewModel`.
- **Settings page**: "Home Screen Mode Toggle" switch row in the Content Mode section, right below the existing Content Mode segmented control, following the `ExpressiveTimedCommentsToggleItem` pattern (press-scale spring, icon chip, switch).
- **Onboarding**: a second `SettingSwitchRow` ("Home screen switch") on the Video mode page, so new users choose it up front.
- Turning it off hides the pill from both Home top bars; mode switching remains available via Settings.

## Files

- `ui/components/MusicVideoToggle.kt` (new): toggle composable + hoisted `MusicVideoToggleState`
- `ui/home/HomeScreen.kt`: `onVideoModeToggle`/`showModeToggle` params, hoisted state, `AnimatedContent` mode morph, toggle in `TopBarSection`
- `ui/video/VideoHomeContent.kt`: toggle in `VideoTopBarSection`
- `data/ThemePreferences.kt`, `ui/theme/ThemeViewModel.kt`: new persisted preference
- `ui/settings/SettingsScreen.kt`: `ExpressiveHomeModeToggleItem` in Content Mode section
- `ui/onboarding/OnboardingScreen.kt`: switch row on the Video mode page
- `MainActivity.kt`: threads the preference and callbacks to Home, Settings, and Onboarding

No changes to mode persistence behavior — the pill drives the same `ThemePreferences.videoMode` flow the Settings/onboarding toggles already use, so everything downstream (tabs, search, feeds) reacts as before.

Verification: reviewed against material3 1.5.0-alpha13 APIs; CI `assembleDebug`/`assembleRelease` will compile-check and produce APKs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzU43taFTP3cBEmKuh1BrK