### PR TITLE
Add AMOLED Black theme setting with pure black dark backgrounds

### DIFF
--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -50,6 +50,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             val themeViewModel: ThemeViewModel = viewModel()
             val themeMode by themeViewModel.themeMode.collectAsState()
+            val amoledTheme by themeViewModel.amoledTheme.collectAsState()
             val loadLocalSongs by themeViewModel.loadLocalSongs.collectAsState()
             val ambientBackground by themeViewModel.ambientBackground.collectAsState()
             val videoMode by themeViewModel.videoMode.collectAsState()
@@ -79,11 +80,13 @@ class MainActivity : ComponentActivity() {
                 }
             }
             
-            IvorMusicTheme(darkTheme = isDarkTheme) {
+            IvorMusicTheme(darkTheme = isDarkTheme, amoledDark = amoledTheme) {
                 Box(modifier = Modifier.fillMaxSize()) {
                     MusicApp(
                         currentThemeMode = themeMode,
                         onThemeModeChange = { themeViewModel.setThemeMode(it) },
+                        amoledTheme = amoledTheme,
+                        onAmoledThemeToggle = { themeViewModel.setAmoledTheme(it) },
                         isDarkMode = isDarkTheme, // Derived for compatibility
                         onThemeToggle = { isDark ->
                             themeViewModel.setThemeMode(if (isDark) ThemeMode.DARK else ThemeMode.LIGHT)
@@ -136,6 +139,8 @@ class MainActivity : ComponentActivity() {
 fun MusicApp(
     currentThemeMode: ThemeMode,
     onThemeModeChange: (ThemeMode) -> Unit,
+    amoledTheme: Boolean,
+    onAmoledThemeToggle: (Boolean) -> Unit,
     isDarkMode: Boolean,
     onThemeToggle: (Boolean) -> Unit,
     loadLocalSongs: Boolean,
@@ -261,6 +266,8 @@ fun MusicApp(
                 com.ivor.ivormusic.ui.settings.SettingsScreen(
                     currentThemeMode = currentThemeMode,
                     onThemeModeChange = onThemeModeChange,
+                    amoledTheme = amoledTheme,
+                    onAmoledThemeToggle = onAmoledThemeToggle,
                     loadLocalSongs = loadLocalSongs,
                     onLoadLocalSongsToggle = onLoadLocalSongsToggle,
                     ambientBackground = ambientBackground,

--- a/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
@@ -19,6 +19,9 @@ class ThemePreferences(context: Context) {
     private val _themeMode = MutableStateFlow(getThemeModePreference())
     val themeMode: StateFlow<ThemeMode> = _themeMode.asStateFlow()
 
+    private val _amoledTheme = MutableStateFlow(getAmoledThemePreference())
+    val amoledTheme: StateFlow<Boolean> = _amoledTheme.asStateFlow()
+
     private val _loadLocalSongs = MutableStateFlow(getLoadLocalSongsPreference())
     val loadLocalSongs: StateFlow<Boolean> = _loadLocalSongs.asStateFlow()
     
@@ -77,6 +80,7 @@ class ThemePreferences(context: Context) {
         private const val PREFS_NAME = "ivor_music_theme_prefs"
         private const val KEY_THEME_MODE = "theme_mode_enum"
         private const val KEY_OLD_DARK_MODE = "dark_mode" // For migration
+        private const val KEY_AMOLED_THEME = "amoled_theme"
         private const val KEY_LOAD_LOCAL_SONGS = "load_local_songs"
         private const val KEY_AMBIENT_BACKGROUND = "ambient_background"
         private const val KEY_VIDEO_MODE = "video_mode"
@@ -174,6 +178,21 @@ class ThemePreferences(context: Context) {
         }
         
         return ThemeMode.SYSTEM
+    }
+
+    /**
+     * Get the stored AMOLED theme preference. Defaults to false.
+     */
+    private fun getAmoledThemePreference(): Boolean {
+        return prefs.getBoolean(KEY_AMOLED_THEME, false)
+    }
+
+    /**
+     * Save AMOLED theme preference and update the flow.
+     */
+    fun setAmoledTheme(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_AMOLED_THEME, enabled).apply()
+        _amoledTheme.value = enabled
     }
 
     /**

--- a/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
@@ -3874,6 +3874,208 @@ class YouTubeRepository(private val context: Context) {
         postWatchApi(endpoint, body) != null
     }
 
+    // ============================================================
+    // Playlist editing: playlist/create, playlist/delete and
+    // browse/edit_playlist. The same InnerTube write endpoints exist
+    // on both hosts — music=true goes through music.youtube.com
+    // (WEB_REMIX) so edits land in the YouTube Music library,
+    // music=false through www.youtube.com (WEB) for video playlists
+    // and Watch Later. These are the long-stable action-based writes
+    // (same family as like/subscribe above); responses are only
+    // checked for a STATUS_SUCCEEDED/playlistId, never deep-parsed.
+    // ============================================================
+
+    private fun musicContext(): org.json.JSONObject =
+        org.json.JSONObject().put(
+            "client",
+            org.json.JSONObject()
+                .put("clientName", "WEB_REMIX")
+                .put("clientVersion", WEB_REMIX_VERSION)
+                .put("hl", "en")
+                .put("gl", "US")
+        )
+
+    /**
+     * POST to an InnerTube endpoint on music.youtube.com with cookies and a
+     * music-origin SAPISIDHASH (the hash is per-origin — a www.youtube.com
+     * hash is rejected here). Returns the raw body or null on failure.
+     */
+    private fun postMusicApi(endpoint: String, body: org.json.JSONObject): String? {
+        val cookies = sessionManager.getCookies() ?: return null
+        val auth = YouTubeAuthUtils.getAuthorizationHeader(cookies, "https://music.youtube.com")
+            ?: return null
+        val request = okhttp3.Request.Builder()
+            .url("https://music.youtube.com/youtubei/v1/$endpoint?prettyPrint=false")
+            .post(body.toString().toRequestBody("application/json".toMediaType()))
+            .addHeader("Cookie", cookies)
+            .addHeader("Authorization", auth)
+            .addHeader("User-Agent", BROWSER_USER_AGENT)
+            .addHeader("Origin", "https://music.youtube.com")
+            .addHeader("X-Origin", "https://music.youtube.com")
+            .addHeader("X-Goog-AuthUser", "0")
+            .build()
+        return try {
+            okHttpClient.newCall(request).execute().use { response ->
+                if (response.isSuccessful) {
+                    response.body?.string()
+                } else {
+                    android.util.Log.w("YouTubeRepo", "music api $endpoint HTTP ${response.code}")
+                    null
+                }
+            }
+        } catch (e: Exception) {
+            android.util.Log.e("YouTubeRepo", "music api $endpoint failed", e)
+            null
+        }
+    }
+
+    private fun postPlaylistApi(music: Boolean, endpoint: String, body: org.json.JSONObject): String? =
+        if (music) postMusicApi(endpoint, body) else postWatchApi(endpoint, body)
+
+    private fun playlistContext(music: Boolean): org.json.JSONObject =
+        if (music) musicContext() else webContext()
+
+    /** Playlist ids sometimes carry the VL browse prefix — edit calls need it stripped. */
+    private fun normalizePlaylistId(playlistId: String): String = playlistId.removePrefix("VL")
+
+    /** edit_playlist responses report success in a top-level status field. */
+    private fun editStatusOk(raw: String?): Boolean {
+        if (raw == null) return false
+        return try {
+            org.json.JSONObject(raw).optString("status") == "STATUS_SUCCEEDED"
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    /**
+     * Create a playlist, optionally with initial videos. Returns the new
+     * playlist id or null. Requires login.
+     */
+    suspend fun createYouTubePlaylist(
+        title: String,
+        music: Boolean,
+        videoIds: List<String> = emptyList()
+    ): String? = withContext(Dispatchers.IO) {
+        if (!sessionManager.isLoggedIn()) return@withContext null
+        val body = org.json.JSONObject()
+            .put("context", playlistContext(music))
+            .put("title", title)
+        if (videoIds.isNotEmpty()) {
+            body.put("videoIds", org.json.JSONArray(videoIds))
+        }
+        val raw = postPlaylistApi(music, "playlist/create", body) ?: return@withContext null
+        try {
+            org.json.JSONObject(raw).optString("playlistId").takeIf { it.isNotBlank() }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Delete a playlist. playlist/delete only works on playlists the user
+     * owns; for saved (someone else's) playlists it fails, so fall back to
+     * removing the playlist from the library instead. Requires login.
+     */
+    suspend fun deleteYouTubePlaylist(playlistId: String, music: Boolean): Boolean =
+        withContext(Dispatchers.IO) {
+            if (!sessionManager.isLoggedIn()) return@withContext false
+            val id = normalizePlaylistId(playlistId)
+            val body = org.json.JSONObject()
+                .put("context", playlistContext(music))
+                .put("playlistId", id)
+            if (postPlaylistApi(music, "playlist/delete", body) != null) return@withContext true
+            val unlikeBody = org.json.JSONObject()
+                .put("context", playlistContext(music))
+                .put("target", org.json.JSONObject().put("playlistId", id))
+            postPlaylistApi(music, "like/removelike", unlikeBody) != null
+        }
+
+    /**
+     * Rename a playlist (and optionally replace its description). Only works
+     * on playlists the user owns. Requires login.
+     */
+    suspend fun renameYouTubePlaylist(
+        playlistId: String,
+        title: String,
+        music: Boolean,
+        description: String? = null
+    ): Boolean = withContext(Dispatchers.IO) {
+        if (!sessionManager.isLoggedIn()) return@withContext false
+        val actions = org.json.JSONArray().put(
+            org.json.JSONObject()
+                .put("action", "ACTION_SET_PLAYLIST_NAME")
+                .put("playlistName", title)
+        )
+        if (description != null) {
+            actions.put(
+                org.json.JSONObject()
+                    .put("action", "ACTION_SET_PLAYLIST_DESCRIPTION")
+                    .put("playlistDescription", description)
+            )
+        }
+        val body = org.json.JSONObject()
+            .put("context", playlistContext(music))
+            .put("playlistId", normalizePlaylistId(playlistId))
+            .put("actions", actions)
+        editStatusOk(postPlaylistApi(music, "browse/edit_playlist", body))
+    }
+
+    /**
+     * Add a video/song to a playlist ("WL" adds to Watch Later). Requires login.
+     */
+    suspend fun addToYouTubePlaylist(
+        playlistId: String,
+        videoId: String,
+        music: Boolean
+    ): Boolean = withContext(Dispatchers.IO) {
+        if (!sessionManager.isLoggedIn()) return@withContext false
+        val body = org.json.JSONObject()
+            .put("context", playlistContext(music))
+            .put("playlistId", normalizePlaylistId(playlistId))
+            .put(
+                "actions",
+                org.json.JSONArray().put(
+                    org.json.JSONObject()
+                        .put("action", "ACTION_ADD_VIDEO")
+                        .put("addedVideoId", videoId)
+                )
+            )
+        editStatusOk(postPlaylistApi(music, "browse/edit_playlist", body))
+    }
+
+    /**
+     * Remove a video/song from a playlist. Works for Watch Later ("WL");
+     * the liked lists ("LL" videos, "LM" music) are not editable playlists —
+     * removing from them means removing the like. Requires login.
+     */
+    suspend fun removeFromYouTubePlaylist(
+        playlistId: String,
+        videoId: String,
+        music: Boolean
+    ): Boolean = withContext(Dispatchers.IO) {
+        if (!sessionManager.isLoggedIn()) return@withContext false
+        val id = normalizePlaylistId(playlistId)
+        if (id == "LL" || id == "LM") {
+            val body = org.json.JSONObject()
+                .put("context", playlistContext(music))
+                .put("target", org.json.JSONObject().put("videoId", videoId))
+            return@withContext postPlaylistApi(music, "like/removelike", body) != null
+        }
+        val body = org.json.JSONObject()
+            .put("context", playlistContext(music))
+            .put("playlistId", id)
+            .put(
+                "actions",
+                org.json.JSONArray().put(
+                    org.json.JSONObject()
+                        .put("action", "ACTION_REMOVE_VIDEO_BY_VIDEO_ID")
+                        .put("removedVideoId", videoId)
+                )
+            )
+        editStatusOk(postPlaylistApi(music, "browse/edit_playlist", body))
+    }
+
     /**
      * Post a new top-level comment. createCommentParams comes from the first
      * comments page (CommentsPage.createCommentParams). Returns the created

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
@@ -232,6 +232,42 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    /** Create a new YouTube playlist from the video Library tab. Requires login. */
+    fun createVideoPlaylist(name: String) {
+        val trimmed = name.trim()
+        if (trimmed.isEmpty()) return
+        viewModelScope.launch {
+            if (youtubeRepository.createYouTubePlaylist(trimmed, music = false) != null) {
+                loadVideoPlaylists(force = true)
+            }
+        }
+    }
+
+    /** Delete a YouTube playlist. Optimistic removal, restored on failure. */
+    fun deleteVideoPlaylist(playlistId: String) {
+        val previous = _videoPlaylists.value
+        _videoPlaylists.value = previous.filterNot { it.playlistId == playlistId }
+        viewModelScope.launch {
+            if (!youtubeRepository.deleteYouTubePlaylist(playlistId, music = false)) {
+                _videoPlaylists.value = previous
+            }
+        }
+    }
+
+    /**
+     * Remove a video from a playlist, Watch Later ("WL") or Liked videos
+     * ("LL", removes the like). Optimistic removal, restored on failure.
+     */
+    fun removePlaylistVideo(playlistId: String, video: VideoItem) {
+        val previous = _playlistVideos.value
+        _playlistVideos.value = previous.filterNot { it.videoId == video.videoId }
+        viewModelScope.launch {
+            if (!youtubeRepository.removeFromYouTubePlaylist(playlistId, video.videoId, music = false)) {
+                _playlistVideos.value = previous
+            }
+        }
+    }
+
     /** Load the notification inbox. Requires login. */
     fun loadNotifications(force: Boolean = false) {
         if (_isNotificationsLoading.value) return
@@ -592,6 +628,42 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     fun replaceLocalPlaylistSongs(playlistId: String, songs: List<Song>) {
         viewModelScope.launch {
             playlistRepository.replacePlaylistSongs(playlistId, songs)
+        }
+    }
+
+    // --- YouTube Music playlist editing (music.youtube.com side) ---
+
+    /** Rename a YouTube Music playlist; the local list entry updates on success. */
+    fun renameYouTubePlaylist(playlistId: String, name: String, description: String?) {
+        val trimmed = name.trim()
+        if (trimmed.isEmpty()) return
+        viewModelScope.launch {
+            val ok = youtubeRepository.renameYouTubePlaylist(
+                playlistId, trimmed, music = true, description = description
+            )
+            if (ok) {
+                _youtubePlaylists.value = _youtubePlaylists.value.map {
+                    if (it.id == playlistId) it.copy(name = trimmed, description = description) else it
+                }
+            }
+        }
+    }
+
+    /** Delete a YouTube Music playlist. Optimistic removal, restored on failure. */
+    fun deleteYouTubePlaylist(playlistId: String) {
+        val previous = _youtubePlaylists.value
+        _youtubePlaylists.value = previous.filterNot { it.id == playlistId }
+        viewModelScope.launch {
+            if (!youtubeRepository.deleteYouTubePlaylist(playlistId, music = true)) {
+                _youtubePlaylists.value = previous
+            }
+        }
+    }
+
+    /** Remove a song from a YouTube Music playlist ("LM" removes the like). */
+    fun removeSongFromYouTubePlaylist(playlistId: String, song: Song) {
+        viewModelScope.launch {
+            youtubeRepository.removeFromYouTubePlaylist(playlistId, song.id, music = true)
         }
     }
 

--- a/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
@@ -393,10 +393,18 @@ fun LibraryMainScreen(
                             likedSongs = likedSongs,
                             onPlaylistClick = onNavigateToPlaylist,
                             onEditPlaylist = { playlist, newName, newDescription ->
-                                viewModel.updateLocalPlaylist(playlist.id, newName, newDescription)
+                                if (localPlaylistIds.contains(playlist.id)) {
+                                    viewModel.updateLocalPlaylist(playlist.id, newName, newDescription)
+                                } else {
+                                    viewModel.renameYouTubePlaylist(playlist.id, newName, newDescription)
+                                }
                             },
                             onDeletePlaylist = { playlist ->
-                                viewModel.deleteLocalPlaylist(playlist.id)
+                                if (localPlaylistIds.contains(playlist.id)) {
+                                    viewModel.deleteLocalPlaylist(playlist.id)
+                                } else {
+                                    viewModel.deleteYouTubePlaylist(playlist.id)
+                                }
                             },
                             onLikedSongsClick = {
                                 onNavigateToPlaylist(PlaylistDisplayItem("Liked Songs", "LM", "You", likedSongs.size, null))
@@ -769,13 +777,17 @@ fun PlaylistsGrid(
         }
         items(playlists) { playlist ->
             val isLocalPlaylist = localPlaylistIds.contains(playlist.id)
+            // YouTube playlists are editable through InnerTube; the synthesized
+            // Supermix ("RTM") and Your Likes ("LM") entries are not real playlists
+            val isYouTubeEditable = !isLocalPlaylist &&
+                playlist.id != "RTM" && playlist.id != "LM"
             ExpressivePlaylistCard(
                 name = playlist.name ?: "Untitled",
                 count = playlist.itemCount,
                 subtitle = if (playlist.itemCount < 0) playlist.uploaderName.ifBlank { "Playlist" } else null,
                 thumbnailUrl = playlist.thumbnailUrl,
                 description = playlist.description,
-                isEditable = isLocalPlaylist,
+                isEditable = isLocalPlaylist || isYouTubeEditable,
                 onEditConfirmed = { name, description -> onEditPlaylist(playlist, name, description) },
                 onDeleteConfirmed = { onDeletePlaylist(playlist) },
                 onClick = { onPlaylistClick(playlist) }
@@ -1031,7 +1043,7 @@ fun ExpressivePlaylistCard(
         AlertDialog(
             onDismissRequest = { showDeleteDialog = false },
             title = { Text("Delete playlist?") },
-            text = { Text("This will permanently remove \"$name\" and its local metadata.") },
+            text = { Text("This will permanently remove \"$name\".") },
             confirmButton = {
                 TextButton(onClick = {
                     onDeleteConfirmed()
@@ -1290,6 +1302,13 @@ fun PlaylistDetailScreen(
     val isLocalPlaylist = remember(playlist.id, localPlaylistIds, isAlbum) {
         !isAlbum && localPlaylistIds.contains(playlist.id)
     }
+    // YouTube playlists can be edited through InnerTube. "LM" (Your Likes) only
+    // supports song removal (= removing the like), not rename/delete, and the
+    // synthesized Supermix ("RTM") and radio mixes are not editable at all.
+    val isYouTubePlaylist = !isAlbum && !isLocalPlaylist
+    val canEditYouTubeSongs = isYouTubePlaylist &&
+        (playlist.id.startsWith("PL") || playlist.id == "LM")
+    val canRenameDeleteYouTube = isYouTubePlaylist && playlist.id.startsWith("PL")
     var songs by remember { mutableStateOf(preloadedSongs ?: emptyList()) }
     val isLoading by viewModel.isLoading.collectAsState()
     val isFetching = remember { mutableStateOf(songs.isEmpty()) }
@@ -1356,7 +1375,7 @@ fun PlaylistDetailScreen(
                     }
                 },
                 actions = {
-                    if (isLocalPlaylist) {
+                    if (isLocalPlaylist || canEditYouTubeSongs) {
                         IconButton(
                             onClick = {
                                 val enablingReorder = !isReorderMode
@@ -1375,9 +1394,11 @@ fun PlaylistDetailScreen(
                         ) {
                             Icon(
                                 imageVector = if (isReorderMode) Icons.Rounded.Done else Icons.Rounded.DragHandle,
-                                contentDescription = if (isReorderMode) "Finish reordering" else "Reorder playlist"
+                                contentDescription = if (isReorderMode) "Finish editing" else "Edit songs"
                             )
                         }
+                    }
+                    if (isLocalPlaylist || canRenameDeleteYouTube) {
                         IconButton(onClick = { showEditDialog = true }) {
                             Icon(Icons.Rounded.Edit, contentDescription = "Rename playlist")
                         }
@@ -1580,12 +1601,17 @@ fun PlaylistDetailScreen(
                         items = filteredSongs,
                         key = { _, song -> "playlist_${resolvedPlaylist.id}_${song.id}" }
                     ) { index, song ->
-                        val reorderEnabled = isLocalPlaylist && isReorderMode && searchQuery.isBlank()
+                        // Manage mode: song removal for local and YouTube playlists;
+                        // drag reordering stays local-only (InnerTube move needs
+                        // setVideoIds the parser does not keep).
+                        val manageEnabled = isReorderMode && searchQuery.isBlank() &&
+                            (isLocalPlaylist || canEditYouTubeSongs)
+                        val reorderEnabled = manageEnabled && isLocalPlaylist
                         val isDragging = draggingSongId == song.id
                         val animatedContainerColor by animateColorAsState(
                             targetValue = when {
                                 isDragging -> MaterialTheme.colorScheme.primaryContainer
-                                reorderEnabled -> MaterialTheme.colorScheme.surfaceContainerLow
+                                manageEnabled -> MaterialTheme.colorScheme.surfaceContainerLow
                                 else -> Color.Transparent
                             },
                             animationSpec = spring(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessMediumLow),
@@ -1594,7 +1620,7 @@ fun PlaylistDetailScreen(
                         val animatedTonalElevation by animateDpAsState(
                             targetValue = when {
                                 isDragging -> 8.dp
-                                reorderEnabled -> 2.dp
+                                manageEnabled -> 2.dp
                                 else -> 0.dp
                             },
                             animationSpec = spring(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessMediumLow),
@@ -1610,7 +1636,7 @@ fun PlaylistDetailScreen(
                             song = song,
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(horizontal = 12.dp, vertical = if (reorderEnabled) 4.dp else 0.dp)
+                                .padding(horizontal = 12.dp, vertical = if (manageEnabled) 4.dp else 0.dp)
                                 .then(if (isDragging) Modifier else Modifier.animateItem())
                                 .zIndex(if (isDragging) 2f else 0f)
                                 .offset(y = if (isDragging) with(density) { dragOffsetY.toDp() } else 0.dp)
@@ -1673,8 +1699,8 @@ fun PlaylistDetailScreen(
                             containerColor = animatedContainerColor,
                             tonalElevation = animatedTonalElevation,
                             shadowElevation = animatedShadowElevation,
-                            shape = if (reorderEnabled) RoundedCornerShape(24.dp) else RoundedCornerShape(0.dp),
-                            trailingContent = if (reorderEnabled) {
+                            shape = if (manageEnabled) RoundedCornerShape(24.dp) else RoundedCornerShape(0.dp),
+                            trailingContent = if (manageEnabled) {
                                 {
                                     Row(
                                         verticalAlignment = Alignment.CenterVertically,
@@ -1687,8 +1713,12 @@ fun PlaylistDetailScreen(
                                                 songs = songs.toMutableList().apply {
                                                     removeAll { it.id == song.id }
                                                 }
-                                                viewModel.replaceLocalPlaylistSongs(resolvedPlaylist.id, songs)
-                                                reorderDirty = false
+                                                if (isLocalPlaylist) {
+                                                    viewModel.replaceLocalPlaylistSongs(resolvedPlaylist.id, songs)
+                                                    reorderDirty = false
+                                                } else {
+                                                    viewModel.removeSongFromYouTubePlaylist(resolvedPlaylist.id, song)
+                                                }
                                             }
                                         ) {
                                             Icon(
@@ -1698,40 +1728,42 @@ fun PlaylistDetailScreen(
                                                 modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)
                                             )
                                         }
-                                        Column(
-                                            horizontalAlignment = Alignment.End,
-                                            verticalArrangement = Arrangement.spacedBy(6.dp)
-                                        ) {
-                                            Surface(
-                                                shape = RoundedCornerShape(14.dp),
-                                                color = if (isDragging) {
-                                                    MaterialTheme.colorScheme.tertiaryContainer
-                                                } else {
-                                                    MaterialTheme.colorScheme.surfaceContainerHighest
-                                                }
+                                        if (reorderEnabled) {
+                                            Column(
+                                                horizontalAlignment = Alignment.End,
+                                                verticalArrangement = Arrangement.spacedBy(6.dp)
                                             ) {
-                                                Icon(
-                                                    imageVector = Icons.Rounded.DragHandle,
-                                                    contentDescription = "Drag to reorder",
-                                                    tint = if (isDragging) {
-                                                        MaterialTheme.colorScheme.onTertiaryContainer
+                                                Surface(
+                                                    shape = RoundedCornerShape(14.dp),
+                                                    color = if (isDragging) {
+                                                        MaterialTheme.colorScheme.tertiaryContainer
                                                     } else {
-                                                        MaterialTheme.colorScheme.onSurfaceVariant
-                                                    },
-                                                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)
+                                                        MaterialTheme.colorScheme.surfaceContainerHighest
+                                                    }
+                                                ) {
+                                                    Icon(
+                                                        imageVector = Icons.Rounded.DragHandle,
+                                                        contentDescription = "Drag to reorder",
+                                                        tint = if (isDragging) {
+                                                            MaterialTheme.colorScheme.onTertiaryContainer
+                                                        } else {
+                                                            MaterialTheme.colorScheme.onSurfaceVariant
+                                                        },
+                                                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)
+                                                    )
+                                                }
+                                                Text(
+                                                    text = if (isDragging) "Moving" else "Hold",
+                                                    style = MaterialTheme.typography.labelSmall,
+                                                    color = MaterialTheme.colorScheme.onSurfaceVariant
                                                 )
                                             }
-                                            Text(
-                                                text = if (isDragging) "Moving" else "Hold",
-                                                style = MaterialTheme.typography.labelSmall,
-                                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                                            )
                                         }
                                     }
                                 }
                             } else null,
                             onClick = {
-                                if (!reorderEnabled) {
+                                if (!manageEnabled) {
                                     onPlayQueue(filteredSongs, song)
                                 }
                             }
@@ -1742,26 +1774,34 @@ fun PlaylistDetailScreen(
         }
     }
 
-    if (showEditDialog && isLocalPlaylist) {
+    if (showEditDialog && (isLocalPlaylist || canRenameDeleteYouTube)) {
         EditPlaylistDialog(
             initialName = resolvedPlaylist.name,
             initialDescription = resolvedPlaylist.description,
             onDismiss = { showEditDialog = false },
             onConfirm = { newName, newDescription ->
-                viewModel.updateLocalPlaylist(resolvedPlaylist.id, newName, newDescription)
+                if (isLocalPlaylist) {
+                    viewModel.updateLocalPlaylist(resolvedPlaylist.id, newName, newDescription)
+                } else {
+                    viewModel.renameYouTubePlaylist(resolvedPlaylist.id, newName, newDescription)
+                }
                 showEditDialog = false
             }
         )
     }
 
-    if (showDeleteDialog && isLocalPlaylist) {
+    if (showDeleteDialog && (isLocalPlaylist || canRenameDeleteYouTube)) {
         AlertDialog(
             onDismissRequest = { showDeleteDialog = false },
             title = { Text("Delete playlist?") },
-            text = { Text("This will permanently remove \"${resolvedPlaylist.name}\" and its local metadata.") },
+            text = { Text("This will permanently remove \"${resolvedPlaylist.name}\".") },
             confirmButton = {
                 TextButton(onClick = {
-                    viewModel.deleteLocalPlaylist(resolvedPlaylist.id)
+                    if (isLocalPlaylist) {
+                        viewModel.deleteLocalPlaylist(resolvedPlaylist.id)
+                    } else {
+                        viewModel.deleteYouTubePlaylist(resolvedPlaylist.id)
+                    }
                     showDeleteDialog = false
                     onBack()
                 }) {

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/GesturePlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/GesturePlayerContent.kt
@@ -99,7 +99,7 @@ fun GesturePlayerSheetContent(
     var showQueue by remember { mutableStateOf(false) }
     var showLyrics by remember { mutableStateOf(false) }
     var showAddToPlaylist by remember { mutableStateOf(false) }
-    val localPlaylists by viewModel.localPlaylists.collectAsState()
+    val addToPlaylistItems by viewModel.addToPlaylistItems.collectAsState()
 
     // Sleep timer
     val sleepTimerEndsAt by viewModel.sleepTimerEndsAt.collectAsState()
@@ -156,7 +156,10 @@ fun GesturePlayerSheetContent(
                     ambientBackground = ambientBackground,
                     onCollapse = onCollapse,
                     onShowQueue = { showQueue = true },
-                    onShowAddToPlaylist = { showAddToPlaylist = true }, // Pass callback
+                    onShowAddToPlaylist = {
+                        viewModel.loadYouTubePlaylistsForSheet()
+                        showAddToPlaylist = true
+                    },
                     onArtistClick = onArtistClick,
                     onToggleShuffle = { viewModel.toggleShuffle() },
                     onToggleRepeat = { viewModel.toggleRepeat() },
@@ -189,7 +192,7 @@ fun GesturePlayerSheetContent(
 
     if (showAddToPlaylist) {
         AddToPlaylistSheet(
-            playlists = localPlaylists,
+            playlists = addToPlaylistItems,
             onPlaylistClick = { playlist ->
                 viewModel.addToPlaylist(playlist.id)
                 showAddToPlaylist = false

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
@@ -92,7 +92,7 @@ fun PlayerSheetContent(
     
     var showQueue by remember { mutableStateOf(false) }
     var showAddToPlaylist by remember { mutableStateOf(false) }
-    val localPlaylists by viewModel.localPlaylists.collectAsState()
+    val addToPlaylistItems by viewModel.addToPlaylistItems.collectAsState()
 
     // 🌟 Stable shapes - prevents "square flash" on initial render
     // IconButtonDefaults.shapes() already uses internal remember/caching
@@ -160,7 +160,10 @@ fun PlayerSheetContent(
                     
                     onCollapse = onCollapse,
                     onShowQueue = { showQueue = true },
-                    onShowAddToPlaylist = { showAddToPlaylist = true },
+                    onShowAddToPlaylist = {
+                        viewModel.loadYouTubePlaylistsForSheet()
+                        showAddToPlaylist = true
+                    },
                     onArtistClick = onArtistClick,
                     viewModel = viewModel,
                     primaryColor = primaryColor,
@@ -177,7 +180,7 @@ fun PlayerSheetContent(
 
     if (showAddToPlaylist) {
         AddToPlaylistSheet(
-            playlists = localPlaylists,
+            playlists = addToPlaylistItems,
             onPlaylistClick = { playlist ->
                 viewModel.addToPlaylist(playlist.id)
                 showAddToPlaylist = false

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
@@ -108,13 +108,33 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
     
     // Playlist Repository (Local Playlists)
     private val playlistRepository = com.ivor.ivormusic.data.PlaylistRepository(context)
-    
-    // Expose only local playlists for "Add to Playlist" feature (since we can only write to local ones)
+
     private val _localPlaylists = playlistRepository.userPlaylists
-    val localPlaylists: StateFlow<List<com.ivor.ivormusic.data.PlaylistDisplayItem>> = 
+    val localPlaylists: StateFlow<List<com.ivor.ivormusic.data.PlaylistDisplayItem>> =
         _localPlaylists.map { list ->
             list.map { it.toDisplayItem() }
         }.stateIn(viewModelScope, kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000), emptyList())
+
+    // YouTube playlists songs can be added to (loaded on demand when the
+    // Add to Playlist sheet opens; only real "PL..." playlists are editable,
+    // not the synthesized Supermix/Likes entries)
+    private val _youtubeAddablePlaylists =
+        MutableStateFlow<List<com.ivor.ivormusic.data.PlaylistDisplayItem>>(emptyList())
+
+    /** Local playlists followed by editable YouTube playlists, for the Add to Playlist sheet. */
+    val addToPlaylistItems: StateFlow<List<com.ivor.ivormusic.data.PlaylistDisplayItem>> =
+        kotlinx.coroutines.flow.combine(localPlaylists, _youtubeAddablePlaylists) { local, youtube ->
+            local + youtube
+        }.stateIn(viewModelScope, kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000), emptyList())
+
+    /** Fetch the user's YouTube playlists for the Add to Playlist sheet (once per session). */
+    fun loadYouTubePlaylistsForSheet() {
+        if (_youtubeAddablePlaylists.value.isNotEmpty() || !youTubeRepository.isLoggedIn()) return
+        viewModelScope.launch {
+            _youtubeAddablePlaylists.value = youTubeRepository.getUserPlaylists()
+                .filter { it.id.startsWith("PL") }
+        }
+    }
         
     // Cache & Crossfade Settings exposed for UI
     private val themePreferences = com.ivor.ivormusic.data.ThemePreferences(context)
@@ -884,7 +904,13 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
     fun addToPlaylist(playlistId: String, song: Song? = _currentSong.value) {
         if (song == null) return
         viewModelScope.launch {
-            playlistRepository.addSongToPlaylist(playlistId, song)
+            val isLocal = playlistRepository.userPlaylists.value.any { it.id == playlistId }
+            if (isLocal) {
+                playlistRepository.addSongToPlaylist(playlistId, song)
+            } else if (song.source == com.ivor.ivormusic.data.SongSource.YOUTUBE) {
+                // YouTube playlist target: the song id is the videoId
+                youTubeRepository.addToYouTubePlaylist(playlistId, song.id, music = true)
+            }
         }
     }
     

--- a/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.ChevronRight
 import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Contrast
 import androidx.compose.material.icons.rounded.DarkMode
 import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.SystemUpdate
@@ -172,6 +173,8 @@ private class PolygonShape(private val polygon: RoundedPolygon) : Shape {
 fun SettingsScreen(
     currentThemeMode: ThemeMode,
     onThemeModeChange: (ThemeMode) -> Unit,
+    amoledTheme: Boolean,
+    onAmoledThemeToggle: (Boolean) -> Unit,
     loadLocalSongs: Boolean,
     onLoadLocalSongsToggle: (Boolean) -> Unit,
     ambientBackground: Boolean,
@@ -315,7 +318,18 @@ fun SettingsScreen(
                         )
                         
                         SettingsDivider()
-                        
+
+                        // AMOLED pure black toggle
+                        ExpressiveAmoledThemeToggleItem(
+                            enabled = amoledTheme,
+                            onToggle = onAmoledThemeToggle,
+                            textColor = textColor,
+                            secondaryTextColor = secondaryTextColor,
+                            accentColor = accentColor
+                        )
+
+                        SettingsDivider()
+
                         // Ambient Background toggle
                         ExpressiveAmbientBackgroundToggleItem(
                             enabled = ambientBackground,
@@ -1174,6 +1188,85 @@ private fun ExpressiveLocalSongsToggleItem(
 }
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun ExpressiveAmoledThemeToggleItem(
+    enabled: Boolean,
+    onToggle: (Boolean) -> Unit,
+    textColor: Color,
+    secondaryTextColor: Color,
+    accentColor: Color
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.97f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
+        label = "scale"
+    )
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .scale(scale)
+            .clip(RoundedCornerShape(18.dp))
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null
+            ) { onToggle(!enabled) }
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // Icon
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .clip(RoundedCornerShape(14.dp))
+                .background(accentColor.copy(alpha = 0.12f)),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.Contrast,
+                contentDescription = null,
+                tint = accentColor,
+                modifier = Modifier.size(26.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        // Text
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = "AMOLED Black",
+                color = textColor,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = if (enabled) "Pure black backgrounds in dark theme" else "Standard dark backgrounds",
+                color = secondaryTextColor,
+                fontSize = 13.sp
+            )
+        }
+
+        // Switch
+        Switch(
+            checked = enabled,
+            onCheckedChange = onToggle,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = Color.White,
+                checkedTrackColor = accentColor,
+                uncheckedThumbColor = Color.White,
+                uncheckedTrackColor = secondaryTextColor.copy(alpha = 0.3f),
+                uncheckedBorderColor = Color.Transparent,
+                checkedBorderColor = Color.Transparent
+            )
+        )
+    }
+}
+
 @Composable
 private fun ExpressiveAmbientBackgroundToggleItem(
     enabled: Boolean,

--- a/app/src/main/java/com/ivor/ivormusic/ui/theme/Theme.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/theme/Theme.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import androidx.annotation.ChecksSdkIntAtLeast
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialExpressiveTheme
 import androidx.compose.material3.MotionScheme
@@ -39,6 +40,22 @@ private val DarkColorScheme = darkColorScheme(
     onSurfaceVariant = TextSecondary
 )
 
+/**
+ * Pure black variant for AMOLED displays: background and base surface go to
+ * true #000000, and the surface container ramp is compressed toward black so
+ * cards keep a subtle elevation separation without the default grey wash.
+ */
+private fun ColorScheme.toAmoled(): ColorScheme = copy(
+    background = Color.Black,
+    surface = Color.Black,
+    surfaceDim = Color.Black,
+    surfaceContainerLowest = Color.Black,
+    surfaceContainerLow = Color(0xFF0A0A0A),
+    surfaceContainer = Color(0xFF101010),
+    surfaceContainerHigh = Color(0xFF181818),
+    surfaceContainerHighest = Color(0xFF202020)
+)
+
 // Expressive shapes with more rounded corners
 private val ExpressiveShapes = Shapes(
     extraSmall = RoundedCornerShape(8.dp),
@@ -53,9 +70,10 @@ private val ExpressiveShapes = Shapes(
 fun IvorMusicTheme(
     darkTheme: Boolean = true, // Default to dark theme for this music app
     dynamicColor: Boolean = true, // Enable dynamic color by default for expressive Material 3
+    amoledDark: Boolean = false, // Pure black backgrounds when dark theme is active
     content: @Composable () -> Unit
 ) {
-    val colorScheme = when {
+    val baseColorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             val context = LocalContext.current
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
@@ -63,6 +81,7 @@ fun IvorMusicTheme(
         darkTheme -> DarkColorScheme
         else -> expressiveLightColorScheme()
     }
+    val colorScheme = if (darkTheme && amoledDark) baseColorScheme.toAmoled() else baseColorScheme
     
     val view = LocalView.current
     if (!view.isInEditMode) {

--- a/app/src/main/java/com/ivor/ivormusic/ui/theme/ThemeViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/theme/ThemeViewModel.kt
@@ -16,6 +16,7 @@ class ThemeViewModel(application: Application) : AndroidViewModel(application) {
     private val themePreferences = ThemePreferences(application)
 
     val themeMode: StateFlow<ThemeMode> = themePreferences.themeMode
+    val amoledTheme: StateFlow<Boolean> = themePreferences.amoledTheme
     val loadLocalSongs: StateFlow<Boolean> = themePreferences.loadLocalSongs
     val ambientBackground: StateFlow<Boolean> = themePreferences.ambientBackground
     val videoMode: StateFlow<Boolean> = themePreferences.videoMode
@@ -42,6 +43,10 @@ class ThemeViewModel(application: Application) : AndroidViewModel(application) {
 
     fun setThemeMode(mode: ThemeMode) {
         themePreferences.setThemeMode(mode)
+    }
+
+    fun setAmoledTheme(enabled: Boolean) {
+        themePreferences.setAmoledTheme(enabled)
     }
 
     fun setLoadLocalSongs(load: Boolean) {

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoLibraryScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoLibraryScreen.kt
@@ -33,20 +33,27 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
+import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.ChevronRight
+import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.History
 import androidx.compose.material.icons.rounded.Login
+import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material.icons.rounded.ThumbUp
 import androidx.compose.material.icons.rounded.VideoLibrary
 import androidx.compose.material.icons.rounded.WatchLater
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -135,6 +142,8 @@ fun VideoLibraryContent(
                     viewModel.loadPlaylistVideos(playlist.playlistId)
                     page = LibraryPage.Playlist(playlist)
                 },
+                onCreatePlaylist = { name -> viewModel.createVideoPlaylist(name) },
+                onDeletePlaylist = { playlist -> viewModel.deleteVideoPlaylist(playlist.playlistId) },
                 onRefresh = {
                     viewModel.loadYouTubeHistory()
                     if (isYouTubeConnected) viewModel.loadVideoPlaylists(force = true)
@@ -179,9 +188,23 @@ private fun LibraryRoot(
     onLoginClick: () -> Unit,
     onOpenHistory: () -> Unit,
     onOpenPlaylist: (VideoPlaylist) -> Unit,
+    onCreatePlaylist: (String) -> Unit,
+    onDeletePlaylist: (VideoPlaylist) -> Unit,
     onRefresh: () -> Unit,
     contentPadding: PaddingValues
 ) {
+    var showCreateDialog by remember { mutableStateOf(false) }
+
+    if (showCreateDialog) {
+        CreateVideoPlaylistDialog(
+            onDismiss = { showCreateDialog = false },
+            onCreate = { name ->
+                onCreatePlaylist(name)
+                showCreateDialog = false
+            }
+        )
+    }
+
     ExpressivePullToRefresh(
         isRefreshing = isPlaylistsLoading,
         onRefresh = onRefresh,
@@ -275,7 +298,14 @@ private fun LibraryRoot(
 
             // Playlists
             item {
-                SectionHeader(title = "Your Playlists")
+                SectionHeader(
+                    title = "Your Playlists",
+                    actionLabel = if (isLoggedIn) "New" else null,
+                    actionIcon = Icons.Rounded.Add,
+                    onAction = if (isLoggedIn) {
+                        { showCreateDialog = true }
+                    } else null
+                )
             }
             if (!isLoggedIn) {
                 item { LibraryLoginCard(onLoginClick = onLoginClick) }
@@ -312,6 +342,7 @@ private fun LibraryRoot(
                     PlaylistRow(
                         playlist = playlist,
                         onClick = { onOpenPlaylist(playlist) },
+                        onDelete = { onDeletePlaylist(playlist) },
                         modifier = Modifier.padding(horizontal = 16.dp)
                     )
                 }
@@ -326,6 +357,7 @@ private fun LibraryRoot(
 private fun SectionHeader(
     title: String,
     actionLabel: String? = null,
+    actionIcon: ImageVector = Icons.Rounded.ChevronRight,
     onAction: (() -> Unit)? = null
 ) {
     Row(
@@ -345,13 +377,49 @@ private fun SectionHeader(
             TextButton(onClick = onAction) {
                 Text(actionLabel)
                 Icon(
-                    imageVector = Icons.Rounded.ChevronRight,
+                    imageVector = actionIcon,
                     contentDescription = null,
                     modifier = Modifier.size(18.dp)
                 )
             }
         }
     }
+}
+
+@Composable
+private fun CreateVideoPlaylistDialog(
+    onDismiss: () -> Unit,
+    onCreate: (String) -> Unit
+) {
+    var name by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("New playlist") },
+        text = {
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text("Name") },
+                singleLine = true,
+                shape = RoundedCornerShape(16.dp),
+                modifier = Modifier.fillMaxWidth()
+            )
+        },
+        confirmButton = {
+            Button(
+                onClick = { onCreate(name) },
+                enabled = name.isNotBlank()
+            ) {
+                Text("Create")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        }
+    )
 }
 
 @Composable
@@ -459,8 +527,31 @@ private fun HistoryPreviewCard(
 private fun PlaylistRow(
     playlist: VideoPlaylist,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onDelete: (() -> Unit)? = null
 ) {
+    var showMenu by remember { mutableStateOf(false) }
+    var showDeleteConfirm by remember { mutableStateOf(false) }
+
+    if (showDeleteConfirm) {
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirm = false },
+            title = { Text("Delete playlist?") },
+            text = { Text("This will permanently remove \"${playlist.title}\" from your YouTube account.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    showDeleteConfirm = false
+                    onDelete?.invoke()
+                }) {
+                    Text("Delete")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteConfirm = false }) { Text("Cancel") }
+            }
+        )
+    }
+
     Surface(
         modifier = modifier
             .fillMaxWidth()
@@ -539,11 +630,36 @@ private fun PlaylistRow(
                     )
                 }
             }
-            Icon(
-                imageVector = Icons.Rounded.ChevronRight,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+            if (onDelete != null) {
+                Box {
+                    IconButton(onClick = { showMenu = true }) {
+                        Icon(
+                            imageVector = Icons.Rounded.MoreVert,
+                            contentDescription = "Playlist options",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    DropdownMenu(
+                        expanded = showMenu,
+                        onDismissRequest = { showMenu = false }
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("Delete playlist") },
+                            onClick = {
+                                showMenu = false
+                                showDeleteConfirm = true
+                            },
+                            leadingIcon = { Icon(Icons.Rounded.Delete, contentDescription = null) }
+                        )
+                    }
+                }
+            } else {
+                Icon(
+                    imageVector = Icons.Rounded.ChevronRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
         }
     }
 }
@@ -667,6 +783,12 @@ private fun PlaylistDetail(
                     PlaylistVideoRow(
                         video = video,
                         onClick = { onVideoClick(video) },
+                        onRemove = { viewModel.removePlaylistVideo(playlist.playlistId, video) },
+                        removeLabel = when (playlist.playlistId) {
+                            "WL" -> "Remove from Watch Later"
+                            "LL" -> "Remove from Liked videos"
+                            else -> "Remove from playlist"
+                        },
                         modifier = Modifier.padding(horizontal = 16.dp)
                     )
                 }
@@ -680,8 +802,12 @@ private fun PlaylistDetail(
 private fun PlaylistVideoRow(
     video: VideoItem,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onRemove: (() -> Unit)? = null,
+    removeLabel: String = "Remove from playlist"
 ) {
+    var showMenu by remember { mutableStateOf(false) }
+
     Surface(
         modifier = modifier
             .fillMaxWidth()
@@ -753,6 +879,30 @@ private fun PlaylistVideoRow(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )
+                }
+            }
+            if (onRemove != null) {
+                Box {
+                    IconButton(onClick = { showMenu = true }) {
+                        Icon(
+                            imageVector = Icons.Rounded.MoreVert,
+                            contentDescription = "Video options",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    DropdownMenu(
+                        expanded = showMenu,
+                        onDismissRequest = { showMenu = false }
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text(removeLabel) },
+                            onClick = {
+                                showMenu = false
+                                onRemove()
+                            },
+                            leadingIcon = { Icon(Icons.Rounded.Delete, contentDescription = null) }
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
@@ -6,6 +6,8 @@ import androidx.annotation.OptIn
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
@@ -50,6 +52,7 @@ fun VideoPlayerContent(
     val relatedVideos by viewModel.relatedVideos.collectAsState()
     val isAutoPlayEnabled by viewModel.isAutoPlayEnabled.collectAsState()
     val isLooping by viewModel.isLooping.collectAsState()
+    val playbackSpeed by viewModel.playbackSpeed.collectAsState()
     val playbackError by viewModel.playbackError.collectAsState()
     val engagement by viewModel.engagement.collectAsState()
     val isLoggedIn by viewModel.isLoggedIn.collectAsState()
@@ -380,6 +383,45 @@ fun VideoPlayerContent(
                             colors = ListItemDefaults.colors(
                                 containerColor = Color.Transparent
                             )
+                        )
+                    }
+                }
+
+                HorizontalDivider(
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
+                    color = MaterialTheme.colorScheme.outlineVariant
+                )
+
+                Text(
+                    text = "Playback speed",
+                    style = MaterialTheme.typography.headlineSmall,
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(rememberScrollState())
+                        .padding(horizontal = 24.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    VideoPlayerViewModel.PLAYBACK_SPEED_OPTIONS.forEach { speed ->
+                        val label = if (speed == 1f) "Normal"
+                            else "${speed.toString().removeSuffix(".0")}x"
+                        FilterChip(
+                            selected = speed == playbackSpeed,
+                            onClick = { viewModel.setPlaybackSpeed(speed) },
+                            label = { Text(label) },
+                            leadingIcon = if (speed == playbackSpeed) {
+                                {
+                                    Icon(
+                                        Icons.Rounded.Check,
+                                        contentDescription = "Selected",
+                                        modifier = Modifier.size(FilterChipDefaults.IconSize)
+                                    )
+                                }
+                            } else null
                         )
                     }
                 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -1,6 +1,10 @@
 package com.ivor.ivormusic.ui.video
 
+import android.app.Activity
+import android.content.Context
+import android.media.AudioManager
 import android.view.ViewGroup
+import android.view.WindowManager
 import android.widget.FrameLayout
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Spring
@@ -10,6 +14,9 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.calculateZoom
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
@@ -36,9 +43,13 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.Comment
+import androidx.compose.material.icons.automirrored.rounded.VolumeOff
+import androidx.compose.material.icons.automirrored.rounded.VolumeUp
 import androidx.compose.material.icons.outlined.ThumbDown
 import androidx.compose.material.icons.outlined.ThumbUp
 import androidx.compose.material.icons.rounded.Autorenew
+import androidx.compose.material.icons.rounded.BrightnessHigh
+import androidx.compose.material.icons.rounded.BrightnessLow
 import androidx.compose.material.icons.rounded.Error
 import androidx.compose.material.icons.rounded.ExpandMore
 import androidx.compose.material.icons.rounded.Forward10
@@ -73,6 +84,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -84,6 +96,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChanged
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -94,8 +108,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 import coil.compose.AsyncImage
+import kotlin.math.abs
+import kotlin.math.roundToInt
 import com.ivor.ivormusic.data.LikeStatus
 import com.ivor.ivormusic.data.VideoEngagement
 import com.ivor.ivormusic.data.VideoItem
@@ -141,10 +158,15 @@ fun FullscreenPlayerContent(
     // Stable shapes to prevent "square flash"
     val stableShapes = IconButtonDefaults.shapes()
 
+    // Pinch-to-zoom: fill the screen (crop) vs fit inside it
+    var isZoomedToFill by remember { mutableStateOf(false) }
+
     PlayerGestureSurface(
         onToggleControls = onToggleControls,
         onSeekBackward = onSeekBackward,
-        onSeekForward = onSeekForward
+        onSeekForward = onSeekForward,
+        fullscreenGesturesEnabled = true,
+        onZoomedToFillChange = { isZoomedToFill = it }
     ) {
         // Video View
         AndroidView(
@@ -156,6 +178,13 @@ fun FullscreenPlayerContent(
                         ViewGroup.LayoutParams.MATCH_PARENT,
                         ViewGroup.LayoutParams.MATCH_PARENT
                     )
+                }
+            },
+            update = { playerView ->
+                playerView.resizeMode = if (isZoomedToFill) {
+                    AspectRatioFrameLayout.RESIZE_MODE_ZOOM
+                } else {
+                    AspectRatioFrameLayout.RESIZE_MODE_FIT
                 }
             },
             modifier = Modifier.fillMaxSize()
@@ -548,10 +577,24 @@ private fun PlayerSeekBar(
 /** Seconds jumped per double-tap on either edge of the video surface. */
 private const val DOUBLE_TAP_SEEK_SECONDS = 10
 
+/** Which level a vertical drag is adjusting, for the feedback overlay. */
+private enum class LevelAdjustment { Brightness, Volume }
+
+/** Accumulated pinch ratios beyond these thresholds toggle zoom-to-fill. */
+private const val PINCH_ZOOM_IN_THRESHOLD = 1.15f
+private const val PINCH_ZOOM_OUT_THRESHOLD = 0.87f
+
 /**
  * Wraps the video surface with tap gestures: single tap toggles the controls,
  * a double tap on the left rewinds and on the right fast-forwards (YouTube-style),
  * with an animated badge that accumulates when tapped repeatedly.
+ *
+ * With [fullscreenGesturesEnabled] it also recognizes, like most video players:
+ * - vertical drag on the left half = screen brightness (window-level override,
+ *   restored when the surface leaves composition);
+ * - vertical drag on the right half = media volume;
+ * - pinch open/closed = zoom the video to fill the screen / fit inside it,
+ *   reported through [onZoomedToFillChange].
  */
 @Composable
 private fun PlayerGestureSurface(
@@ -559,6 +602,8 @@ private fun PlayerGestureSurface(
     onSeekBackward: () -> Unit,
     onSeekForward: () -> Unit,
     modifier: Modifier = Modifier,
+    fullscreenGesturesEnabled: Boolean = false,
+    onZoomedToFillChange: (Boolean) -> Unit = {},
     content: @Composable BoxScope.() -> Unit
 ) {
     // side: -1 rewind, +1 forward, 0 hidden. seconds accumulates on rapid taps.
@@ -573,6 +618,35 @@ private fun PlayerGestureSurface(
             delay(650)
             side = 0
             seconds = 0
+        }
+    }
+
+    val context = LocalContext.current
+    val activity = context as? Activity
+    val audioManager = remember(context) {
+        context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    }
+
+    // Brightness/volume feedback overlay: which level is being adjusted and
+    // its current 0..1 value. adjustPulse restarts the auto-hide timer.
+    var adjustment by remember { mutableStateOf<LevelAdjustment?>(null) }
+    var adjustmentLevel by remember { mutableFloatStateOf(0f) }
+    var adjustPulse by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(adjustPulse) {
+        if (adjustment != null) {
+            delay(800)
+            adjustment = null
+        }
+    }
+
+    // The brightness gesture overrides the window brightness; hand control
+    // back to the system when the fullscreen surface goes away.
+    if (fullscreenGesturesEnabled) {
+        DisposableEffect(activity) {
+            onDispose {
+                activity?.let { setWindowBrightness(it, WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE) }
+            }
         }
     }
 
@@ -592,6 +666,68 @@ private fun PlayerGestureSurface(
                     }
                 )
             }
+            .then(
+                if (!fullscreenGesturesEnabled) Modifier
+                else Modifier.pointerInput(activity) {
+                    awaitEachGesture {
+                        val down = awaitFirstDown(requireUnconsumed = false)
+                        val leftSide = down.position.x < size.width / 2f
+                        // 0 = undecided, 1 = vertical level drag, 2 = pinch
+                        var mode = 0
+                        var accumulatedZoom = 1f
+                        var level = 0f
+                        while (true) {
+                            val event = awaitPointerEvent()
+                            val pressed = event.changes.filter { it.pressed }
+                            if (pressed.isEmpty()) break
+                            // A child (slider, button) claimed the gesture
+                            if (mode == 0 && event.changes.any { it.isConsumed }) break
+
+                            if (pressed.size > 1 && mode != 1) {
+                                mode = 2
+                                accumulatedZoom *= event.calculateZoom()
+                                if (accumulatedZoom > PINCH_ZOOM_IN_THRESHOLD) {
+                                    onZoomedToFillChange(true)
+                                } else if (accumulatedZoom < PINCH_ZOOM_OUT_THRESHOLD) {
+                                    onZoomedToFillChange(false)
+                                }
+                                event.changes.forEach { if (it.positionChanged()) it.consume() }
+                            } else if (pressed.size == 1 && mode != 2) {
+                                val change = pressed.first()
+                                if (mode == 0) {
+                                    val totalDx = change.position.x - down.position.x
+                                    val totalDy = change.position.y - down.position.y
+                                    if (abs(totalDy) > viewConfiguration.touchSlop &&
+                                        abs(totalDy) > abs(totalDx)
+                                    ) {
+                                        mode = 1
+                                        level = if (leftSide) {
+                                            activity?.let { currentWindowBrightness(it) } ?: 0.5f
+                                        } else {
+                                            currentVolumeFraction(audioManager)
+                                        }
+                                    }
+                                }
+                                if (mode == 1) {
+                                    val dy = change.position.y - change.previousPosition.y
+                                    // Dragging ~70% of the surface height sweeps the full range
+                                    level = (level - dy / (size.height * 0.7f)).coerceIn(0f, 1f)
+                                    if (leftSide) {
+                                        activity?.let { setWindowBrightness(it, level.coerceAtLeast(0.01f)) }
+                                        adjustment = LevelAdjustment.Brightness
+                                    } else {
+                                        setVolumeFraction(audioManager, level)
+                                        adjustment = LevelAdjustment.Volume
+                                    }
+                                    adjustmentLevel = level
+                                    adjustPulse++
+                                    change.consume()
+                                }
+                            }
+                        }
+                    }
+                }
+            )
     ) {
         content()
 
@@ -607,6 +743,96 @@ private fun PlayerGestureSurface(
             forward = true,
             modifier = Modifier.align(Alignment.CenterEnd)
         )
+
+        adjustment?.let { kind ->
+            LevelIndicator(
+                kind = kind,
+                level = adjustmentLevel,
+                modifier = Modifier
+                    .align(if (kind == LevelAdjustment.Brightness) Alignment.CenterStart else Alignment.CenterEnd)
+                    .padding(horizontal = 48.dp)
+            )
+        }
+    }
+}
+
+/** Vertical level bar + icon shown while a brightness/volume drag is active. */
+@Composable
+private fun LevelIndicator(
+    kind: LevelAdjustment,
+    level: Float,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = modifier
+            .clip(RoundedCornerShape(20.dp))
+            .background(Color.Black.copy(alpha = 0.55f))
+            .padding(horizontal = 14.dp, vertical = 18.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .width(6.dp)
+                .height(110.dp)
+                .clip(CircleShape)
+                .background(Color.White.copy(alpha = 0.3f)),
+            contentAlignment = Alignment.BottomCenter
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .fillMaxHeight(level.coerceIn(0f, 1f))
+                    .clip(CircleShape)
+                    .background(Color.White)
+            )
+        }
+        Icon(
+            imageVector = when {
+                kind == LevelAdjustment.Volume && level <= 0.001f -> Icons.AutoMirrored.Rounded.VolumeOff
+                kind == LevelAdjustment.Volume -> Icons.AutoMirrored.Rounded.VolumeUp
+                level < 0.3f -> Icons.Rounded.BrightnessLow
+                else -> Icons.Rounded.BrightnessHigh
+            },
+            contentDescription = null,
+            tint = Color.White,
+            modifier = Modifier.size(22.dp)
+        )
+    }
+}
+
+/** Current window brightness, falling back to the system setting when unset. */
+private fun currentWindowBrightness(activity: Activity): Float {
+    val fromWindow = activity.window.attributes.screenBrightness
+    if (fromWindow >= 0f) return fromWindow
+    return try {
+        android.provider.Settings.System.getInt(
+            activity.contentResolver,
+            android.provider.Settings.System.SCREEN_BRIGHTNESS
+        ) / 255f
+    } catch (e: Exception) {
+        0.5f
+    }
+}
+
+private fun setWindowBrightness(activity: Activity, value: Float) {
+    val window = activity.window
+    val attributes = window.attributes
+    attributes.screenBrightness = value
+    window.attributes = attributes
+}
+
+private fun currentVolumeFraction(audioManager: AudioManager): Float {
+    val max = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
+    if (max <= 0) return 0f
+    return audioManager.getStreamVolume(AudioManager.STREAM_MUSIC).toFloat() / max
+}
+
+private fun setVolumeFraction(audioManager: AudioManager, fraction: Float) {
+    val max = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
+    val target = (fraction * max).roundToInt().coerceIn(0, max)
+    if (target != audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)) {
+        audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, target, 0)
     }
 }
 

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
@@ -74,6 +74,9 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
     private val _isLooping = MutableStateFlow(false)
     val isLooping: StateFlow<Boolean> = _isLooping.asStateFlow()
 
+    private val _playbackSpeed = MutableStateFlow(1f)
+    val playbackSpeed: StateFlow<Float> = _playbackSpeed.asStateFlow()
+
     private var playbackReportJob: kotlinx.coroutines.Job? = null
 
     // Track quality change listener to prevent leaks
@@ -183,6 +186,12 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         _exoPlayer?.repeatMode = if (_isLooping.value) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
     }
 
+    /** Set the playback speed for the current video. Resets to 1x on video change. */
+    fun setPlaybackSpeed(speed: Float) {
+        _playbackSpeed.value = speed
+        _exoPlayer?.setPlaybackSpeed(speed)
+    }
+
     fun playVideo(video: VideoItem) {
         if (_currentVideo.value?.videoId == video.videoId) {
             // Already playing this video, just expand
@@ -205,6 +214,10 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         commentsLoadedForVideoId = null
         _createCommentParams.value = null
         _isLoggedIn.value = youtubeRepository.isLoggedIn()
+
+        // Speed is per-video, like YouTube
+        _playbackSpeed.value = 1f
+        _exoPlayer?.setPlaybackSpeed(1f)
 
         // ========== PHASE 1: START PLAYBACK ASAP (fast) ==========
         // Uses lightweight getVideoStreamQualities() which ONLY fetches stream URLs
@@ -645,6 +658,9 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
 
     companion object {
         private val TIMESTAMP_REGEX = Regex("""(?<!\d)(?:(\d{1,2}):)?(\d{1,2}):(\d{2})(?!\d)""")
+
+        /** Speeds offered in the player's speed menu. */
+        val PLAYBACK_SPEED_OPTIONS = listOf(0.25f, 0.5f, 0.75f, 1f, 1.25f, 1.5f, 1.75f, 2f)
     }
 
     override fun onCleared() {


### PR DESCRIPTION
Settings > Appearance gains an AMOLED Black toggle. When dark theme is
active it swaps the background and base surface to true #000000 and
compresses the surface container ramp toward black, so cards keep a
subtle elevation separation on OLED displays.

Closes #51

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Pfgypt14kotBvuYcUFeSuf