### PR TITLE
Six expressive player styles: Editorial, Poster, Bento, Sticker, Morph, Dial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ local.properties
 keystore/
 # Claude Code local artifacts
 .claude/
+
+# Kotlin build session data
+.kotlin/

--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -248,6 +248,7 @@ fun MusicApp(
                     onVideoModeToggle = onVideoModeToggle,
                     showModeToggle = homeModeToggleEnabled,
                     playerStyle = playerStyle,
+                    onPlayerStyleChange = onPlayerStyleChange,
                     manualScan = manualScanEnabled
                 )
             }

--- a/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
@@ -489,5 +489,7 @@ enum class PlayerStyle {
     /** Kinetic type player where the title itself is the progress display */
     POSTER,
     /** Squish grid of flat tonal tiles with press physics */
-    BENTO
+    BENTO,
+    /** Die-cut sticker with drag, peel and squash-and-stretch physics */
+    STICKER
 }

--- a/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
@@ -491,5 +491,7 @@ enum class PlayerStyle {
     /** Squish grid of flat tonal tiles with press physics */
     BENTO,
     /** Die-cut sticker with drag, peel and squash-and-stretch physics */
-    STICKER
+    STICKER,
+    /** Living hero shape that cycles organic cuts while playing */
+    MORPH
 }

--- a/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
@@ -487,5 +487,7 @@ enum class PlayerStyle {
     /** Two-tone magazine player with die-cut art and a word-pill transport */
     EDITORIAL,
     /** Kinetic type player where the title itself is the progress display */
-    POSTER
+    POSTER,
+    /** Squish grid of flat tonal tiles with press physics */
+    BENTO
 }

--- a/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
@@ -493,5 +493,7 @@ enum class PlayerStyle {
     /** Die-cut sticker with drag, peel and squash-and-stretch physics */
     STICKER,
     /** Living hero shape that cycles organic cuts while playing */
-    MORPH
+    MORPH,
+    /** Rotary instrument: a tick-ring dial spun to scrub */
+    DIAL
 }

--- a/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
@@ -483,5 +483,9 @@ enum class PlayerStyle {
     /** Classic button-based player with play/pause/next/previous controls */
     CLASSIC,
     /** Gesture-based carousel player with swipe navigation */
-    GESTURE
+    GESTURE,
+    /** Two-tone magazine player with die-cut art and a word-pill transport */
+    EDITORIAL,
+    /** Kinetic type player where the title itself is the progress display */
+    POSTER
 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeScreen.kt
@@ -151,6 +151,7 @@ fun HomeScreen(
     onVideoModeToggle: (Boolean) -> Unit = {},
     showModeToggle: Boolean = true,
     playerStyle: PlayerStyle = PlayerStyle.CLASSIC,
+    onPlayerStyleChange: (PlayerStyle) -> Unit = {},
     manualScan: Boolean = false
 ) {
     val context = androidx.compose.ui.platform.LocalContext.current
@@ -582,6 +583,7 @@ fun HomeScreen(
             viewModel = playerViewModel,
             ambientBackground = ambientBackground,
             playerStyle = playerStyle,
+            onPlayerStyleChange = onPlayerStyleChange,
             onArtistClick = { artistName ->
                 // Collapse player and navigate to Library tab to show artist
                 showPlayerSheet = false

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/BentoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/BentoPlayerContent.kt
@@ -1,0 +1,642 @@
+package com.ivor.ivormusic.ui.player
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Repeat
+import androidx.compose.material.icons.filled.RepeatOne
+import androidx.compose.material.icons.filled.Shuffle
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material.icons.rounded.Lyrics
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.PlaylistAdd
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialShapes
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.media3.common.Player
+import coil.compose.AsyncImage
+import com.ivor.ivormusic.ui.components.LikeBurstIcon
+
+/**
+ * Bento Player - the squish grid style.
+ *
+ * The whole screen is a bento box of flat tonal tiles with physical mass.
+ * Pure-flat contract: no gradients, no shadows, no scrims - hierarchy comes
+ * from the tonal surface ladder and tile size alone.
+ *
+ * Signature moves:
+ * - Transport tiles have press mass: the pressed tile expands while its
+ *   neighbors compress, springing back on release (the ButtonGroup squish
+ *   physics generalized to layout weights).
+ * - The art tile's corner radius slowly breathes while music plays and
+ *   settles when paused - the grid itself is the play state.
+ * - Progress is a hard-edged two-tone fill inside its own tile; the color
+ *   boundary is the playhead.
+ * - Checked toggles morph rounder and jump tonal color, never elevate.
+ *
+ * See docs/PLAYER_STYLES_PURE_EXPRESSIVE_CONCEPTS.md section 2.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun BentoPlayerSheetContent(
+    viewModel: PlayerViewModel,
+    ambientBackground: Boolean = true,
+    onCollapse: () -> Unit,
+    onLoadMore: () -> Unit = {},
+    onArtistClick: (String) -> Unit = {}
+) {
+    BackHandler(enabled = true) { onCollapse() }
+
+    val currentSong by viewModel.currentSong.collectAsState()
+    val isPlaying by viewModel.isPlaying.collectAsState()
+    val isBuffering by viewModel.isBuffering.collectAsState()
+    val playWhenReady by viewModel.playWhenReady.collectAsState()
+    val progress by viewModel.progress.collectAsState()
+    val duration by viewModel.duration.collectAsState()
+    val shuffleModeEnabled by viewModel.shuffleModeEnabled.collectAsState()
+    val repeatMode by viewModel.repeatMode.collectAsState()
+    val currentQueue by viewModel.currentQueue.collectAsState()
+    val isFavorite by viewModel.isCurrentSongLiked.collectAsState()
+    val lyricsResult by viewModel.lyricsResult.collectAsState()
+    val isLoadingMore by viewModel.isLoadingMore.collectAsState()
+    val localPlaylists by viewModel.localPlaylists.collectAsState()
+
+    var showQueue by remember { mutableStateOf(false) }
+    var showLyrics by remember { mutableStateOf(false) }
+    var showAddToPlaylist by remember { mutableStateOf(false) }
+
+    val boardColor = MaterialTheme.colorScheme.surfaceContainerLowest
+    val tileColor = MaterialTheme.colorScheme.surfaceContainerHigh
+    val onTile = MaterialTheme.colorScheme.onSurface
+    val onTileVariant = MaterialTheme.colorScheme.onSurfaceVariant
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(boardColor)
+    ) {
+        Crossfade(targetState = showQueue, label = "BentoQueueTransition") { queueVisible ->
+            if (queueVisible) {
+                EditorialQueueView(
+                    queue = currentQueue,
+                    currentSong = currentSong,
+                    onSongClick = { song -> viewModel.skipToSong(song) },
+                    onRemoveSong = { index -> viewModel.removeQueueItem(index) },
+                    onLoadMore = onLoadMore,
+                    isLoadingMore = isLoadingMore,
+                    onCollapse = onCollapse,
+                    onBackToPlayer = { showQueue = false },
+                    field = boardColor,
+                    accent = onTile
+                )
+            } else {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .statusBarsPadding()
+                        .padding(horizontal = 12.dp)
+                        .padding(top = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    // ========== TOP ROW ==========
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(56.dp),
+                        horizontalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        BentoTile(
+                            onClick = onCollapse,
+                            color = tileColor,
+                            contentColor = onTile,
+                            modifier = Modifier
+                                .width(56.dp)
+                                .fillMaxHeight()
+                        ) {
+                            Icon(
+                                Icons.Default.KeyboardArrowDown, "Collapse",
+                                modifier = Modifier.size(26.dp)
+                            )
+                        }
+                        Surface(
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxHeight(),
+                            shape = RoundedCornerShape(18.dp),
+                            color = tileColor,
+                            contentColor = onTileVariant
+                        ) {
+                            Box(contentAlignment = Alignment.Center) {
+                                Text(
+                                    text = "NOW PLAYING",
+                                    style = MaterialTheme.typography.labelLarge.copy(letterSpacing = 3.sp)
+                                )
+                            }
+                        }
+                        BentoTile(
+                            onClick = { showAddToPlaylist = true },
+                            color = tileColor,
+                            contentColor = onTile,
+                            modifier = Modifier
+                                .width(56.dp)
+                                .fillMaxHeight()
+                        ) {
+                            Icon(
+                                Icons.Rounded.PlaylistAdd, "Add to Playlist",
+                                modifier = Modifier.size(24.dp)
+                            )
+                        }
+                    }
+
+                    // ========== ART TILE (corner-breathing) ==========
+                    val infinite = rememberInfiniteTransition(label = "BentoBreath")
+                    val breathing by infinite.animateFloat(
+                        initialValue = 28f,
+                        targetValue = 52f,
+                        animationSpec = infiniteRepeatable(
+                            animation = tween(durationMillis = 2600, easing = FastOutSlowInEasing),
+                            repeatMode = RepeatMode.Reverse
+                        ),
+                        label = "BentoBreathValue"
+                    )
+                    // Spring chases a moving target while playing and a
+                    // fixed one while paused, so pause settles smoothly.
+                    val artCorner by animateFloatAsState(
+                        targetValue = if (isPlaying) breathing else 36f,
+                        animationSpec = spring(
+                            dampingRatio = Spring.DampingRatioNoBouncy,
+                            stiffness = Spring.StiffnessLow
+                        ),
+                        label = "BentoArtCorner"
+                    )
+
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f)
+                            .clip(RoundedCornerShape(artCorner.dp))
+                            .background(tileColor)
+                            .clickable { viewModel.togglePlayPause() }
+                    ) {
+                        Crossfade(targetState = showLyrics, label = "BentoArtLyrics") { lyricsVisible ->
+                            if (lyricsVisible) {
+                                Box(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+                                    SyncedLyricsView(
+                                        lyricsResult = lyricsResult,
+                                        currentPositionMs = progress,
+                                        onSeekTo = { viewModel.seekTo(it) },
+                                        ambientBackground = false,
+                                        primaryColor = MaterialTheme.colorScheme.primary,
+                                        onSurfaceColor = onTile,
+                                        onSurfaceVariantColor = onTileVariant
+                                    )
+                                }
+                            } else {
+                                val artModel = currentSong?.highResThumbnailUrl
+                                    ?: currentSong?.thumbnailUrl
+                                    ?: currentSong?.albumArtUri
+                                if (artModel != null) {
+                                    AsyncImage(
+                                        model = artModel,
+                                        contentDescription = "Album Art",
+                                        modifier = Modifier.fillMaxSize(),
+                                        contentScale = ContentScale.Crop
+                                    )
+                                } else {
+                                    Box(
+                                        modifier = Modifier.fillMaxSize(),
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Rounded.MusicNote,
+                                            contentDescription = null,
+                                            tint = onTileVariant.copy(alpha = 0.4f),
+                                            modifier = Modifier.size(96.dp)
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // ========== TITLE TILE ==========
+                    Surface(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(20.dp),
+                        color = tileColor
+                    ) {
+                        Column(modifier = Modifier.padding(horizontal = 18.dp, vertical = 12.dp)) {
+                            Text(
+                                text = currentSong?.title?.takeIf { !it.startsWith("Unknown") }
+                                    ?: "Untitled",
+                                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                                color = onTile,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            val artistName = currentSong?.artist?.takeIf { !it.startsWith("Unknown") }
+                                ?: "Unknown Artist"
+                            Text(
+                                text = artistName,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = onTileVariant,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier
+                                    .clip(RoundedCornerShape(6.dp))
+                                    .clickable(enabled = artistName != "Unknown Artist") {
+                                        onArtistClick(artistName)
+                                    }
+                            )
+                        }
+                    }
+
+                    // ========== PROGRESS TILE (hard two-tone fill) ==========
+                    BentoProgressTile(
+                        progress = progress,
+                        duration = duration,
+                        onSeekTo = { viewModel.seekTo(it) },
+                        trackColor = tileColor,
+                        fillColor = MaterialTheme.colorScheme.primaryContainer,
+                        onTile = onTile,
+                        onTileVariant = onTileVariant
+                    )
+
+                    // ========== TRANSPORT ROW (squish physics) ==========
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(84.dp),
+                        horizontalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        BentoSquishTile(
+                            baseWeight = 1f,
+                            onClick = { viewModel.skipToPrevious() },
+                            color = MaterialTheme.colorScheme.secondaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                        ) {
+                            Icon(
+                                Icons.Default.SkipPrevious, "Previous",
+                                modifier = Modifier.size(32.dp)
+                            )
+                        }
+                        BentoSquishTile(
+                            baseWeight = 1.6f,
+                            onClick = { viewModel.togglePlayPause() },
+                            color = MaterialTheme.colorScheme.primaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                        ) {
+                            if (isBuffering && playWhenReady && !isPlaying) {
+                                LoadingIndicator(
+                                    modifier = Modifier.size(36.dp),
+                                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                    polygons = listOf(
+                                        MaterialShapes.SoftBurst,
+                                        MaterialShapes.Cookie9Sided,
+                                        MaterialShapes.Pill,
+                                        MaterialShapes.Sunny
+                                    )
+                                )
+                            } else {
+                                Icon(
+                                    imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                                    contentDescription = if (isPlaying) "Pause" else "Play",
+                                    modifier = Modifier.size(40.dp)
+                                )
+                            }
+                        }
+                        BentoSquishTile(
+                            baseWeight = 1f,
+                            onClick = { viewModel.skipToNext() },
+                            color = MaterialTheme.colorScheme.secondaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                        ) {
+                            Icon(
+                                Icons.Default.SkipNext, "Next",
+                                modifier = Modifier.size(32.dp)
+                            )
+                        }
+                    }
+
+                    // ========== STATUS ROW ==========
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(56.dp),
+                        horizontalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        BentoToggleTile(
+                            checked = isFavorite,
+                            onClick = { viewModel.toggleCurrentSongLike() },
+                            uncheckedColor = tileColor,
+                            uncheckedContent = onTileVariant
+                        ) {
+                            LikeBurstIcon(isFavorite = isFavorite, iconSize = 22.dp)
+                        }
+                        BentoToggleTile(
+                            checked = shuffleModeEnabled,
+                            onClick = { viewModel.toggleShuffle() },
+                            uncheckedColor = tileColor,
+                            uncheckedContent = onTileVariant
+                        ) {
+                            Icon(Icons.Default.Shuffle, "Shuffle", modifier = Modifier.size(22.dp))
+                        }
+                        BentoToggleTile(
+                            checked = repeatMode != Player.REPEAT_MODE_OFF,
+                            onClick = { viewModel.toggleRepeat() },
+                            uncheckedColor = tileColor,
+                            uncheckedContent = onTileVariant
+                        ) {
+                            Icon(
+                                if (repeatMode == Player.REPEAT_MODE_ONE) Icons.Default.RepeatOne
+                                else Icons.Default.Repeat,
+                                "Repeat",
+                                modifier = Modifier.size(22.dp)
+                            )
+                        }
+                        BentoToggleTile(
+                            checked = showLyrics,
+                            onClick = { showLyrics = !showLyrics },
+                            uncheckedColor = tileColor,
+                            uncheckedContent = onTileVariant
+                        ) {
+                            Icon(Icons.Rounded.Lyrics, "Lyrics", modifier = Modifier.size(22.dp))
+                        }
+                        // Up-next peek tile: expands into the queue.
+                        Surface(
+                            onClick = { showQueue = true },
+                            modifier = Modifier
+                                .weight(2f)
+                                .fillMaxHeight(),
+                            shape = RoundedCornerShape(18.dp),
+                            color = tileColor,
+                            contentColor = onTileVariant
+                        ) {
+                            Row(
+                                modifier = Modifier.padding(horizontal = 14.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Icon(
+                                    Icons.AutoMirrored.Filled.QueueMusic,
+                                    contentDescription = "Queue",
+                                    modifier = Modifier.size(18.dp)
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                val nextTitle = remember(currentQueue, currentSong?.id) {
+                                    val index = currentQueue.indexOfFirst { it.id == currentSong?.id }
+                                    currentQueue.getOrNull(index + 1)?.title ?: "End of queue"
+                                }
+                                Text(
+                                    text = nextTitle,
+                                    style = MaterialTheme.typography.labelMedium,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                            }
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.navigationBarsPadding())
+                }
+            }
+        }
+    }
+
+    if (showAddToPlaylist) {
+        AddToPlaylistSheet(
+            playlists = localPlaylists,
+            onPlaylistClick = { playlist ->
+                viewModel.addToPlaylist(playlist.id)
+                showAddToPlaylist = false
+            },
+            onCreateNewClick = { name, desc ->
+                viewModel.createPlaylist(name, desc)
+                showAddToPlaylist = false
+            },
+            onDismissRequest = { showAddToPlaylist = false }
+        )
+    }
+}
+
+/** Plain flat tile with a click action. */
+@Composable
+private fun BentoTile(
+    onClick: () -> Unit,
+    color: Color,
+    contentColor: Color,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    Surface(
+        onClick = onClick,
+        modifier = modifier,
+        shape = RoundedCornerShape(18.dp),
+        color = color,
+        contentColor = contentColor
+    ) {
+        Box(contentAlignment = Alignment.Center) { content() }
+    }
+}
+
+/**
+ * Transport tile with press mass: while pressed its layout weight grows so
+ * neighbors physically compress, springing back on release.
+ */
+@Composable
+private fun androidx.compose.foundation.layout.RowScope.BentoSquishTile(
+    baseWeight: Float,
+    onClick: () -> Unit,
+    color: Color,
+    contentColor: Color,
+    content: @Composable () -> Unit
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val pressed by interaction.collectIsPressedAsState()
+    val weight by animateFloatAsState(
+        targetValue = if (pressed) baseWeight * 1.35f else baseWeight,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMedium
+        ),
+        label = "BentoSquish"
+    )
+    Surface(
+        onClick = onClick,
+        interactionSource = interaction,
+        modifier = Modifier
+            .weight(weight.coerceAtLeast(0.1f))
+            .fillMaxHeight(),
+        shape = RoundedCornerShape(24.dp),
+        color = color,
+        contentColor = contentColor
+    ) {
+        Box(contentAlignment = Alignment.Center) { content() }
+    }
+}
+
+/**
+ * Square toggle tile: checked state jumps to tertiaryContainer and morphs
+ * rounder - tonal color and corner radius carry the state, never elevation.
+ */
+@Composable
+private fun androidx.compose.foundation.layout.RowScope.BentoToggleTile(
+    checked: Boolean,
+    onClick: () -> Unit,
+    uncheckedColor: Color,
+    uncheckedContent: Color,
+    content: @Composable () -> Unit
+) {
+    val corner by animateDpAsState(
+        targetValue = if (checked) 26.dp else 16.dp,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMedium
+        ),
+        label = "BentoToggleCorner"
+    )
+    Surface(
+        onClick = onClick,
+        modifier = Modifier
+            .weight(1f)
+            .fillMaxHeight(),
+        shape = RoundedCornerShape(corner),
+        color = if (checked) MaterialTheme.colorScheme.tertiaryContainer else uncheckedColor,
+        contentColor = if (checked) MaterialTheme.colorScheme.onTertiaryContainer else uncheckedContent
+    ) {
+        Box(contentAlignment = Alignment.Center) { content() }
+    }
+}
+
+/**
+ * Progress as a tile: a hard-edged two-tone fill whose color boundary is
+ * the playhead. An invisible slider on top scrubs; one seek on release.
+ */
+@Composable
+private fun BentoProgressTile(
+    progress: Long,
+    duration: Long,
+    onSeekTo: (Long) -> Unit,
+    trackColor: Color,
+    fillColor: Color,
+    onTile: Color,
+    onTileVariant: Color
+) {
+    var scrubPosition by remember { mutableStateOf<Float?>(null) }
+    val displayedProgress = scrubPosition?.toLong() ?: progress
+    val fraction = if (duration > 0) {
+        (displayedProgress.toFloat() / duration.toFloat()).coerceIn(0f, 1f)
+    } else 0f
+    val animatedFraction by animateFloatAsState(
+        targetValue = fraction,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioNoBouncy,
+            stiffness = Spring.StiffnessLow
+        ),
+        label = "BentoProgressFill"
+    )
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(64.dp)
+            .clip(RoundedCornerShape(20.dp))
+            .background(trackColor)
+    ) {
+        if (animatedFraction > 0f) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(animatedFraction)
+                    .fillMaxHeight()
+                    .background(fillColor)
+            )
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = formatEditorialTime(displayedProgress),
+                style = MaterialTheme.typography.labelLarge,
+                color = onTile
+            )
+            Text(
+                text = formatEditorialTime(duration),
+                style = MaterialTheme.typography.labelLarge,
+                color = onTileVariant
+            )
+        }
+        Slider(
+            value = scrubPosition ?: progress.toFloat(),
+            onValueChange = { scrubPosition = it },
+            onValueChangeFinished = {
+                scrubPosition?.let { onSeekTo(it.toLong()) }
+                scrubPosition = null
+            },
+            valueRange = 0f..(duration.toFloat().coerceAtLeast(1f)),
+            colors = SliderDefaults.colors(
+                thumbColor = Color.Transparent,
+                activeTrackColor = Color.Transparent,
+                inactiveTrackColor = Color.Transparent
+            ),
+            modifier = Modifier.fillMaxSize()
+        )
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/BentoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/BentoPlayerContent.kt
@@ -14,6 +14,7 @@ import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
@@ -63,6 +64,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -98,7 +100,8 @@ fun BentoPlayerSheetContent(
     ambientBackground: Boolean = true,
     onCollapse: () -> Unit,
     onLoadMore: () -> Unit = {},
-    onArtistClick: (String) -> Unit = {}
+    onArtistClick: (String) -> Unit = {},
+    onRequestStyleSwitcher: () -> Unit = {}
 ) {
     BackHandler(enabled = true) { onCollapse() }
 
@@ -231,7 +234,12 @@ fun BentoPlayerSheetContent(
                             .weight(1f)
                             .clip(RoundedCornerShape(artCorner.dp))
                             .background(tileColor)
-                            .clickable { viewModel.togglePlayPause() }
+                            .pointerInput(Unit) {
+                                detectTapGestures(
+                                    onTap = { viewModel.togglePlayPause() },
+                                    onLongPress = { onRequestStyleSwitcher() }
+                                )
+                            }
                     ) {
                         Crossfade(targetState = showLyrics, label = "BentoArtLyrics") { lyricsVisible ->
                             if (lyricsVisible) {

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/DialPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/DialPlayerContent.kt
@@ -1,0 +1,570 @@
+package com.ivor.ivormusic.ui.player
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Repeat
+import androidx.compose.material.icons.filled.RepeatOne
+import androidx.compose.material.icons.filled.Shuffle
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material.icons.rounded.Lyrics
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.PlaylistAdd
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialShapes
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.graphics.shapes.Morph
+import androidx.media3.common.Player
+import coil.compose.AsyncImage
+import com.ivor.ivormusic.data.Song
+import com.ivor.ivormusic.ui.components.LikeBurstIcon
+import kotlin.math.abs
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * Dial Player - the rotary instrument style.
+ *
+ * Replaces the seek bar with a huge flat tick-ring dial. The ring spins
+ * one full revolution per track past a fixed needle at twelve o'clock,
+ * with played ticks filled solid and upcoming ticks hollow. Dragging
+ * around the ring physically rotates it to scrub, clicking a haptic
+ * detent every few ticks; one seek fires on release. Pure-flat: strokes,
+ * dots and flat fills only.
+ *
+ * The center puck is the album art die-cut per track; it morphs to a
+ * circle on pause, tap toggles playback and long-press opens the queue.
+ *
+ * See docs/PLAYER_STYLES_PURE_EXPRESSIVE_CONCEPTS.md section 3.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun DialPlayerSheetContent(
+    viewModel: PlayerViewModel,
+    ambientBackground: Boolean = true,
+    onCollapse: () -> Unit,
+    onLoadMore: () -> Unit = {},
+    onArtistClick: (String) -> Unit = {}
+) {
+    BackHandler(enabled = true) { onCollapse() }
+
+    val currentSong by viewModel.currentSong.collectAsState()
+    val isPlaying by viewModel.isPlaying.collectAsState()
+    val isBuffering by viewModel.isBuffering.collectAsState()
+    val playWhenReady by viewModel.playWhenReady.collectAsState()
+    val progress by viewModel.progress.collectAsState()
+    val duration by viewModel.duration.collectAsState()
+    val shuffleModeEnabled by viewModel.shuffleModeEnabled.collectAsState()
+    val repeatMode by viewModel.repeatMode.collectAsState()
+    val currentQueue by viewModel.currentQueue.collectAsState()
+    val isFavorite by viewModel.isCurrentSongLiked.collectAsState()
+    val lyricsResult by viewModel.lyricsResult.collectAsState()
+    val isLoadingMore by viewModel.isLoadingMore.collectAsState()
+    val localPlaylists by viewModel.localPlaylists.collectAsState()
+
+    var showQueue by remember { mutableStateOf(false) }
+    var showLyrics by remember { mutableStateOf(false) }
+    var showAddToPlaylist by remember { mutableStateOf(false) }
+
+    val field = MaterialTheme.colorScheme.surfaceContainerLowest
+    val ink = MaterialTheme.colorScheme.onSurface
+    val inkVariant = MaterialTheme.colorScheme.onSurfaceVariant
+    val accent = MaterialTheme.colorScheme.primary
+    val chipColor = MaterialTheme.colorScheme.surfaceContainerHigh
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(field)
+    ) {
+        Crossfade(targetState = showQueue, label = "DialQueueTransition") { queueVisible ->
+            if (queueVisible) {
+                EditorialQueueView(
+                    queue = currentQueue,
+                    currentSong = currentSong,
+                    onSongClick = { song -> viewModel.skipToSong(song) },
+                    onRemoveSong = { index -> viewModel.removeQueueItem(index) },
+                    onLoadMore = onLoadMore,
+                    isLoadingMore = isLoadingMore,
+                    onCollapse = onCollapse,
+                    onBackToPlayer = { showQueue = false },
+                    field = field,
+                    accent = ink
+                )
+            } else {
+                Column(modifier = Modifier.fillMaxSize()) {
+
+                    // ========== TOP BAR ==========
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .statusBarsPadding()
+                            .padding(horizontal = 20.dp, vertical = 12.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        EditorialCircleButton(
+                            onClick = onCollapse,
+                            accent = chipColor,
+                            field = ink,
+                            size = 44.dp
+                        ) {
+                            Icon(
+                                Icons.Default.KeyboardArrowDown, "Collapse",
+                                modifier = Modifier.size(26.dp)
+                            )
+                        }
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            EditorialCircleButton(
+                                onClick = { showAddToPlaylist = true },
+                                accent = chipColor,
+                                field = ink,
+                                size = 44.dp
+                            ) {
+                                Icon(
+                                    Icons.Rounded.PlaylistAdd, "Add to Playlist",
+                                    modifier = Modifier.size(22.dp)
+                                )
+                            }
+                            EditorialCircleButton(
+                                onClick = { showQueue = true },
+                                accent = chipColor,
+                                field = ink,
+                                size = 44.dp
+                            ) {
+                                Icon(
+                                    Icons.AutoMirrored.Filled.QueueMusic, "Queue",
+                                    modifier = Modifier.size(22.dp)
+                                )
+                            }
+                        }
+                    }
+
+                    // ========== THE DIAL / LYRICS ==========
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f)
+                    ) {
+                        Crossfade(targetState = showLyrics, label = "DialLyrics") { lyricsVisible ->
+                            if (lyricsVisible) {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .padding(horizontal = 24.dp)
+                                ) {
+                                    SyncedLyricsView(
+                                        lyricsResult = lyricsResult,
+                                        currentPositionMs = progress,
+                                        onSeekTo = { viewModel.seekTo(it) },
+                                        ambientBackground = false,
+                                        primaryColor = accent,
+                                        onSurfaceColor = ink,
+                                        onSurfaceVariantColor = inkVariant
+                                    )
+                                }
+                            } else {
+                                RotaryDial(
+                                    currentSong = currentSong,
+                                    isPlaying = isPlaying,
+                                    isBuffering = isBuffering && playWhenReady && !isPlaying,
+                                    progress = progress,
+                                    duration = duration,
+                                    onSeekTo = { viewModel.seekTo(it) },
+                                    onPlayPause = { viewModel.togglePlayPause() },
+                                    onLongPress = { showQueue = true }
+                                )
+                            }
+                        }
+                    }
+
+                    // ========== READOUT ==========
+                    Text(
+                        text = "${formatEditorialTime(progress)}  /  ${formatEditorialTime(duration)}",
+                        style = MaterialTheme.typography.titleMedium.copy(
+                            fontFamily = FontFamily.Monospace,
+                            letterSpacing = 2.sp
+                        ),
+                        color = ink,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+
+                    Spacer(modifier = Modifier.height(6.dp))
+
+                    // ========== TITLE / ARTIST ==========
+                    Text(
+                        text = currentSong?.title?.takeIf { !it.startsWith("Unknown") } ?: "Untitled",
+                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                        color = ink,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 24.dp)
+                    )
+                    val artistName = currentSong?.artist?.takeIf { !it.startsWith("Unknown") }
+                        ?: "Unknown Artist"
+                    Text(
+                        text = artistName,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = inkVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier
+                            .align(Alignment.CenterHorizontally)
+                            .clip(RoundedCornerShape(8.dp))
+                            .clickable(enabled = artistName != "Unknown Artist") {
+                                onArtistClick(artistName)
+                            }
+                            .padding(horizontal = 8.dp, vertical = 4.dp)
+                    )
+
+                    Spacer(modifier = Modifier.height(10.dp))
+
+                    // ========== CONTROLS ==========
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.CenterHorizontally),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        EditorialCircleButton(
+                            onClick = { viewModel.skipToPrevious() },
+                            accent = chipColor,
+                            field = ink,
+                            size = 56.dp
+                        ) {
+                            Icon(
+                                Icons.Default.SkipPrevious, "Previous",
+                                modifier = Modifier.size(28.dp)
+                            )
+                        }
+                        EditorialChip(
+                            checked = isFavorite,
+                            onClick = { viewModel.toggleCurrentSongLike() },
+                            accent = accent,
+                            field = MaterialTheme.colorScheme.onPrimary
+                        ) {
+                            LikeBurstIcon(isFavorite = isFavorite, iconSize = 20.dp)
+                        }
+                        EditorialChip(
+                            checked = shuffleModeEnabled,
+                            onClick = { viewModel.toggleShuffle() },
+                            accent = accent,
+                            field = MaterialTheme.colorScheme.onPrimary
+                        ) {
+                            Icon(Icons.Default.Shuffle, "Shuffle", modifier = Modifier.size(20.dp))
+                        }
+                        EditorialChip(
+                            checked = repeatMode != Player.REPEAT_MODE_OFF,
+                            onClick = { viewModel.toggleRepeat() },
+                            accent = accent,
+                            field = MaterialTheme.colorScheme.onPrimary
+                        ) {
+                            Icon(
+                                if (repeatMode == Player.REPEAT_MODE_ONE) Icons.Default.RepeatOne
+                                else Icons.Default.Repeat,
+                                "Repeat",
+                                modifier = Modifier.size(20.dp)
+                            )
+                        }
+                        EditorialChip(
+                            checked = showLyrics,
+                            onClick = { showLyrics = !showLyrics },
+                            accent = accent,
+                            field = MaterialTheme.colorScheme.onPrimary
+                        ) {
+                            Icon(Icons.Rounded.Lyrics, "Lyrics", modifier = Modifier.size(20.dp))
+                        }
+                        EditorialCircleButton(
+                            onClick = { viewModel.skipToNext() },
+                            accent = chipColor,
+                            field = ink,
+                            size = 56.dp
+                        ) {
+                            Icon(Icons.Default.SkipNext, "Next", modifier = Modifier.size(28.dp))
+                        }
+                    }
+
+                    Spacer(
+                        modifier = Modifier
+                            .navigationBarsPadding()
+                            .height(8.dp)
+                    )
+                }
+            }
+        }
+    }
+
+    if (showAddToPlaylist) {
+        AddToPlaylistSheet(
+            playlists = localPlaylists,
+            onPlaylistClick = { playlist ->
+                viewModel.addToPlaylist(playlist.id)
+                showAddToPlaylist = false
+            },
+            onCreateNewClick = { name, desc ->
+                viewModel.createPlaylist(name, desc)
+                showAddToPlaylist = false
+            },
+            onDismissRequest = { showAddToPlaylist = false }
+        )
+    }
+}
+
+/**
+ * The rotary dial: 60 flat ticks spinning past a fixed needle at twelve
+ * o'clock (one revolution per track), played ticks solid, upcoming hollow.
+ * Dragging anywhere on the ring rotates it 1:1 to scrub with a haptic
+ * click per detent; a single seek fires on release. The center puck is
+ * per-track die-cut art that morphs to a circle on pause.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun RotaryDial(
+    currentSong: Song?,
+    isPlaying: Boolean,
+    isBuffering: Boolean,
+    progress: Long,
+    duration: Long,
+    onSeekTo: (Long) -> Unit,
+    onPlayPause: () -> Unit,
+    onLongPress: () -> Unit
+) {
+    val tickColor = MaterialTheme.colorScheme.primary
+    val tickTrackColor = MaterialTheme.colorScheme.outlineVariant
+    val needleColor = MaterialTheme.colorScheme.onSurface
+
+    var scrubFraction by remember { mutableStateOf<Float?>(null) }
+    val liveProgress by rememberUpdatedState(progress)
+    val liveDuration by rememberUpdatedState(duration)
+    val displayedFraction = scrubFraction
+        ?: if (duration > 0) (progress.toFloat() / duration.toFloat()).coerceIn(0f, 1f) else 0f
+
+    val haptics = LocalHapticFeedback.current
+    val density = LocalDensity.current
+
+    // Puck: per-track die-cut while playing, circle at rest.
+    val dieCuts = remember {
+        listOf(
+            MaterialShapes.Sunny,
+            MaterialShapes.Cookie9Sided,
+            MaterialShapes.Clover4Leaf,
+            MaterialShapes.Cookie12Sided,
+            MaterialShapes.SoftBurst
+        )
+    }
+    val trackPolygon = remember(currentSong?.id) {
+        dieCuts[abs(currentSong?.id?.hashCode() ?: 0) % dieCuts.size]
+    }
+    val puckMorph = remember(trackPolygon) { Morph(MaterialShapes.Circle, trackPolygon) }
+    val puckProgress by animateFloatAsState(
+        targetValue = if (isPlaying) 1f else 0f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessLow
+        ),
+        label = "DialPuckMorph"
+    )
+    val puckShape = remember(puckMorph, puckProgress) {
+        EditorialMorphShape(puckMorph, puckProgress)
+    }
+
+    BoxWithConstraints(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        if (maxWidth < 50.dp || maxHeight < 50.dp) return@BoxWithConstraints
+        val dialSize = minOf(maxWidth, maxHeight) * 0.9f
+        val puckSize = dialSize * 0.44f
+        val tickWidthPx = with(density) { 4.dp.toPx() }
+        val filledTickWidthPx = with(density) { 6.dp.toPx() }
+        val needleWidthPx = with(density) { 6.dp.toPx() }
+
+        // Tick ring with rotary scrub input.
+        Canvas(
+            modifier = Modifier
+                .size(dialSize)
+                .pointerInput(Unit) {
+                    var previousAngle = 0f
+                    var lastDetent = -1
+                    detectDragGestures(
+                        onDragStart = { position ->
+                            val center = Offset(size.width / 2f, size.height / 2f)
+                            previousAngle = Math.toDegrees(
+                                atan2(
+                                    (position.y - center.y).toDouble(),
+                                    (position.x - center.x).toDouble()
+                                )
+                            ).toFloat()
+                            scrubFraction = if (liveDuration > 0) {
+                                (liveProgress.toFloat() / liveDuration.toFloat()).coerceIn(0f, 1f)
+                            } else 0f
+                            lastDetent = ((scrubFraction ?: 0f) * 60).toInt()
+                        },
+                        onDrag = { change, _ ->
+                            change.consume()
+                            val center = Offset(size.width / 2f, size.height / 2f)
+                            val angle = Math.toDegrees(
+                                atan2(
+                                    (change.position.y - center.y).toDouble(),
+                                    (change.position.x - center.x).toDouble()
+                                )
+                            ).toFloat()
+                            var delta = angle - previousAngle
+                            if (delta > 180f) delta -= 360f
+                            if (delta < -180f) delta += 360f
+                            previousAngle = angle
+                            val next = ((scrubFraction ?: 0f) + delta / 360f).coerceIn(0f, 1f)
+                            scrubFraction = next
+                            val detent = (next * 60).toInt()
+                            if (detent != lastDetent) {
+                                lastDetent = detent
+                                haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                            }
+                        },
+                        onDragEnd = {
+                            scrubFraction?.let { onSeekTo((it * liveDuration).toLong()) }
+                            scrubFraction = null
+                        },
+                        onDragCancel = { scrubFraction = null }
+                    )
+                }
+        ) {
+            val center = this.center
+            val outerRadius = size.minDimension / 2f - filledTickWidthPx
+            val innerRadius = outerRadius * 0.88f
+            val tickCount = 60
+            // The ring spins one revolution per track past the fixed
+            // needle; the filled arc always trails the twelve o'clock mark.
+            val rotation = -displayedFraction * 360f
+            val filledCount = (displayedFraction * tickCount).toInt()
+
+            for (i in 0 until tickCount) {
+                val filled = i < filledCount
+                val angleRad = Math.toRadians(
+                    (i * 360.0 / tickCount) - 90.0 + rotation
+                )
+                val cosA = cos(angleRad).toFloat()
+                val sinA = sin(angleRad).toFloat()
+                drawLine(
+                    color = if (filled) tickColor else tickTrackColor,
+                    start = Offset(center.x + cosA * innerRadius, center.y + sinA * innerRadius),
+                    end = Offset(center.x + cosA * outerRadius, center.y + sinA * outerRadius),
+                    strokeWidth = if (filled) filledTickWidthPx else tickWidthPx,
+                    cap = StrokeCap.Round
+                )
+            }
+
+            // Fixed needle at twelve o'clock.
+            drawLine(
+                color = needleColor,
+                start = Offset(center.x, center.y - outerRadius - filledTickWidthPx),
+                end = Offset(center.x, center.y - innerRadius + filledTickWidthPx),
+                strokeWidth = needleWidthPx,
+                cap = StrokeCap.Round
+            )
+        }
+
+        // Center puck.
+        Box(
+            modifier = Modifier
+                .size(puckSize)
+                .clip(puckShape)
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                .pointerInput(Unit) {
+                    detectTapGestures(
+                        onTap = { onPlayPause() },
+                        onLongPress = { onLongPress() }
+                    )
+                },
+            contentAlignment = Alignment.Center
+        ) {
+            val artModel = currentSong?.highResThumbnailUrl
+                ?: currentSong?.thumbnailUrl
+                ?: currentSong?.albumArtUri
+            if (artModel != null) {
+                AsyncImage(
+                    model = artModel,
+                    contentDescription = "Album Art",
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
+                )
+            } else {
+                Icon(
+                    imageVector = Icons.Rounded.MusicNote,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                    modifier = Modifier.size(puckSize * 0.35f)
+                )
+            }
+            if (isBuffering) {
+                LoadingIndicator(
+                    modifier = Modifier.size(36.dp),
+                    color = tickColor,
+                    polygons = listOf(
+                        MaterialShapes.SoftBurst,
+                        MaterialShapes.Cookie9Sided,
+                        MaterialShapes.Pill,
+                        MaterialShapes.Sunny
+                    )
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/DialPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/DialPlayerContent.kt
@@ -85,7 +85,8 @@ import kotlin.math.sin
  * dots and flat fills only.
  *
  * The center puck is the album art die-cut per track; it morphs to a
- * circle on pause, tap toggles playback and long-press opens the queue.
+ * circle on pause, tap toggles playback and long-press opens the style
+ * wheel (the queue lives behind its top-bar button).
  *
  * See docs/PLAYER_STYLES_PURE_EXPRESSIVE_CONCEPTS.md section 3.
  */
@@ -96,7 +97,8 @@ fun DialPlayerSheetContent(
     ambientBackground: Boolean = true,
     onCollapse: () -> Unit,
     onLoadMore: () -> Unit = {},
-    onArtistClick: (String) -> Unit = {}
+    onArtistClick: (String) -> Unit = {},
+    onRequestStyleSwitcher: () -> Unit = {}
 ) {
     BackHandler(enabled = true) { onCollapse() }
 
@@ -224,7 +226,7 @@ fun DialPlayerSheetContent(
                                     duration = duration,
                                     onSeekTo = { viewModel.seekTo(it) },
                                     onPlayPause = { viewModel.togglePlayPause() },
-                                    onLongPress = { showQueue = true }
+                                    onLongPress = onRequestStyleSwitcher
                                 )
                             }
                         }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/EditorialPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/EditorialPlayerContent.kt
@@ -947,6 +947,31 @@ internal class EditorialMorphShape(
     }
 }
 
+/**
+ * Shape backed by a single RoundedPolygon scaled to fill the composable
+ * bounds. Static sibling of EditorialMorphShape.
+ */
+internal class EditorialPolygonShape(
+    private val polygon: RoundedPolygon
+) : Shape {
+    override fun createOutline(
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density
+    ): Outline {
+        val path = polygon.toPath().asComposePath()
+        val matrix = Matrix()
+        val bounds = polygon.calculateBounds()
+        val boundsWidth = bounds[2] - bounds[0]
+        val boundsHeight = bounds[3] - bounds[1]
+
+        matrix.scale(size.width / boundsWidth, size.height / boundsHeight)
+        matrix.translate(-bounds[0], -bounds[1])
+        path.transform(matrix)
+        return Outline.Generic(path)
+    }
+}
+
 internal fun formatEditorialTime(durationMs: Long): String {
     val totalSeconds = durationMs / 1000
     val minutes = totalSeconds / 60

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/EditorialPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/EditorialPlayerContent.kt
@@ -1,0 +1,955 @@
+package com.ivor.ivormusic.ui.player
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Repeat
+import androidx.compose.material.icons.filled.RepeatOne
+import androidx.compose.material.icons.filled.Shuffle
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.Download
+import androidx.compose.material.icons.rounded.GraphicEq
+import androidx.compose.material.icons.rounded.Lyrics
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.PlaylistAdd
+import androidx.compose.material.icons.rounded.Smartphone
+import androidx.compose.material3.CircularWavyProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.LinearWavyProgressIndicator
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialShapes
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Matrix
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.asComposePath
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.graphics.shapes.Morph
+import androidx.graphics.shapes.RoundedPolygon
+import androidx.graphics.shapes.toPath
+import androidx.media3.common.Player
+import coil.compose.AsyncImage
+import com.ivor.ivormusic.data.LyricsResult
+import com.ivor.ivormusic.data.Song
+import com.ivor.ivormusic.ui.components.LikeBurstIcon
+import kotlin.math.abs
+
+/**
+ * Editorial Player - the two-tone magazine style.
+ *
+ * Modeled on Google's Material 3 Expressive announcement mock (the "Serafina"
+ * player screen). Pure-flat contract: no gradients, no shadows, no scrims.
+ * Exactly two colors plus the artwork - a flat field (primaryContainer) and
+ * one accent (onPrimaryContainer) carry every element. Hierarchy comes from
+ * size and shape only.
+ *
+ * Signature moves:
+ * - Album art die-cut into a per-track MaterialShapes polygon that morphs to
+ *   a new cut on every track change.
+ * - Display serif italic headline, re-typeset per track like a new spread.
+ * - PLAY/PAUSE word pill: the label is the icon.
+ * - Wavy-played / flat-remaining progress line whose wave settles on pause.
+ *
+ * See docs/PLAYER_STYLES_PURE_EXPRESSIVE_CONCEPTS.md section 5.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun EditorialPlayerSheetContent(
+    viewModel: PlayerViewModel,
+    ambientBackground: Boolean = true,
+    onCollapse: () -> Unit,
+    onLoadMore: () -> Unit = {},
+    onArtistClick: (String) -> Unit = {}
+) {
+    BackHandler(enabled = true) { onCollapse() }
+
+    val currentSong by viewModel.currentSong.collectAsState()
+    val isPlaying by viewModel.isPlaying.collectAsState()
+    val isBuffering by viewModel.isBuffering.collectAsState()
+    val playWhenReady by viewModel.playWhenReady.collectAsState()
+    val progress by viewModel.progress.collectAsState()
+    val duration by viewModel.duration.collectAsState()
+    val shuffleModeEnabled by viewModel.shuffleModeEnabled.collectAsState()
+    val repeatMode by viewModel.repeatMode.collectAsState()
+    val currentQueue by viewModel.currentQueue.collectAsState()
+    val isFavorite by viewModel.isCurrentSongLiked.collectAsState()
+    val lyricsResult by viewModel.lyricsResult.collectAsState()
+    val isLoadingMore by viewModel.isLoadingMore.collectAsState()
+    val localPlaylists by viewModel.localPlaylists.collectAsState()
+
+    var showQueue by remember { mutableStateOf(false) }
+    var showLyrics by remember { mutableStateOf(false) }
+    var showAddToPlaylist by remember { mutableStateOf(false) }
+
+    // The two-tone contract: field + accent, nothing else.
+    val field = MaterialTheme.colorScheme.primaryContainer
+    val accent = MaterialTheme.colorScheme.onPrimaryContainer
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(field)
+    ) {
+        Crossfade(targetState = showQueue, label = "EditorialQueueTransition") { queueVisible ->
+            if (queueVisible) {
+                EditorialQueueView(
+                    queue = currentQueue,
+                    currentSong = currentSong,
+                    onSongClick = { song -> viewModel.skipToSong(song) },
+                    onRemoveSong = { index -> viewModel.removeQueueItem(index) },
+                    onLoadMore = onLoadMore,
+                    isLoadingMore = isLoadingMore,
+                    onCollapse = onCollapse,
+                    onBackToPlayer = { showQueue = false },
+                    field = field,
+                    accent = accent
+                )
+            } else {
+                EditorialNowPlayingView(
+                    currentSong = currentSong,
+                    isPlaying = isPlaying,
+                    isBuffering = isBuffering,
+                    playWhenReady = playWhenReady,
+                    progress = progress,
+                    duration = duration,
+                    shuffleModeEnabled = shuffleModeEnabled,
+                    repeatMode = repeatMode,
+                    isFavorite = isFavorite,
+                    showLyrics = showLyrics,
+                    lyricsResult = lyricsResult,
+                    onToggleLyrics = { showLyrics = !showLyrics },
+                    onPlayPause = { viewModel.togglePlayPause() },
+                    onPrevious = { viewModel.skipToPrevious() },
+                    onNext = { viewModel.skipToNext() },
+                    onSeekTo = { viewModel.seekTo(it) },
+                    onToggleShuffle = { viewModel.toggleShuffle() },
+                    onToggleRepeat = { viewModel.toggleRepeat() },
+                    onFavoriteToggle = { viewModel.toggleCurrentSongLike() },
+                    onDownloadToggle = { currentSong?.let { viewModel.toggleDownload(it) } },
+                    isDownloaded = currentSong?.let { viewModel.isDownloaded(it.id) } ?: false,
+                    isDownloading = currentSong?.let { viewModel.isDownloading(it.id) } ?: false,
+                    isLocalOriginal = currentSong?.let { viewModel.isLocalOriginal(it) } ?: false,
+                    onCollapse = onCollapse,
+                    onShowQueue = { showQueue = true },
+                    onShowAddToPlaylist = { showAddToPlaylist = true },
+                    onArtistClick = onArtistClick,
+                    field = field,
+                    accent = accent
+                )
+            }
+        }
+    }
+
+    if (showAddToPlaylist) {
+        AddToPlaylistSheet(
+            playlists = localPlaylists,
+            onPlaylistClick = { playlist ->
+                viewModel.addToPlaylist(playlist.id)
+                showAddToPlaylist = false
+            },
+            onCreateNewClick = { name, desc ->
+                viewModel.createPlaylist(name, desc)
+                showAddToPlaylist = false
+            },
+            onDismissRequest = { showAddToPlaylist = false }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun EditorialNowPlayingView(
+    currentSong: Song?,
+    isPlaying: Boolean,
+    isBuffering: Boolean,
+    playWhenReady: Boolean,
+    progress: Long,
+    duration: Long,
+    shuffleModeEnabled: Boolean,
+    repeatMode: Int,
+    isFavorite: Boolean,
+    showLyrics: Boolean,
+    lyricsResult: LyricsResult,
+    onToggleLyrics: () -> Unit,
+    onPlayPause: () -> Unit,
+    onPrevious: () -> Unit,
+    onNext: () -> Unit,
+    onSeekTo: (Long) -> Unit,
+    onToggleShuffle: () -> Unit,
+    onToggleRepeat: () -> Unit,
+    onFavoriteToggle: (Boolean) -> Unit,
+    onDownloadToggle: () -> Unit,
+    isDownloaded: Boolean,
+    isDownloading: Boolean,
+    isLocalOriginal: Boolean,
+    onCollapse: () -> Unit,
+    onShowQueue: () -> Unit,
+    onShowAddToPlaylist: () -> Unit,
+    onArtistClick: (String) -> Unit,
+    field: Color,
+    accent: Color
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+
+        // ========== TOP BAR ==========
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .statusBarsPadding()
+                .padding(horizontal = 20.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            EditorialCircleButton(
+                onClick = onCollapse,
+                accent = accent,
+                field = field,
+                size = 44.dp
+            ) {
+                Icon(Icons.Default.KeyboardArrowDown, "Collapse", modifier = Modifier.size(26.dp))
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                EditorialCircleButton(
+                    onClick = onShowAddToPlaylist,
+                    accent = accent,
+                    field = field,
+                    size = 44.dp
+                ) {
+                    Icon(Icons.Rounded.PlaylistAdd, "Add to Playlist", modifier = Modifier.size(22.dp))
+                }
+                EditorialCircleButton(
+                    onClick = onShowQueue,
+                    accent = accent,
+                    field = field,
+                    size = 44.dp
+                ) {
+                    Icon(Icons.AutoMirrored.Filled.QueueMusic, "Queue", modifier = Modifier.size(22.dp))
+                }
+            }
+        }
+
+        // ========== DIE-CUT ART / LYRICS ==========
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            contentAlignment = Alignment.Center
+        ) {
+            Crossfade(targetState = showLyrics, label = "EditorialArtLyrics") { lyricsVisible ->
+                if (lyricsVisible) {
+                    Box(modifier = Modifier.fillMaxSize().padding(horizontal = 24.dp)) {
+                        SyncedLyricsView(
+                            lyricsResult = lyricsResult,
+                            currentPositionMs = progress,
+                            onSeekTo = onSeekTo,
+                            ambientBackground = false,
+                            primaryColor = accent,
+                            onSurfaceColor = accent,
+                            onSurfaceVariantColor = accent.copy(alpha = 0.6f)
+                        )
+                    }
+                } else {
+                    EditorialDieCutArt(
+                        currentSong = currentSong,
+                        isPlaying = isPlaying,
+                        onTap = onPlayPause,
+                        accent = accent,
+                        field = field
+                    )
+                }
+            }
+        }
+
+        // ========== HEADLINE ==========
+        val title = currentSong?.title?.takeIf { !it.startsWith("Unknown") } ?: "Untitled"
+        val headlineBase = when {
+            title.length <= 12 -> MaterialTheme.typography.displayLarge
+            title.length <= 24 -> MaterialTheme.typography.displayMedium
+            else -> MaterialTheme.typography.displaySmall
+        }
+        Text(
+            text = title,
+            style = headlineBase.copy(
+                fontFamily = FontFamily.Serif,
+                fontStyle = FontStyle.Italic,
+                fontWeight = FontWeight.Bold
+            ),
+            color = accent,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+        )
+
+        val artistName = currentSong?.artist?.takeIf { !it.startsWith("Unknown") } ?: "Unknown Artist"
+        Text(
+            text = artistName.uppercase(),
+            style = MaterialTheme.typography.labelLarge.copy(letterSpacing = 2.sp),
+            color = accent.copy(alpha = 0.8f),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier
+                .padding(horizontal = 20.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .clickable(enabled = artistName != "Unknown Artist") { onArtistClick(artistName) }
+                .padding(horizontal = 4.dp, vertical = 4.dp)
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // ========== CONTROL CLUSTER (asymmetric bento) ==========
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+        ) {
+            // Row 1: word pill + previous circle
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(80.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                // The word IS the icon.
+                Surface(
+                    onClick = onPlayPause,
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight(),
+                    shape = RoundedCornerShape(50),
+                    color = accent,
+                    contentColor = field
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        if (isBuffering && playWhenReady && !isPlaying) {
+                            LoadingIndicator(
+                                modifier = Modifier.size(36.dp),
+                                color = field,
+                                polygons = listOf(
+                                    MaterialShapes.SoftBurst,
+                                    MaterialShapes.Cookie9Sided,
+                                    MaterialShapes.Pill,
+                                    MaterialShapes.Sunny
+                                )
+                            )
+                        } else {
+                            AnimatedContent(
+                                targetState = isPlaying,
+                                label = "EditorialPlayWord"
+                            ) { playing ->
+                                Text(
+                                    text = if (playing) "PAUSE" else "PLAY",
+                                    style = MaterialTheme.typography.headlineSmall.copy(
+                                        fontWeight = FontWeight.Medium,
+                                        letterSpacing = 3.sp
+                                    )
+                                )
+                            }
+                        }
+                    }
+                }
+                EditorialCircleButton(
+                    onClick = onPrevious,
+                    accent = accent,
+                    field = field,
+                    size = 80.dp
+                ) {
+                    Icon(Icons.Default.SkipPrevious, "Previous", modifier = Modifier.size(34.dp))
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Row 2: next circle + progress line with times
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                EditorialCircleButton(
+                    onClick = onNext,
+                    accent = accent,
+                    field = field,
+                    size = 80.dp
+                ) {
+                    Icon(Icons.Default.SkipNext, "Next", modifier = Modifier.size(34.dp))
+                }
+
+                Column(modifier = Modifier.weight(1f)) {
+                    // Scrub locally, seek once on release (streamed tracks
+                    // rebuffer if seeked per drag frame).
+                    var scrubPosition by remember { mutableStateOf<Float?>(null) }
+                    val displayedProgress = scrubPosition?.toLong() ?: progress
+                    val progressFraction =
+                        if (duration > 0) displayedProgress.toFloat() / duration.toFloat() else 0f
+                    val animatedProgress by animateFloatAsState(
+                        targetValue = progressFraction,
+                        animationSpec = spring(
+                            dampingRatio = Spring.DampingRatioNoBouncy,
+                            stiffness = Spring.StiffnessLow
+                        ),
+                        label = "EditorialProgress"
+                    )
+                    val lineStroke = Stroke(
+                        width = with(LocalDensity.current) { 4.dp.toPx() },
+                        cap = StrokeCap.Round
+                    )
+
+                    Box(contentAlignment = Alignment.Center) {
+                        // Wavy played portion, flat remainder - the wave
+                        // settles flat when paused.
+                        LinearWavyProgressIndicator(
+                            progress = { animatedProgress },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(14.dp),
+                            color = accent,
+                            trackColor = accent.copy(alpha = 0.35f),
+                            stroke = lineStroke,
+                            trackStroke = lineStroke,
+                            amplitude = { if (isPlaying) 1f else 0f }
+                        )
+                        Slider(
+                            value = scrubPosition ?: progress.toFloat(),
+                            onValueChange = { scrubPosition = it },
+                            onValueChangeFinished = {
+                                scrubPosition?.let { onSeekTo(it.toLong()) }
+                                scrubPosition = null
+                            },
+                            valueRange = 0f..(duration.toFloat().coerceAtLeast(1f)),
+                            colors = SliderDefaults.colors(
+                                thumbColor = Color.Transparent,
+                                activeTrackColor = Color.Transparent,
+                                inactiveTrackColor = Color.Transparent
+                            ),
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text(
+                            text = formatEditorialTime(displayedProgress),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = accent.copy(alpha = 0.8f)
+                        )
+                        Text(
+                            text = formatEditorialTime(duration),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = accent.copy(alpha = 0.8f)
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // ========== CHIPS ROW ==========
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.CenterHorizontally)
+            ) {
+                EditorialChip(
+                    checked = isFavorite,
+                    onClick = { onFavoriteToggle(!isFavorite) },
+                    accent = accent,
+                    field = field
+                ) {
+                    LikeBurstIcon(isFavorite = isFavorite, iconSize = 20.dp)
+                }
+                EditorialChip(
+                    checked = isDownloaded || isDownloading,
+                    onClick = { if (!isDownloading && !isLocalOriginal) onDownloadToggle() },
+                    accent = accent,
+                    field = field
+                ) {
+                    when {
+                        isLocalOriginal -> Icon(
+                            Icons.Rounded.Smartphone, "Local File",
+                            modifier = Modifier.size(20.dp)
+                        )
+                        isDownloading -> CircularWavyProgressIndicator(
+                            modifier = Modifier.size(20.dp),
+                            color = field
+                        )
+                        else -> Icon(
+                            if (isDownloaded) Icons.Rounded.CheckCircle else Icons.Rounded.Download,
+                            if (isDownloaded) "Downloaded" else "Download",
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                }
+                EditorialChip(
+                    checked = shuffleModeEnabled,
+                    onClick = onToggleShuffle,
+                    accent = accent,
+                    field = field
+                ) {
+                    Icon(Icons.Default.Shuffle, "Shuffle", modifier = Modifier.size(20.dp))
+                }
+                EditorialChip(
+                    checked = repeatMode != Player.REPEAT_MODE_OFF,
+                    onClick = onToggleRepeat,
+                    accent = accent,
+                    field = field
+                ) {
+                    Icon(
+                        if (repeatMode == Player.REPEAT_MODE_ONE) Icons.Default.RepeatOne
+                        else Icons.Default.Repeat,
+                        "Repeat",
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+                EditorialChip(
+                    checked = showLyrics,
+                    onClick = onToggleLyrics,
+                    accent = accent,
+                    field = field
+                ) {
+                    Icon(Icons.Rounded.Lyrics, "Lyrics", modifier = Modifier.size(20.dp))
+                }
+            }
+        }
+
+        Spacer(
+            modifier = Modifier
+                .navigationBarsPadding()
+                .height(8.dp)
+        )
+    }
+}
+
+/**
+ * The die-cut artwork: album art clipped by a per-track MaterialShapes
+ * polygon. On track change the clip morphs from the previous cut to the new
+ * one; the art settles slightly smaller while paused.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun EditorialDieCutArt(
+    currentSong: Song?,
+    isPlaying: Boolean,
+    onTap: () -> Unit,
+    accent: Color,
+    field: Color
+) {
+    val dieCuts = remember {
+        listOf(
+            MaterialShapes.Flower,
+            MaterialShapes.Clover4Leaf,
+            MaterialShapes.Puffy,
+            MaterialShapes.Cookie12Sided,
+            MaterialShapes.SoftBurst
+        )
+    }
+    val targetPolygon = remember(currentSong?.id) {
+        dieCuts[abs(currentSong?.id?.hashCode() ?: 0) % dieCuts.size]
+    }
+
+    var morphFrom by remember { mutableStateOf(targetPolygon) }
+    var morphTo by remember { mutableStateOf(targetPolygon) }
+    val morphProgress = remember { Animatable(1f) }
+    LaunchedEffect(targetPolygon) {
+        if (targetPolygon !== morphTo) {
+            morphFrom = morphTo
+            morphTo = targetPolygon
+            morphProgress.snapTo(0f)
+            morphProgress.animateTo(
+                targetValue = 1f,
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioLowBouncy,
+                    stiffness = Spring.StiffnessLow
+                )
+            )
+        }
+    }
+    val morph = remember(morphFrom, morphTo) { Morph(morphFrom, morphTo) }
+    val dieCutShape = remember(morph, morphProgress.value) {
+        EditorialMorphShape(morph, morphProgress.value)
+    }
+
+    // Paused art settles slightly smaller; playing art sits at full size.
+    val artScale by animateFloatAsState(
+        targetValue = if (isPlaying) 1f else 0.94f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessLow
+        ),
+        label = "EditorialArtScale"
+    )
+
+    BoxWithConstraints(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        if (maxWidth < 50.dp || maxHeight < 50.dp) return@BoxWithConstraints
+        val artSize = minOf(maxWidth, maxHeight) * 0.95f
+
+        Box(
+            modifier = Modifier
+                .size(artSize)
+                .graphicsLayer {
+                    scaleX = artScale
+                    scaleY = artScale
+                }
+                .clip(dieCutShape)
+                .background(accent)
+                .clickable { onTap() },
+            contentAlignment = Alignment.Center
+        ) {
+            val artModel = currentSong?.highResThumbnailUrl
+                ?: currentSong?.thumbnailUrl
+                ?: currentSong?.albumArtUri
+            if (artModel != null) {
+                AsyncImage(
+                    model = artModel,
+                    contentDescription = "Album Art",
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
+                )
+            } else {
+                Icon(
+                    imageVector = Icons.Rounded.MusicNote,
+                    contentDescription = null,
+                    tint = field,
+                    modifier = Modifier.size(artSize * 0.3f)
+                )
+            }
+        }
+    }
+}
+
+/** Flat accent circle button with field-colored content. */
+@Composable
+internal fun EditorialCircleButton(
+    onClick: () -> Unit,
+    accent: Color,
+    field: Color,
+    size: androidx.compose.ui.unit.Dp,
+    content: @Composable () -> Unit
+) {
+    FilledIconButton(
+        onClick = onClick,
+        shape = CircleShape,
+        colors = IconButtonDefaults.filledIconButtonColors(
+            containerColor = accent,
+            contentColor = field
+        ),
+        modifier = Modifier.size(size)
+    ) {
+        content()
+    }
+}
+
+/**
+ * Two-tone toggle chip: checked = accent fill with field glyph, unchecked =
+ * bare accent glyph on the field. No third color, no outline.
+ */
+@Composable
+internal fun EditorialChip(
+    checked: Boolean,
+    onClick: () -> Unit,
+    accent: Color,
+    field: Color,
+    content: @Composable () -> Unit
+) {
+    Surface(
+        onClick = onClick,
+        shape = CircleShape,
+        color = if (checked) accent else Color.Transparent,
+        contentColor = if (checked) field else accent,
+        modifier = Modifier.size(48.dp)
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            content()
+        }
+    }
+}
+
+/**
+ * Editorial queue: the same two-tone spread. The current track is the only
+ * inverted row (accent fill, field text) - print-style emphasis. Shared with
+ * the Poster style, which passes its own field/accent pair.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+internal fun EditorialQueueView(
+    queue: List<Song>,
+    currentSong: Song?,
+    onSongClick: (Song) -> Unit,
+    onRemoveSong: (index: Int) -> Unit,
+    onLoadMore: () -> Unit,
+    isLoadingMore: Boolean,
+    onCollapse: () -> Unit,
+    onBackToPlayer: () -> Unit,
+    field: Color,
+    accent: Color
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(field)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .statusBarsPadding()
+                .padding(horizontal = 20.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            EditorialCircleButton(
+                onClick = onCollapse,
+                accent = accent,
+                field = field,
+                size = 44.dp
+            ) {
+                Icon(Icons.Default.KeyboardArrowDown, "Collapse", modifier = Modifier.size(26.dp))
+            }
+            Text(
+                text = "Up Next",
+                style = MaterialTheme.typography.headlineMedium.copy(
+                    fontFamily = FontFamily.Serif,
+                    fontStyle = FontStyle.Italic,
+                    fontWeight = FontWeight.Bold
+                ),
+                color = accent
+            )
+            EditorialCircleButton(
+                onClick = onBackToPlayer,
+                accent = accent,
+                field = field,
+                size = 44.dp
+            ) {
+                Icon(Icons.Rounded.MusicNote, "Now Playing", modifier = Modifier.size(22.dp))
+            }
+        }
+
+        if (queue.isEmpty()) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text(
+                    text = "Queue is empty",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = accent.copy(alpha = 0.7f)
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(horizontal = 20.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                itemsIndexed(queue, key = { _, song -> "editorial_queue_${song.id}" }) { index, song ->
+                    val isCurrent = song.id == currentSong?.id
+                    Surface(
+                        onClick = { onSongClick(song) },
+                        shape = RoundedCornerShape(24.dp),
+                        color = if (isCurrent) accent else Color.Transparent,
+                        contentColor = if (isCurrent) field else accent,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .animateItem()
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 12.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Box(modifier = Modifier.width(28.dp), contentAlignment = Alignment.Center) {
+                                if (isCurrent) {
+                                    Icon(
+                                        Icons.Rounded.GraphicEq, "Playing",
+                                        modifier = Modifier.size(18.dp)
+                                    )
+                                } else {
+                                    Text(
+                                        text = "${index + 1}",
+                                        style = MaterialTheme.typography.labelLarge.copy(
+                                            fontFamily = FontFamily.Serif,
+                                            fontStyle = FontStyle.Italic
+                                        )
+                                    )
+                                }
+                            }
+                            Spacer(modifier = Modifier.width(12.dp))
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = song.title,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    fontWeight = if (isCurrent) FontWeight.Bold else FontWeight.Medium,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                                Text(
+                                    text = song.artist,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    modifier = Modifier.graphicsLayer { alpha = 0.75f }
+                                )
+                            }
+                            IconButton(
+                                onClick = { onRemoveSong(index) },
+                                enabled = queue.size > 1,
+                                modifier = Modifier.size(32.dp)
+                            ) {
+                                Icon(
+                                    Icons.Filled.Close, "Remove from queue",
+                                    modifier = Modifier.size(18.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+
+                item(key = "editorial_load_more") {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 20.dp)
+                            .navigationBarsPadding(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Surface(
+                            onClick = onLoadMore,
+                            enabled = !isLoadingMore,
+                            shape = RoundedCornerShape(50),
+                            color = accent,
+                            contentColor = field
+                        ) {
+                            Box(
+                                modifier = Modifier.padding(horizontal = 32.dp, vertical = 14.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                if (isLoadingMore) {
+                                    LoadingIndicator(
+                                        modifier = Modifier.size(20.dp),
+                                        color = field,
+                                        polygons = listOf(
+                                            MaterialShapes.Cookie9Sided,
+                                            MaterialShapes.Pill,
+                                            MaterialShapes.Sunny
+                                        )
+                                    )
+                                } else {
+                                    Text(
+                                        text = "MORE",
+                                        style = MaterialTheme.typography.labelLarge.copy(
+                                            letterSpacing = 3.sp,
+                                            fontWeight = FontWeight.Medium
+                                        )
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Shape backed by a graphics-shapes Morph at a given progress, scaled to
+ * fill the composable bounds (same idiom as OnboardingScreen's MorphShape).
+ */
+internal class EditorialMorphShape(
+    private val morph: Morph,
+    private val progress: Float
+) : Shape {
+    override fun createOutline(
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density
+    ): Outline {
+        val path = morph.toPath(progress).asComposePath()
+        val matrix = Matrix()
+        val bounds = morph.calculateBounds()
+        val boundsWidth = bounds[2] - bounds[0]
+        val boundsHeight = bounds[3] - bounds[1]
+
+        matrix.scale(size.width / boundsWidth, size.height / boundsHeight)
+        matrix.translate(-bounds[0], -bounds[1])
+        path.transform(matrix)
+        return Outline.Generic(path)
+    }
+}
+
+internal fun formatEditorialTime(durationMs: Long): String {
+    val totalSeconds = durationMs / 1000
+    val minutes = totalSeconds / 60
+    val seconds = totalSeconds % 60
+    return String.format("%d:%02d", minutes, seconds)
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/EditorialPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/EditorialPlayerContent.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -80,6 +81,7 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.asComposePath
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontFamily
@@ -125,7 +127,8 @@ fun EditorialPlayerSheetContent(
     ambientBackground: Boolean = true,
     onCollapse: () -> Unit,
     onLoadMore: () -> Unit = {},
-    onArtistClick: (String) -> Unit = {}
+    onArtistClick: (String) -> Unit = {},
+    onRequestStyleSwitcher: () -> Unit = {}
 ) {
     BackHandler(enabled = true) { onCollapse() }
 
@@ -199,6 +202,7 @@ fun EditorialPlayerSheetContent(
                     onShowQueue = { showQueue = true },
                     onShowAddToPlaylist = { showAddToPlaylist = true },
                     onArtistClick = onArtistClick,
+                    onRequestStyleSwitcher = onRequestStyleSwitcher,
                     field = field,
                     accent = accent
                 )
@@ -252,6 +256,7 @@ private fun EditorialNowPlayingView(
     onShowQueue: () -> Unit,
     onShowAddToPlaylist: () -> Unit,
     onArtistClick: (String) -> Unit,
+    onRequestStyleSwitcher: () -> Unit,
     field: Color,
     accent: Color
 ) {
@@ -319,6 +324,7 @@ private fun EditorialNowPlayingView(
                         currentSong = currentSong,
                         isPlaying = isPlaying,
                         onTap = onPlayPause,
+                        onLongPress = onRequestStyleSwitcher,
                         accent = accent,
                         field = field
                     )
@@ -601,6 +607,7 @@ private fun EditorialDieCutArt(
     currentSong: Song?,
     isPlaying: Boolean,
     onTap: () -> Unit,
+    onLongPress: () -> Unit,
     accent: Color,
     field: Color
 ) {
@@ -665,7 +672,12 @@ private fun EditorialDieCutArt(
                 }
                 .clip(dieCutShape)
                 .background(accent)
-                .clickable { onTap() },
+                .pointerInput(Unit) {
+                    detectTapGestures(
+                        onTap = { onTap() },
+                        onLongPress = { onLongPress() }
+                    )
+                },
             contentAlignment = Alignment.Center
         ) {
             val artModel = currentSong?.highResThumbnailUrl

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/ExpandablePlayer.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/ExpandablePlayer.kt
@@ -297,6 +297,17 @@ fun ExpandablePlayer(
                                     onArtistClick = onArtistClick
                                 )
                             }
+                            PlayerStyle.STICKER -> {
+                                StickerPlayerSheetContent(
+                                    viewModel = viewModel,
+                                    ambientBackground = ambientBackground,
+                                    onCollapse = { onExpandChange(false) },
+                                    onLoadMore = {
+                                        viewModel.loadMoreRecommendations()
+                                    },
+                                    onArtistClick = onArtistClick
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/ExpandablePlayer.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/ExpandablePlayer.kt
@@ -319,6 +319,17 @@ fun ExpandablePlayer(
                                     onArtistClick = onArtistClick
                                 )
                             }
+                            PlayerStyle.DIAL -> {
+                                DialPlayerSheetContent(
+                                    viewModel = viewModel,
+                                    ambientBackground = ambientBackground,
+                                    onCollapse = { onExpandChange(false) },
+                                    onLoadMore = {
+                                        viewModel.loadMoreRecommendations()
+                                    },
+                                    onArtistClick = onArtistClick
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/ExpandablePlayer.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/ExpandablePlayer.kt
@@ -308,6 +308,17 @@ fun ExpandablePlayer(
                                     onArtistClick = onArtistClick
                                 )
                             }
+                            PlayerStyle.MORPH -> {
+                                MorphPlayerSheetContent(
+                                    viewModel = viewModel,
+                                    ambientBackground = ambientBackground,
+                                    onCollapse = { onExpandChange(false) },
+                                    onLoadMore = {
+                                        viewModel.loadMoreRecommendations()
+                                    },
+                                    onArtistClick = onArtistClick
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/ExpandablePlayer.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/ExpandablePlayer.kt
@@ -1,6 +1,9 @@
 package com.ivor.ivormusic.ui.player
 
+import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
@@ -53,10 +56,19 @@ fun ExpandablePlayer(
     viewModel: PlayerViewModel,
     ambientBackground: Boolean = true,
     playerStyle: PlayerStyle = PlayerStyle.CLASSIC,
+    onPlayerStyleChange: (PlayerStyle) -> Unit = {},
     onArtistClick: (String) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     if (currentSong == null) return
+
+    // Long-pressing the artwork in any style summons the style wheel; it
+    // lives here, above whichever style is active, so the player can morph
+    // live underneath it.
+    var showStyleWheel by remember { mutableStateOf(false) }
+    LaunchedEffect(isExpanded) {
+        if (!isExpanded) showStyleWheel = false
+    }
 
     val configuration = LocalConfiguration.current
     val screenHeight = configuration.screenHeightDp.dp
@@ -241,7 +253,14 @@ fun ExpandablePlayer(
                             .height(expandedHeight)
                             .graphicsLayer { alpha = fullAlpha }
                     ) {
-                        when (playerStyle) {
+                        // Crossfade makes a live style swap (from the style
+                        // wheel or Settings) a soft morph instead of a cut.
+                        Crossfade(
+                            targetState = playerStyle,
+                            animationSpec = MaterialTheme.motionScheme.slowEffectsSpec(),
+                            label = "PlayerStyleSwap"
+                        ) { activeStyle ->
+                        when (activeStyle) {
                             PlayerStyle.CLASSIC -> {
                                 PlayerSheetContent(
                                     viewModel = viewModel,
@@ -250,7 +269,8 @@ fun ExpandablePlayer(
                                     onLoadMore = {
                                         viewModel.loadMoreRecommendations()
                                     },
-                                    onArtistClick = onArtistClick
+                                    onArtistClick = onArtistClick,
+                                    onRequestStyleSwitcher = { showStyleWheel = true }
                                 )
                             }
                             PlayerStyle.GESTURE -> {
@@ -261,7 +281,8 @@ fun ExpandablePlayer(
                                     onLoadMore = {
                                         viewModel.loadMoreRecommendations()
                                     },
-                                    onArtistClick = onArtistClick
+                                    onArtistClick = onArtistClick,
+                                    onRequestStyleSwitcher = { showStyleWheel = true }
                                 )
                             }
                             PlayerStyle.EDITORIAL -> {
@@ -272,7 +293,8 @@ fun ExpandablePlayer(
                                     onLoadMore = {
                                         viewModel.loadMoreRecommendations()
                                     },
-                                    onArtistClick = onArtistClick
+                                    onArtistClick = onArtistClick,
+                                    onRequestStyleSwitcher = { showStyleWheel = true }
                                 )
                             }
                             PlayerStyle.POSTER -> {
@@ -283,7 +305,8 @@ fun ExpandablePlayer(
                                     onLoadMore = {
                                         viewModel.loadMoreRecommendations()
                                     },
-                                    onArtistClick = onArtistClick
+                                    onArtistClick = onArtistClick,
+                                    onRequestStyleSwitcher = { showStyleWheel = true }
                                 )
                             }
                             PlayerStyle.BENTO -> {
@@ -294,7 +317,8 @@ fun ExpandablePlayer(
                                     onLoadMore = {
                                         viewModel.loadMoreRecommendations()
                                     },
-                                    onArtistClick = onArtistClick
+                                    onArtistClick = onArtistClick,
+                                    onRequestStyleSwitcher = { showStyleWheel = true }
                                 )
                             }
                             PlayerStyle.STICKER -> {
@@ -305,7 +329,8 @@ fun ExpandablePlayer(
                                     onLoadMore = {
                                         viewModel.loadMoreRecommendations()
                                     },
-                                    onArtistClick = onArtistClick
+                                    onArtistClick = onArtistClick,
+                                    onRequestStyleSwitcher = { showStyleWheel = true }
                                 )
                             }
                             PlayerStyle.MORPH -> {
@@ -316,7 +341,8 @@ fun ExpandablePlayer(
                                     onLoadMore = {
                                         viewModel.loadMoreRecommendations()
                                     },
-                                    onArtistClick = onArtistClick
+                                    onArtistClick = onArtistClick,
+                                    onRequestStyleSwitcher = { showStyleWheel = true }
                                 )
                             }
                             PlayerStyle.DIAL -> {
@@ -327,9 +353,23 @@ fun ExpandablePlayer(
                                     onLoadMore = {
                                         viewModel.loadMoreRecommendations()
                                     },
-                                    onArtistClick = onArtistClick
+                                    onArtistClick = onArtistClick,
+                                    onRequestStyleSwitcher = { showStyleWheel = true }
                                 )
                             }
+                        }
+                        }
+
+                        androidx.compose.animation.AnimatedVisibility(
+                            visible = showStyleWheel,
+                            enter = fadeIn(MaterialTheme.motionScheme.fastEffectsSpec()),
+                            exit = fadeOut(MaterialTheme.motionScheme.fastEffectsSpec())
+                        ) {
+                            PlayerStyleWheel(
+                                currentStyle = playerStyle,
+                                onStyleSelected = onPlayerStyleChange,
+                                onDismiss = { showStyleWheel = false }
+                            )
                         }
                     }
                 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/ExpandablePlayer.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/ExpandablePlayer.kt
@@ -286,6 +286,17 @@ fun ExpandablePlayer(
                                     onArtistClick = onArtistClick
                                 )
                             }
+                            PlayerStyle.BENTO -> {
+                                BentoPlayerSheetContent(
+                                    viewModel = viewModel,
+                                    ambientBackground = ambientBackground,
+                                    onCollapse = { onExpandChange(false) },
+                                    onLoadMore = {
+                                        viewModel.loadMoreRecommendations()
+                                    },
+                                    onArtistClick = onArtistClick
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/ExpandablePlayer.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/ExpandablePlayer.kt
@@ -264,6 +264,28 @@ fun ExpandablePlayer(
                                     onArtistClick = onArtistClick
                                 )
                             }
+                            PlayerStyle.EDITORIAL -> {
+                                EditorialPlayerSheetContent(
+                                    viewModel = viewModel,
+                                    ambientBackground = ambientBackground,
+                                    onCollapse = { onExpandChange(false) },
+                                    onLoadMore = {
+                                        viewModel.loadMoreRecommendations()
+                                    },
+                                    onArtistClick = onArtistClick
+                                )
+                            }
+                            PlayerStyle.POSTER -> {
+                                PosterPlayerSheetContent(
+                                    viewModel = viewModel,
+                                    ambientBackground = ambientBackground,
+                                    onCollapse = { onExpandChange(false) },
+                                    onLoadMore = {
+                                        viewModel.loadMoreRecommendations()
+                                    },
+                                    onArtistClick = onArtistClick
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/GesturePlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/GesturePlayerContent.kt
@@ -73,7 +73,8 @@ fun GesturePlayerSheetContent(
     ambientBackground: Boolean = true,
     onCollapse: () -> Unit,
     onLoadMore: () -> Unit = {},
-    onArtistClick: (String) -> Unit = {}
+    onArtistClick: (String) -> Unit = {},
+    onRequestStyleSwitcher: () -> Unit = {}
 ) {
     BackHandler(enabled = true) {
         onCollapse()
@@ -166,6 +167,7 @@ fun GesturePlayerSheetContent(
                     onSleepTimerClick = { showSleepTimerDialog = true },
                     onPlayPauseToggle = { viewModel.togglePlayPause() },
                     onSongChange = { song -> viewModel.skipToSong(song) },
+                    onRequestStyleSwitcher = onRequestStyleSwitcher,
 
                     isDownloaded = currentSong?.let { viewModel.isDownloaded(it.id) } ?: false,
                     isDownloading = currentSong?.let { viewModel.isDownloading(it.id) } ?: false,
@@ -235,6 +237,7 @@ private fun GestureNowPlayingView(
     onSleepTimerClick: () -> Unit,
     onPlayPauseToggle: () -> Unit,
     onSongChange: (Song) -> Unit,
+    onRequestStyleSwitcher: () -> Unit,
     isDownloaded: Boolean,
     isDownloading: Boolean,
     isLocalOriginal: Boolean,
@@ -418,7 +421,8 @@ private fun GestureNowPlayingView(
                                         isPlaying = isPlaying,
                                         isBuffering = isBuffering,
                                         onPlayPauseToggle = onPlayPauseToggle,
-                                        onSongChange = onSongChange
+                                        onSongChange = onSongChange,
+                                        onLongPress = onRequestStyleSwitcher
                                     )
                                 } else if (currentSong != null) {
                                     // Single album art
@@ -426,7 +430,8 @@ private fun GestureNowPlayingView(
                                         song = currentSong,
                                         isPlaying = isPlaying,
                                         isBuffering = isBuffering,
-                                        onPlayPauseToggle = onPlayPauseToggle
+                                        onPlayPauseToggle = onPlayPauseToggle,
+                                        onLongPress = onRequestStyleSwitcher
                                     )
                                 }
                             }
@@ -717,7 +722,8 @@ private fun SwipeableAlbumCarousel(
     isPlaying: Boolean,
     isBuffering: Boolean,
     onPlayPauseToggle: () -> Unit,
-    onSongChange: (Song) -> Unit
+    onSongChange: (Song) -> Unit,
+    onLongPress: () -> Unit = {}
 ) {
     // The carousel position as a continuous float
     // Position 0 = first song centered, Position 1 = second song centered, etc.
@@ -853,7 +859,10 @@ private fun SwipeableAlbumCarousel(
                             .then(
                                 if (isCentered) {
                                     Modifier.pointerInput(Unit) {
-                                        detectTapGestures(onTap = { onPlayPauseToggle() })
+                                        detectTapGestures(
+                                            onTap = { onPlayPauseToggle() },
+                                            onLongPress = { onLongPress() }
+                                        )
                                     }
                                 } else Modifier
                             ),
@@ -945,7 +954,8 @@ private fun SingleAlbumArt(
     song: Song?,
     isPlaying: Boolean,
     isBuffering: Boolean,
-    onPlayPauseToggle: () -> Unit
+    onPlayPauseToggle: () -> Unit,
+    onLongPress: () -> Unit = {}
 ) {
     BoxWithConstraints(
         modifier = Modifier.fillMaxSize(),
@@ -965,7 +975,10 @@ private fun SingleAlbumArt(
             modifier = Modifier
                 .size(albumSize)
                 .pointerInput(Unit) {
-                    detectTapGestures(onTap = { onPlayPauseToggle() })
+                    detectTapGestures(
+                        onTap = { onPlayPauseToggle() },
+                        onLongPress = { onLongPress() }
+                    )
                 },
             shape = RoundedCornerShape(cornerRadius),
             color = MaterialTheme.colorScheme.surfaceContainerHigh,

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/MorphPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/MorphPlayerContent.kt
@@ -1,0 +1,660 @@
+package com.ivor.ivormusic.ui.player
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Repeat
+import androidx.compose.material.icons.filled.RepeatOne
+import androidx.compose.material.icons.filled.Shuffle
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material.icons.rounded.Lyrics
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.PlaylistAdd
+import androidx.compose.material3.CircularWavyProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.FloatingToolbarDefaults
+import androidx.compose.material3.HorizontalFloatingToolbar
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.IconToggleButton
+import androidx.compose.material3.LinearWavyProgressIndicator
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialShapes
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.graphics.shapes.Morph
+import androidx.media3.common.Player
+import coil.compose.AsyncImage
+import com.ivor.ivormusic.data.Song
+import com.ivor.ivormusic.ui.components.LikeBurstIcon
+import kotlin.math.abs
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Morph Player - one living shape.
+ *
+ * The album art lives inside a large MaterialShapes polygon that breathes,
+ * tilts and continuously morphs through organic cuts while music plays, and
+ * settles into a circle at rest. The shape IS the play/pause indicator; a
+ * wavy progress ring wraps it and flattens in silence. Conventional
+ * controls only exist as a summonable floating toolbar.
+ *
+ * Unlike the pure-flat styles, Morph keeps the ambient ChromaticMist layer:
+ * color is borrowed from the music.
+ *
+ * See docs/PLAYER_STYLE_MORPH_RESEARCH.md.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
+@Composable
+fun MorphPlayerSheetContent(
+    viewModel: PlayerViewModel,
+    ambientBackground: Boolean = true,
+    onCollapse: () -> Unit,
+    onLoadMore: () -> Unit = {},
+    onArtistClick: (String) -> Unit = {}
+) {
+    BackHandler(enabled = true) { onCollapse() }
+
+    val currentSong by viewModel.currentSong.collectAsState()
+    val isPlaying by viewModel.isPlaying.collectAsState()
+    val isBuffering by viewModel.isBuffering.collectAsState()
+    val playWhenReady by viewModel.playWhenReady.collectAsState()
+    val progress by viewModel.progress.collectAsState()
+    val duration by viewModel.duration.collectAsState()
+    val shuffleModeEnabled by viewModel.shuffleModeEnabled.collectAsState()
+    val repeatMode by viewModel.repeatMode.collectAsState()
+    val currentQueue by viewModel.currentQueue.collectAsState()
+    val isFavorite by viewModel.isCurrentSongLiked.collectAsState()
+    val lyricsResult by viewModel.lyricsResult.collectAsState()
+    val isLoadingMore by viewModel.isLoadingMore.collectAsState()
+    val localPlaylists by viewModel.localPlaylists.collectAsState()
+
+    var showQueue by remember { mutableStateOf(false) }
+    var showLyrics by remember { mutableStateOf(false) }
+    var showAddToPlaylist by remember { mutableStateOf(false) }
+    var controlsVisible by remember { mutableStateOf(true) }
+
+    val surfaceColor = MaterialTheme.colorScheme.background
+    val onSurfaceColor = MaterialTheme.colorScheme.onSurface
+    val onSurfaceVariantColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val primaryColor = MaterialTheme.colorScheme.primary
+
+    // Controls are guests: summoned by a tap, they slip away while music
+    // plays.
+    LaunchedEffect(controlsVisible, isPlaying) {
+        if (controlsVisible && isPlaying) {
+            delay(4500)
+            controlsVisible = false
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(surfaceColor)
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null
+            ) { controlsVisible = true }
+    ) {
+        val albumArtUrl = currentSong?.highResThumbnailUrl
+            ?: currentSong?.thumbnailUrl
+            ?: currentSong?.albumArtUri?.toString()
+        ChromaticMistBackground(
+            albumArtUrl = albumArtUrl,
+            enabled = ambientBackground && !showQueue,
+            modifier = Modifier.fillMaxSize()
+        )
+
+        Crossfade(targetState = showQueue, label = "MorphQueueTransition") { queueVisible ->
+            if (queueVisible) {
+                EditorialQueueView(
+                    queue = currentQueue,
+                    currentSong = currentSong,
+                    onSongClick = { song -> viewModel.skipToSong(song) },
+                    onRemoveSong = { index -> viewModel.removeQueueItem(index) },
+                    onLoadMore = onLoadMore,
+                    isLoadingMore = isLoadingMore,
+                    onCollapse = onCollapse,
+                    onBackToPlayer = { showQueue = false },
+                    field = surfaceColor,
+                    accent = onSurfaceColor
+                )
+            } else {
+                Column(modifier = Modifier.fillMaxSize()) {
+
+                    // ========== TOP BAR ==========
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .statusBarsPadding()
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        MorphUtilityButton(onClick = onCollapse) {
+                            Icon(
+                                Icons.Default.KeyboardArrowDown, "Collapse",
+                                modifier = Modifier.size(26.dp)
+                            )
+                        }
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            MorphUtilityButton(onClick = { showLyrics = !showLyrics }) {
+                                Icon(
+                                    Icons.Rounded.Lyrics, "Lyrics",
+                                    modifier = Modifier.size(22.dp)
+                                )
+                            }
+                            MorphUtilityButton(onClick = { showAddToPlaylist = true }) {
+                                Icon(
+                                    Icons.Rounded.PlaylistAdd, "Add to Playlist",
+                                    modifier = Modifier.size(22.dp)
+                                )
+                            }
+                            MorphUtilityButton(onClick = { showQueue = true }) {
+                                Icon(
+                                    Icons.AutoMirrored.Filled.QueueMusic, "Queue",
+                                    modifier = Modifier.size(22.dp)
+                                )
+                            }
+                        }
+                    }
+
+                    // ========== HERO SHAPE / LYRICS ==========
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f)
+                    ) {
+                        Crossfade(targetState = showLyrics, label = "MorphLyrics") { lyricsVisible ->
+                            if (lyricsVisible) {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .padding(horizontal = 24.dp)
+                                ) {
+                                    SyncedLyricsView(
+                                        lyricsResult = lyricsResult,
+                                        currentPositionMs = progress,
+                                        onSeekTo = { viewModel.seekTo(it) },
+                                        ambientBackground = ambientBackground,
+                                        primaryColor = primaryColor,
+                                        onSurfaceColor = onSurfaceColor,
+                                        onSurfaceVariantColor = onSurfaceVariantColor
+                                    )
+                                }
+                            } else {
+                                MorphHero(
+                                    currentSong = currentSong,
+                                    isPlaying = isPlaying,
+                                    isBuffering = isBuffering && playWhenReady && !isPlaying,
+                                    progressFraction = if (duration > 0) {
+                                        (progress.toFloat() / duration.toFloat()).coerceIn(0f, 1f)
+                                    } else 0f,
+                                    onPlayPause = { viewModel.togglePlayPause() },
+                                    onNext = { viewModel.skipToNext() },
+                                    onPrevious = { viewModel.skipToPrevious() },
+                                    ringColor = primaryColor,
+                                    ringTrackColor = onSurfaceVariantColor.copy(alpha = 0.2f)
+                                )
+                            }
+                        }
+                    }
+
+                    // ========== TITLE / ARTIST ==========
+                    Text(
+                        text = currentSong?.title?.takeIf { !it.startsWith("Unknown") } ?: "Untitled",
+                        style = MaterialTheme.typography.headlineLarge.copy(fontWeight = FontWeight.Bold),
+                        color = onSurfaceColor,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 24.dp)
+                    )
+                    val artistName = currentSong?.artist?.takeIf { !it.startsWith("Unknown") }
+                        ?: "Unknown Artist"
+                    Text(
+                        text = artistName,
+                        style = MaterialTheme.typography.titleMedium,
+                        color = primaryColor.copy(alpha = 0.9f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier
+                            .align(Alignment.CenterHorizontally)
+                            .clip(RoundedCornerShape(8.dp))
+                            .clickable(enabled = artistName != "Unknown Artist") {
+                                onArtistClick(artistName)
+                            }
+                            .padding(horizontal = 8.dp, vertical = 4.dp)
+                    )
+
+                    // ========== SCRUB LINE ==========
+                    Column(modifier = Modifier.padding(horizontal = 24.dp)) {
+                        var scrubPosition by remember { mutableStateOf<Float?>(null) }
+                        val displayedProgress = scrubPosition?.toLong() ?: progress
+                        val fraction = if (duration > 0) {
+                            displayedProgress.toFloat() / duration.toFloat()
+                        } else 0f
+                        val animatedFraction by animateFloatAsState(
+                            targetValue = fraction.coerceIn(0f, 1f),
+                            animationSpec = spring(
+                                dampingRatio = Spring.DampingRatioNoBouncy,
+                                stiffness = Spring.StiffnessLow
+                            ),
+                            label = "MorphScrub"
+                        )
+                        val lineStroke = Stroke(
+                            width = with(LocalDensity.current) { 3.dp.toPx() },
+                            cap = StrokeCap.Round
+                        )
+                        Box(contentAlignment = Alignment.Center) {
+                            LinearWavyProgressIndicator(
+                                progress = { animatedFraction },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(12.dp),
+                                color = primaryColor,
+                                trackColor = onSurfaceVariantColor.copy(alpha = 0.15f),
+                                stroke = lineStroke,
+                                trackStroke = lineStroke,
+                                amplitude = { if (isPlaying) 1f else 0f }
+                            )
+                            Slider(
+                                value = scrubPosition ?: progress.toFloat(),
+                                onValueChange = { scrubPosition = it },
+                                onValueChangeFinished = {
+                                    scrubPosition?.let { viewModel.seekTo(it.toLong()) }
+                                    scrubPosition = null
+                                },
+                                valueRange = 0f..(duration.toFloat().coerceAtLeast(1f)),
+                                colors = SliderDefaults.colors(
+                                    thumbColor = Color.Transparent,
+                                    activeTrackColor = Color.Transparent,
+                                    inactiveTrackColor = Color.Transparent
+                                ),
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        }
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text(
+                                text = formatEditorialTime(displayedProgress),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = onSurfaceVariantColor
+                            )
+                            Text(
+                                text = formatEditorialTime(duration),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = onSurfaceVariantColor
+                            )
+                        }
+                    }
+
+                    // ========== SUMMONED FLOATING TOOLBAR ==========
+                    AnimatedVisibility(
+                        visible = controlsVisible,
+                        enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
+                        exit = slideOutVertically(targetOffsetY = { it }) + fadeOut()
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 10.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            HorizontalFloatingToolbar(
+                                expanded = true,
+                                colors = FloatingToolbarDefaults.standardFloatingToolbarColors(),
+                                floatingActionButton = {
+                                    FloatingToolbarDefaults.StandardFloatingActionButton(
+                                        onClick = { viewModel.toggleCurrentSongLike() }
+                                    ) {
+                                        LikeBurstIcon(isFavorite = isFavorite)
+                                    }
+                                },
+                                content = {
+                                    IconToggleButton(
+                                        checked = shuffleModeEnabled,
+                                        onCheckedChange = { viewModel.toggleShuffle() }
+                                    ) {
+                                        Icon(Icons.Default.Shuffle, "Shuffle")
+                                    }
+                                    androidx.compose.material3.IconButton(
+                                        onClick = { viewModel.skipToPrevious() }
+                                    ) {
+                                        Icon(Icons.Default.SkipPrevious, "Previous")
+                                    }
+                                    androidx.compose.material3.IconButton(
+                                        onClick = { viewModel.skipToNext() }
+                                    ) {
+                                        Icon(Icons.Default.SkipNext, "Next")
+                                    }
+                                    IconToggleButton(
+                                        checked = repeatMode != Player.REPEAT_MODE_OFF,
+                                        onCheckedChange = { viewModel.toggleRepeat() }
+                                    ) {
+                                        Icon(
+                                            if (repeatMode == Player.REPEAT_MODE_ONE) Icons.Default.RepeatOne
+                                            else Icons.Default.Repeat,
+                                            "Repeat"
+                                        )
+                                    }
+                                }
+                            )
+                        }
+                    }
+
+                    Spacer(
+                        modifier = Modifier
+                            .navigationBarsPadding()
+                            .height(6.dp)
+                    )
+                }
+            }
+        }
+    }
+
+    if (showAddToPlaylist) {
+        AddToPlaylistSheet(
+            playlists = localPlaylists,
+            onPlaylistClick = { playlist ->
+                viewModel.addToPlaylist(playlist.id)
+                showAddToPlaylist = false
+            },
+            onCreateNewClick = { name, desc ->
+                viewModel.createPlaylist(name, desc)
+                showAddToPlaylist = false
+            },
+            onDismissRequest = { showAddToPlaylist = false }
+        )
+    }
+}
+
+@Composable
+private fun MorphUtilityButton(
+    onClick: () -> Unit,
+    content: @Composable () -> Unit
+) {
+    FilledIconButton(
+        onClick = onClick,
+        shape = CircleShape,
+        colors = IconButtonDefaults.filledIconButtonColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+            contentColor = MaterialTheme.colorScheme.onSurface
+        ),
+        modifier = Modifier.size(44.dp)
+    ) {
+        content()
+    }
+}
+
+/**
+ * The living hero: album art clipped by a shape that cycles through
+ * organic MaterialShapes cuts while playing and settles to a circle at
+ * rest, wrapped by a wavy progress ring that flattens in silence.
+ *
+ * Each morph segment runs to completion (never cancelled mid-flight), so
+ * a pause settles at the next segment boundary while tilt, breath and the
+ * ring respond instantly.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun MorphHero(
+    currentSong: Song?,
+    isPlaying: Boolean,
+    isBuffering: Boolean,
+    progressFraction: Float,
+    onPlayPause: () -> Unit,
+    onNext: () -> Unit,
+    onPrevious: () -> Unit,
+    ringColor: Color,
+    ringTrackColor: Color
+) {
+    val cycleShapes = remember {
+        listOf(
+            MaterialShapes.Cookie12Sided,
+            MaterialShapes.SoftBurst,
+            MaterialShapes.Sunny,
+            MaterialShapes.Puffy,
+            MaterialShapes.Cookie9Sided
+        )
+    }
+    val circle = remember { MaterialShapes.Circle }
+    var morphPair by remember { mutableStateOf(circle to circle) }
+    val morphProgress = remember { Animatable(1f) }
+    val playingState = rememberUpdatedState(isPlaying)
+
+    LaunchedEffect(Unit) {
+        var index = 0
+        while (isActive) {
+            val target = if (playingState.value) {
+                cycleShapes[index++ % cycleShapes.size]
+            } else {
+                circle
+            }
+            if (target !== morphPair.second) {
+                morphPair = morphPair.second to target
+                morphProgress.snapTo(0f)
+                morphProgress.animateTo(
+                    targetValue = 1f,
+                    animationSpec = tween(durationMillis = 2200, easing = FastOutSlowInEasing)
+                )
+            } else {
+                delay(150)
+            }
+        }
+    }
+    val morph = remember(morphPair) { Morph(morphPair.first, morphPair.second) }
+    val heroShape = remember(morph, morphProgress.value) {
+        EditorialMorphShape(morph, morphProgress.value)
+    }
+
+    // Breath and tilt: springs chase a moving target while playing and a
+    // fixed one when paused, so silence settles smoothly and immediately.
+    val infinite = rememberInfiniteTransition(label = "MorphLife")
+    val breathValue by infinite.animateFloat(
+        initialValue = 0.975f,
+        targetValue = 1.02f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 2400, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "MorphBreathValue"
+    )
+    val tiltValue by infinite.animateFloat(
+        initialValue = -5f,
+        targetValue = 5f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 3600, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "MorphTiltValue"
+    )
+    val breath by animateFloatAsState(
+        targetValue = if (isPlaying) breathValue else 1f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioNoBouncy,
+            stiffness = Spring.StiffnessLow
+        ),
+        label = "MorphBreath"
+    )
+    val tilt by animateFloatAsState(
+        targetValue = if (isPlaying) tiltValue else 0f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioNoBouncy,
+            stiffness = Spring.StiffnessLow
+        ),
+        label = "MorphTilt"
+    )
+
+    // Horizontal drag: stretch toward the skip, spring back if abandoned.
+    val scope = rememberCoroutineScope()
+    val dragX = remember { Animatable(0f) }
+    val currentOnNext by rememberUpdatedState(onNext)
+    val currentOnPrevious by rememberUpdatedState(onPrevious)
+    val currentOnPlayPause by rememberUpdatedState(onPlayPause)
+
+    BoxWithConstraints(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        if (maxWidth < 50.dp || maxHeight < 50.dp) return@BoxWithConstraints
+        val heroSize = minOf(maxWidth, maxHeight) * 0.72f
+        val ringSize = heroSize + 40.dp
+        val skipThresholdPx = with(LocalDensity.current) { 100.dp.toPx() }
+
+        CircularWavyProgressIndicator(
+            progress = { progressFraction },
+            modifier = Modifier.size(ringSize),
+            color = ringColor,
+            trackColor = ringTrackColor,
+            amplitude = { if (isPlaying) 1f else 0f }
+        )
+
+        Box(
+            modifier = Modifier
+                .size(heroSize)
+                .graphicsLayer {
+                    translationX = dragX.value * 0.5f
+                    rotationZ = tilt + dragX.value / 60f
+                    scaleX = breath * (1f + (abs(dragX.value) / 2500f).coerceAtMost(0.08f))
+                    scaleY = breath
+                }
+                .clip(heroShape)
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                .pointerInput(Unit) {
+                    detectTapGestures(onTap = { currentOnPlayPause() })
+                }
+                .pointerInput(Unit) {
+                    detectHorizontalDragGestures(
+                        onHorizontalDrag = { change, dragAmount ->
+                            change.consume()
+                            scope.launch { dragX.snapTo(dragX.value + dragAmount) }
+                        },
+                        onDragEnd = {
+                            val dx = dragX.value
+                            scope.launch {
+                                if (abs(dx) > skipThresholdPx) {
+                                    if (dx < 0) currentOnNext() else currentOnPrevious()
+                                }
+                                dragX.animateTo(
+                                    0f,
+                                    spring(
+                                        dampingRatio = Spring.DampingRatioMediumBouncy,
+                                        stiffness = Spring.StiffnessLow
+                                    )
+                                )
+                            }
+                        },
+                        onDragCancel = {
+                            scope.launch { dragX.animateTo(0f, spring()) }
+                        }
+                    )
+                },
+            contentAlignment = Alignment.Center
+        ) {
+            val artModel = currentSong?.highResThumbnailUrl
+                ?: currentSong?.thumbnailUrl
+                ?: currentSong?.albumArtUri
+            if (artModel != null) {
+                AsyncImage(
+                    model = artModel,
+                    contentDescription = "Album Art",
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
+                )
+            } else {
+                Icon(
+                    imageVector = Icons.Rounded.MusicNote,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                    modifier = Modifier.size(heroSize * 0.3f)
+                )
+            }
+            if (isBuffering) {
+                LoadingIndicator(
+                    modifier = Modifier.size(44.dp),
+                    color = ringColor,
+                    polygons = listOf(
+                        MaterialShapes.SoftBurst,
+                        MaterialShapes.Cookie9Sided,
+                        MaterialShapes.Pill,
+                        MaterialShapes.Sunny
+                    )
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/MorphPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/MorphPlayerContent.kt
@@ -119,7 +119,8 @@ fun MorphPlayerSheetContent(
     ambientBackground: Boolean = true,
     onCollapse: () -> Unit,
     onLoadMore: () -> Unit = {},
-    onArtistClick: (String) -> Unit = {}
+    onArtistClick: (String) -> Unit = {},
+    onRequestStyleSwitcher: () -> Unit = {}
 ) {
     BackHandler(enabled = true) { onCollapse() }
 
@@ -262,6 +263,7 @@ fun MorphPlayerSheetContent(
                                     onPlayPause = { viewModel.togglePlayPause() },
                                     onNext = { viewModel.skipToNext() },
                                     onPrevious = { viewModel.skipToPrevious() },
+                                    onLongPress = onRequestStyleSwitcher,
                                     ringColor = primaryColor,
                                     ringTrackColor = onSurfaceVariantColor.copy(alpha = 0.2f)
                                 )
@@ -479,6 +481,7 @@ private fun MorphHero(
     onPlayPause: () -> Unit,
     onNext: () -> Unit,
     onPrevious: () -> Unit,
+    onLongPress: () -> Unit,
     ringColor: Color,
     ringTrackColor: Color
 ) {
@@ -565,6 +568,7 @@ private fun MorphHero(
     val currentOnNext by rememberUpdatedState(onNext)
     val currentOnPrevious by rememberUpdatedState(onPrevious)
     val currentOnPlayPause by rememberUpdatedState(onPlayPause)
+    val currentOnLongPress by rememberUpdatedState(onLongPress)
 
     BoxWithConstraints(
         modifier = Modifier.fillMaxSize(),
@@ -595,7 +599,10 @@ private fun MorphHero(
                 .clip(heroShape)
                 .background(MaterialTheme.colorScheme.surfaceContainerHigh)
                 .pointerInput(Unit) {
-                    detectTapGestures(onTap = { currentOnPlayPause() })
+                    detectTapGestures(
+                        onTap = { currentOnPlayPause() },
+                        onLongPress = { currentOnLongPress() }
+                    )
                 }
                 .pointerInput(Unit) {
                     detectHorizontalDragGestures(

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -65,7 +66,8 @@ fun PlayerSheetContent(
     ambientBackground: Boolean = true,
     onCollapse: () -> Unit,
     onLoadMore: () -> Unit = {},
-    onArtistClick: (String) -> Unit = {}
+    onArtistClick: (String) -> Unit = {},
+    onRequestStyleSwitcher: () -> Unit = {}
 ) {
     // Handle back press to collapse player instead of quitting app
     BackHandler(enabled = true) {
@@ -162,6 +164,7 @@ fun PlayerSheetContent(
                     onShowQueue = { showQueue = true },
                     onShowAddToPlaylist = { showAddToPlaylist = true },
                     onArtistClick = onArtistClick,
+                    onRequestStyleSwitcher = onRequestStyleSwitcher,
                     viewModel = viewModel,
                     primaryColor = primaryColor,
                     primaryContainerColor = primaryContainerColor,
@@ -219,6 +222,7 @@ private fun ExpressiveNowPlayingView(
     onShowQueue: () -> Unit,
     onShowAddToPlaylist: () -> Unit,
     onArtistClick: (String) -> Unit,
+    onRequestStyleSwitcher: () -> Unit,
     viewModel: PlayerViewModel,
     primaryColor: Color,
     primaryContainerColor: Color,
@@ -385,7 +389,13 @@ private fun ExpressiveNowPlayingView(
                         Box(contentAlignment = Alignment.Center) {
                             // Main album art container with expressive squircle shape
                             Surface(
-                                modifier = Modifier.size(albumSize),
+                                modifier = Modifier
+                                    .size(albumSize)
+                                    .pointerInput(Unit) {
+                                        detectTapGestures(
+                                            onLongPress = { onRequestStyleSwitcher() }
+                                        )
+                                    },
                                 shape = RoundedCornerShape(cornerRadius),
                                 color = MaterialTheme.colorScheme.surfaceContainerHigh
                             ) {

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerStyleWheel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerStyleWheel.kt
@@ -1,0 +1,231 @@
+package com.ivor.ivormusic.ui.player
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Animation
+import androidx.compose.material.icons.rounded.GridView
+import androidx.compose.material.icons.rounded.Interests
+import androidx.compose.material.icons.rounded.Newspaper
+import androidx.compose.material.icons.rounded.PlayCircle
+import androidx.compose.material.icons.rounded.RadioButtonChecked
+import androidx.compose.material.icons.rounded.SwipeRight
+import androidx.compose.material.icons.rounded.TextFields
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialShapes
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.graphics.shapes.RoundedPolygon
+import com.ivor.ivormusic.data.PlayerStyle
+import kotlin.math.cos
+import kotlin.math.roundToInt
+import kotlin.math.sin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * The style wheel: long-press the artwork in any player style and every
+ * style blooms out of the press point as its own die-cut MaterialShapes
+ * button, arranged in a ring. Tap one and the player morphs into that
+ * style live.
+ *
+ * Expressive contract:
+ * - Shape signals identity: each style is cut into the polygon that best
+ *   matches its personality (Editorial is a flower, Dial is a sunny ring,
+ *   Morph is a soft burst, ...).
+ * - Motion is physics: items bloom outward on staggered underdamped
+ *   springs with visible overshoot while the whole ring settles from a
+ *   slight counter-rotation; icons stay upright throughout.
+ * - The overlay is a flat high-alpha surface, no blur, no gradient scrim.
+ * - Haptics mark the open (long-press) and the pick (confirm).
+ */
+internal data class PlayerStyleWheelEntry(
+    val style: PlayerStyle,
+    val label: String,
+    val icon: ImageVector,
+    val polygon: RoundedPolygon
+)
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+internal fun rememberPlayerStyleWheelEntries(): List<PlayerStyleWheelEntry> = remember {
+    listOf(
+        PlayerStyleWheelEntry(PlayerStyle.CLASSIC, "Classic", Icons.Rounded.PlayCircle, MaterialShapes.Circle),
+        PlayerStyleWheelEntry(PlayerStyle.GESTURE, "Gesture", Icons.Rounded.SwipeRight, MaterialShapes.Pill),
+        PlayerStyleWheelEntry(PlayerStyle.EDITORIAL, "Editorial", Icons.Rounded.Newspaper, MaterialShapes.Flower),
+        PlayerStyleWheelEntry(PlayerStyle.POSTER, "Poster", Icons.Rounded.TextFields, MaterialShapes.Gem),
+        PlayerStyleWheelEntry(PlayerStyle.BENTO, "Bento", Icons.Rounded.GridView, MaterialShapes.Cookie4Sided),
+        PlayerStyleWheelEntry(PlayerStyle.STICKER, "Sticker", Icons.Rounded.Interests, MaterialShapes.Clover4Leaf),
+        PlayerStyleWheelEntry(PlayerStyle.MORPH, "Morph", Icons.Rounded.Animation, MaterialShapes.SoftBurst),
+        PlayerStyleWheelEntry(PlayerStyle.DIAL, "Dial", Icons.Rounded.RadioButtonChecked, MaterialShapes.Sunny)
+    )
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun PlayerStyleWheel(
+    currentStyle: PlayerStyle,
+    onStyleSelected: (PlayerStyle) -> Unit,
+    onDismiss: () -> Unit
+) {
+    BackHandler(enabled = true) { onDismiss() }
+    val entries = rememberPlayerStyleWheelEntries()
+    val haptics = LocalHapticFeedback.current
+
+    // Mark the open with the long-press haptic the gesture earned.
+    LaunchedEffect(Unit) {
+        haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+    }
+
+    // Staggered radial bloom: every item springs outward with overshoot.
+    val bloom = remember { entries.map { Animatable(0f) } }
+    val wheelSettle = remember { Animatable(0f) }
+    LaunchedEffect(Unit) {
+        launch {
+            wheelSettle.animateTo(
+                targetValue = 1f,
+                animationSpec = spring(
+                    dampingRatio = 0.7f,
+                    stiffness = Spring.StiffnessLow
+                )
+            )
+        }
+        bloom.forEachIndexed { index, animatable ->
+            launch {
+                delay(index * 35L)
+                animatable.animateTo(
+                    targetValue = 1f,
+                    animationSpec = spring(
+                        dampingRatio = 0.55f,
+                        stiffness = Spring.StiffnessMediumLow
+                    )
+                )
+            }
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        // Flat dismiss field: solid high-alpha surface, no blur, no scrim
+        // gradient. First child, so item touches never reach it.
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.96f))
+                .pointerInput(Unit) {
+                    detectTapGestures(onTap = { onDismiss() })
+                }
+        )
+
+        BoxWithConstraints(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            val radius = minOf(maxWidth, maxHeight) * 0.36f
+            val radiusPx = with(LocalDensity.current) { radius.toPx() }
+            val ringRotation = (1f - wheelSettle.value) * -24f
+
+            // Center readout: what you are on now.
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    text = "Player style",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center
+                )
+                Text(
+                    text = entries.firstOrNull { it.style == currentStyle }?.label ?: "",
+                    style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Center
+                )
+            }
+
+            entries.forEachIndexed { index, entry ->
+                val progress = bloom[index].value
+                val angleRad = Math.toRadians((index * 360.0 / entries.size) - 90.0)
+                val itemX = (cos(angleRad) * radiusPx * progress * wheelRotationCos(ringRotation) -
+                    sin(angleRad) * radiusPx * progress * wheelRotationSin(ringRotation)).roundToInt()
+                val itemY = (sin(angleRad) * radiusPx * progress * wheelRotationCos(ringRotation) +
+                    cos(angleRad) * radiusPx * progress * wheelRotationSin(ringRotation)).roundToInt()
+                val selected = entry.style == currentStyle
+                val itemShape = remember(entry.polygon) { EditorialPolygonShape(entry.polygon) }
+
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier
+                        .offset { IntOffset(itemX, itemY) }
+                        .graphicsLayer {
+                            alpha = progress.coerceIn(0f, 1f)
+                            val scale = progress * (if (selected) 1.12f else 1f)
+                            scaleX = scale
+                            scaleY = scale
+                        }
+                ) {
+                    Surface(
+                        onClick = {
+                            haptics.performHapticFeedback(HapticFeedbackType.Confirm)
+                            onStyleSelected(entry.style)
+                            onDismiss()
+                        },
+                        modifier = Modifier.size(64.dp),
+                        shape = itemShape,
+                        color = if (selected) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.surfaceContainerHigh,
+                        contentColor = if (selected) MaterialTheme.colorScheme.onPrimary
+                        else MaterialTheme.colorScheme.onSurface
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Icon(
+                                imageVector = entry.icon,
+                                contentDescription = entry.label,
+                                modifier = Modifier.size(26.dp)
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = entry.label,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = if (selected) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun wheelRotationCos(degrees: Float): Float =
+    cos(Math.toRadians(degrees.toDouble())).toFloat()
+
+private fun wheelRotationSin(degrees: Float): Float =
+    sin(Math.toRadians(degrees.toDouble())).toFloat()

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PosterPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PosterPlayerContent.kt
@@ -1,0 +1,570 @@
+package com.ivor.ivormusic.ui.player
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Repeat
+import androidx.compose.material.icons.filled.RepeatOne
+import androidx.compose.material.icons.filled.Shuffle
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material.icons.rounded.Lyrics
+import androidx.compose.material.icons.rounded.PlaylistAdd
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialShapes
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.graphics.shapes.Morph
+import androidx.media3.common.Player
+import com.ivor.ivormusic.ui.components.LikeBurstIcon
+import kotlinx.coroutines.delay
+
+/**
+ * Poster Player - the kinetic type style.
+ *
+ * The song title IS the screen: a stack of display-scale words on a flat
+ * field, like a letterpress gig poster. Pure-flat contract: no gradients,
+ * no shadows, no scrims.
+ *
+ * Signature moves:
+ * - Progress is a hard-edged highlighter fill sweeping through the title
+ *   glyphs themselves (played characters in primary, ahead in onSurface).
+ * - Play state is an oversized punctuation mark: a MaterialShapes burst
+ *   that slowly spins while playing and morphs to a full stop on pause.
+ * - Dragging horizontally across the words scrubs; a single seek fires on
+ *   release.
+ * - Controls are summoned by tapping the field and hide themselves again;
+ *   the resting screen is pure typography.
+ *
+ * See docs/PLAYER_STYLES_PURE_EXPRESSIVE_CONCEPTS.md section 1.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun PosterPlayerSheetContent(
+    viewModel: PlayerViewModel,
+    ambientBackground: Boolean = true,
+    onCollapse: () -> Unit,
+    onLoadMore: () -> Unit = {},
+    onArtistClick: (String) -> Unit = {}
+) {
+    BackHandler(enabled = true) { onCollapse() }
+
+    val currentSong by viewModel.currentSong.collectAsState()
+    val isPlaying by viewModel.isPlaying.collectAsState()
+    val isBuffering by viewModel.isBuffering.collectAsState()
+    val playWhenReady by viewModel.playWhenReady.collectAsState()
+    val progress by viewModel.progress.collectAsState()
+    val duration by viewModel.duration.collectAsState()
+    val shuffleModeEnabled by viewModel.shuffleModeEnabled.collectAsState()
+    val repeatMode by viewModel.repeatMode.collectAsState()
+    val currentQueue by viewModel.currentQueue.collectAsState()
+    val isFavorite by viewModel.isCurrentSongLiked.collectAsState()
+    val lyricsResult by viewModel.lyricsResult.collectAsState()
+    val isLoadingMore by viewModel.isLoadingMore.collectAsState()
+    val localPlaylists by viewModel.localPlaylists.collectAsState()
+
+    var showQueue by remember { mutableStateOf(false) }
+    var showLyrics by remember { mutableStateOf(false) }
+    var showAddToPlaylist by remember { mutableStateOf(false) }
+    var controlsVisible by remember { mutableStateOf(true) }
+
+    // Poster palette: quiet field, ink for unplayed type, primary for the
+    // sweep and every control. Roles only.
+    val field = MaterialTheme.colorScheme.surfaceContainerLowest
+    val ink = MaterialTheme.colorScheme.onSurface
+    val accent = MaterialTheme.colorScheme.primary
+    val onAccent = MaterialTheme.colorScheme.onPrimary
+
+    // Summoned controls: any tap on the field brings them back; they slip
+    // away on their own while music plays.
+    LaunchedEffect(controlsVisible, isPlaying) {
+        if (controlsVisible && isPlaying) {
+            delay(5000)
+            controlsVisible = false
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(field)
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null
+            ) { controlsVisible = true }
+    ) {
+        Crossfade(targetState = showQueue, label = "PosterQueueTransition") { queueVisible ->
+            if (queueVisible) {
+                EditorialQueueView(
+                    queue = currentQueue,
+                    currentSong = currentSong,
+                    onSongClick = { song -> viewModel.skipToSong(song) },
+                    onRemoveSong = { index -> viewModel.removeQueueItem(index) },
+                    onLoadMore = onLoadMore,
+                    isLoadingMore = isLoadingMore,
+                    onCollapse = onCollapse,
+                    onBackToPlayer = { showQueue = false },
+                    field = field,
+                    accent = ink
+                )
+            } else {
+                Column(modifier = Modifier.fillMaxSize()) {
+
+                    // ========== TOP BAR ==========
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .statusBarsPadding()
+                            .padding(horizontal = 20.dp, vertical = 12.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        EditorialCircleButton(
+                            onClick = onCollapse,
+                            accent = accent,
+                            field = onAccent,
+                            size = 44.dp
+                        ) {
+                            Icon(
+                                Icons.Default.KeyboardArrowDown, "Collapse",
+                                modifier = Modifier.size(26.dp)
+                            )
+                        }
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            EditorialCircleButton(
+                                onClick = { showAddToPlaylist = true },
+                                accent = accent,
+                                field = onAccent,
+                                size = 44.dp
+                            ) {
+                                Icon(
+                                    Icons.Rounded.PlaylistAdd, "Add to Playlist",
+                                    modifier = Modifier.size(22.dp)
+                                )
+                            }
+                            EditorialCircleButton(
+                                onClick = { showQueue = true },
+                                accent = accent,
+                                field = onAccent,
+                                size = 44.dp
+                            ) {
+                                Icon(
+                                    Icons.AutoMirrored.Filled.QueueMusic, "Queue",
+                                    modifier = Modifier.size(22.dp)
+                                )
+                            }
+                        }
+                    }
+
+                    // ========== THE POSTER (title stack or lyrics) ==========
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f)
+                    ) {
+                        Crossfade(targetState = showLyrics, label = "PosterLyrics") { lyricsVisible ->
+                            if (lyricsVisible) {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .padding(horizontal = 24.dp)
+                                ) {
+                                    SyncedLyricsView(
+                                        lyricsResult = lyricsResult,
+                                        currentPositionMs = progress,
+                                        onSeekTo = { viewModel.seekTo(it) },
+                                        ambientBackground = false,
+                                        primaryColor = accent,
+                                        onSurfaceColor = ink,
+                                        onSurfaceVariantColor = ink.copy(alpha = 0.6f)
+                                    )
+                                }
+                            } else {
+                                PosterTitleStack(
+                                    title = currentSong?.title
+                                        ?.takeIf { !it.startsWith("Unknown") } ?: "Untitled",
+                                    progress = progress,
+                                    duration = duration,
+                                    onSeekTo = { viewModel.seekTo(it) },
+                                    ink = ink,
+                                    accent = accent
+                                )
+                            }
+                        }
+                    }
+
+                    // ========== SIGNATURE ROW: glyph + artist + times ==========
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 24.dp, vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        PosterPunctuationGlyph(
+                            isPlaying = isPlaying,
+                            isBuffering = isBuffering && playWhenReady && !isPlaying,
+                            onTap = { viewModel.togglePlayPause() },
+                            accent = accent,
+                            onAccent = onAccent
+                        )
+                        Spacer(modifier = Modifier.width(16.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            val artistName = currentSong?.artist
+                                ?.takeIf { !it.startsWith("Unknown") } ?: "Unknown Artist"
+                            Text(
+                                text = artistName.uppercase(),
+                                style = MaterialTheme.typography.labelLarge.copy(letterSpacing = 2.sp),
+                                color = ink.copy(alpha = 0.8f),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier
+                                    .clip(RoundedCornerShape(8.dp))
+                                    .clickable(enabled = artistName != "Unknown Artist") {
+                                        onArtistClick(artistName)
+                                    }
+                                    .padding(vertical = 2.dp)
+                            )
+                            Text(
+                                text = "${formatEditorialTime(progress)} of ${formatEditorialTime(duration)}",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = ink.copy(alpha = 0.55f)
+                            )
+                        }
+                    }
+
+                    // ========== SUMMONED CONTROL DECK ==========
+                    AnimatedVisibility(
+                        visible = controlsVisible,
+                        enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
+                        exit = slideOutVertically(targetOffsetY = { it }) + fadeOut()
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 24.dp)
+                                .padding(top = 8.dp, bottom = 12.dp),
+                            horizontalArrangement = Arrangement.spacedBy(
+                                10.dp,
+                                Alignment.CenterHorizontally
+                            ),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            EditorialCircleButton(
+                                onClick = { viewModel.skipToPrevious() },
+                                accent = accent,
+                                field = onAccent,
+                                size = 56.dp
+                            ) {
+                                Icon(
+                                    Icons.Default.SkipPrevious, "Previous",
+                                    modifier = Modifier.size(28.dp)
+                                )
+                            }
+                            EditorialCircleButton(
+                                onClick = { viewModel.skipToNext() },
+                                accent = accent,
+                                field = onAccent,
+                                size = 56.dp
+                            ) {
+                                Icon(
+                                    Icons.Default.SkipNext, "Next",
+                                    modifier = Modifier.size(28.dp)
+                                )
+                            }
+                            EditorialChip(
+                                checked = isFavorite,
+                                onClick = { viewModel.toggleCurrentSongLike() },
+                                accent = accent,
+                                field = onAccent
+                            ) {
+                                LikeBurstIcon(isFavorite = isFavorite, iconSize = 20.dp)
+                            }
+                            EditorialChip(
+                                checked = shuffleModeEnabled,
+                                onClick = { viewModel.toggleShuffle() },
+                                accent = accent,
+                                field = onAccent
+                            ) {
+                                Icon(Icons.Default.Shuffle, "Shuffle", modifier = Modifier.size(20.dp))
+                            }
+                            EditorialChip(
+                                checked = repeatMode != Player.REPEAT_MODE_OFF,
+                                onClick = { viewModel.toggleRepeat() },
+                                accent = accent,
+                                field = onAccent
+                            ) {
+                                Icon(
+                                    if (repeatMode == Player.REPEAT_MODE_ONE) Icons.Default.RepeatOne
+                                    else Icons.Default.Repeat,
+                                    "Repeat",
+                                    modifier = Modifier.size(20.dp)
+                                )
+                            }
+                            EditorialChip(
+                                checked = showLyrics,
+                                onClick = { showLyrics = !showLyrics },
+                                accent = accent,
+                                field = onAccent
+                            ) {
+                                Icon(Icons.Rounded.Lyrics, "Lyrics", modifier = Modifier.size(20.dp))
+                            }
+                        }
+                    }
+
+                    Spacer(
+                        modifier = Modifier
+                            .navigationBarsPadding()
+                            .height(8.dp)
+                    )
+                }
+            }
+        }
+    }
+
+    if (showAddToPlaylist) {
+        AddToPlaylistSheet(
+            playlists = localPlaylists,
+            onPlaylistClick = { playlist ->
+                viewModel.addToPlaylist(playlist.id)
+                showAddToPlaylist = false
+            },
+            onCreateNewClick = { name, desc ->
+                viewModel.createPlaylist(name, desc)
+                showAddToPlaylist = false
+            },
+            onDismissRequest = { showAddToPlaylist = false }
+        )
+    }
+}
+
+/**
+ * The word stack: each word of the title on its own display-scale line.
+ * Playback progress sweeps a hard-edged accent fill through the glyphs,
+ * character-weighted across the words. Dragging horizontally anywhere on
+ * the stack scrubs; one seek fires on release.
+ */
+@Composable
+private fun PosterTitleStack(
+    title: String,
+    progress: Long,
+    duration: Long,
+    onSeekTo: (Long) -> Unit,
+    ink: Color,
+    accent: Color
+) {
+    val allWords = remember(title) { title.trim().split(Regex("\\s+")).filter { it.isNotBlank() } }
+    val words = remember(allWords) {
+        if (allWords.size > 5) allWords.take(4) + "…" else allWords.ifEmpty { listOf("Untitled") }
+    }
+    val charTotals = remember(words) {
+        val counts = words.map { it.length.coerceAtLeast(1) }
+        val total = counts.sum().toFloat()
+        var running = 0
+        counts.map { count ->
+            val start = running / total
+            running += count
+            start to running / total
+        }
+    }
+
+    var scrubFraction by remember { mutableStateOf<Float?>(null) }
+    var stackWidthPx by remember { mutableFloatStateOf(1f) }
+    // pointerInput captures its lambda once per key; read the live values
+    // through rememberUpdatedState so a drag starts from the real position.
+    val liveProgress by rememberUpdatedState(progress)
+    val liveDuration by rememberUpdatedState(duration)
+    val playedFraction = scrubFraction
+        ?: if (duration > 0) (progress.toFloat() / duration.toFloat()).coerceIn(0f, 1f) else 0f
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp)
+            .onSizeChanged { stackWidthPx = it.width.toFloat().coerceAtLeast(1f) }
+            .pointerInput(Unit) {
+                detectHorizontalDragGestures(
+                    onDragStart = {
+                        scrubFraction = if (liveDuration > 0) {
+                            (liveProgress.toFloat() / liveDuration.toFloat()).coerceIn(0f, 1f)
+                        } else 0f
+                    },
+                    onDragEnd = {
+                        scrubFraction?.let { onSeekTo((it * liveDuration).toLong()) }
+                        scrubFraction = null
+                    },
+                    onDragCancel = { scrubFraction = null },
+                    onHorizontalDrag = { change, dragAmount ->
+                        change.consume()
+                        scrubFraction = ((scrubFraction ?: 0f) + dragAmount / stackWidthPx)
+                            .coerceIn(0f, 1f)
+                    }
+                )
+            },
+        verticalArrangement = Arrangement.Center
+    ) {
+        val wordStyle = when {
+            words.maxOf { it.length } <= 8 -> MaterialTheme.typography.displayLarge
+            words.maxOf { it.length } <= 13 -> MaterialTheme.typography.displayMedium
+            else -> MaterialTheme.typography.displaySmall
+        }.copy(fontWeight = FontWeight.Black)
+
+        words.forEachIndexed { index, word ->
+            val (start, end) = charTotals[index]
+            val wordFraction = when {
+                playedFraction <= start -> 0f
+                playedFraction >= end -> 1f
+                else -> (playedFraction - start) / (end - start)
+            }
+            // Base ink word with a hard-clipped accent overlay: the
+            // highlighter sweep. Animate only the smoothly-progressing
+            // fraction, no crossfade.
+            val animatedWordFraction by animateFloatAsState(
+                targetValue = wordFraction,
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioNoBouncy,
+                    stiffness = Spring.StiffnessLow
+                ),
+                label = "PosterWordFill$index"
+            )
+            Box {
+                Text(
+                    text = word,
+                    style = wordStyle,
+                    color = ink,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = word,
+                    style = wordStyle,
+                    color = accent,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.drawWithContent {
+                        clipRect(right = size.width * animatedWordFraction) {
+                            this@drawWithContent.drawContent()
+                        }
+                    }
+                )
+            }
+        }
+    }
+}
+
+/**
+ * The oversized punctuation mark: a burst that slowly spins while music
+ * plays and morphs into a full stop when paused. Tapping it toggles
+ * playback - the shape is the play/pause control and its own feedback.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun PosterPunctuationGlyph(
+    isPlaying: Boolean,
+    isBuffering: Boolean,
+    onTap: () -> Unit,
+    accent: Color,
+    onAccent: Color
+) {
+    val burstToDot = remember { Morph(MaterialShapes.SoftBurst, MaterialShapes.Circle) }
+    val morphProgress by animateFloatAsState(
+        targetValue = if (isPlaying) 0f else 1f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessLow
+        ),
+        label = "PosterGlyphMorph"
+    )
+    val glyphShape = remember(morphProgress) { EditorialMorphShape(burstToDot, morphProgress) }
+
+    val spin = rememberInfiniteTransition(label = "PosterGlyphSpin")
+    val spinAngle by spin.animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 12000, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "PosterGlyphAngle"
+    )
+
+    Box(
+        modifier = Modifier
+            .size(64.dp)
+            .graphicsLayer { rotationZ = if (isPlaying) spinAngle else 0f }
+            .clip(glyphShape)
+            .background(accent)
+            .clickable { onTap() },
+        contentAlignment = Alignment.Center
+    ) {
+        if (isBuffering) {
+            LoadingIndicator(
+                modifier = Modifier.size(28.dp),
+                color = onAccent,
+                polygons = listOf(
+                    MaterialShapes.SoftBurst,
+                    MaterialShapes.Cookie9Sided,
+                    MaterialShapes.Pill,
+                    MaterialShapes.Sunny
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PosterPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PosterPlayerContent.kt
@@ -19,6 +19,7 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -103,7 +104,8 @@ fun PosterPlayerSheetContent(
     ambientBackground: Boolean = true,
     onCollapse: () -> Unit,
     onLoadMore: () -> Unit = {},
-    onArtistClick: (String) -> Unit = {}
+    onArtistClick: (String) -> Unit = {},
+    onRequestStyleSwitcher: () -> Unit = {}
 ) {
     BackHandler(enabled = true) { onCollapse() }
 
@@ -244,6 +246,7 @@ fun PosterPlayerSheetContent(
                                     progress = progress,
                                     duration = duration,
                                     onSeekTo = { viewModel.seekTo(it) },
+                                    onLongPress = onRequestStyleSwitcher,
                                     ink = ink,
                                     accent = accent
                                 )
@@ -407,6 +410,7 @@ private fun PosterTitleStack(
     progress: Long,
     duration: Long,
     onSeekTo: (Long) -> Unit,
+    onLongPress: () -> Unit,
     ink: Color,
     accent: Color
 ) {
@@ -439,6 +443,9 @@ private fun PosterTitleStack(
             .fillMaxSize()
             .padding(horizontal = 24.dp)
             .onSizeChanged { stackWidthPx = it.width.toFloat().coerceAtLeast(1f) }
+            .pointerInput(Unit) {
+                detectTapGestures(onLongPress = { onLongPress() })
+            }
             .pointerInput(Unit) {
                 detectHorizontalDragGestures(
                     onDragStart = {

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/StickerPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/StickerPlayerContent.kt
@@ -1,0 +1,689 @@
+package com.ivor.ivormusic.ui.player
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.VectorConverter
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Repeat
+import androidx.compose.material.icons.filled.RepeatOne
+import androidx.compose.material.icons.filled.Shuffle
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material.icons.rounded.Lyrics
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.PlaylistAdd
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearWavyProgressIndicator
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialShapes
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.media3.common.Player
+import coil.compose.AsyncImage
+import com.ivor.ivormusic.data.Song
+import com.ivor.ivormusic.ui.components.LikeBurstIcon
+import kotlin.math.abs
+import kotlinx.coroutines.launch
+
+/**
+ * Sticker Player - the die-cut playful style.
+ *
+ * The album art is die-cut into a per-track MaterialShapes sticker slapped
+ * at a slight angle onto a flat color-block board. Pure-flat contract: the
+ * sticker's "lift" is a thick flat outline ring plus its resting tilt, not
+ * a shadow.
+ *
+ * Signature moves:
+ * - The sticker is grabbable: small drags rubber-band back with an
+ *   underdamped spring; a committed horizontal drag peels it off screen and
+ *   the next track's sticker slaps on with an overshooting entrance.
+ * - Tap squashes and stretches the sticker (and toggles playback); the
+ *   action commits immediately, the animation follows.
+ * - It sways almost imperceptibly while music plays and sits perfectly
+ *   straight when paused.
+ * - Each track gets its own die-cut shape - the cut is part of the song's
+ *   identity.
+ *
+ * See docs/PLAYER_STYLES_PURE_EXPRESSIVE_CONCEPTS.md section 4.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun StickerPlayerSheetContent(
+    viewModel: PlayerViewModel,
+    ambientBackground: Boolean = true,
+    onCollapse: () -> Unit,
+    onLoadMore: () -> Unit = {},
+    onArtistClick: (String) -> Unit = {}
+) {
+    BackHandler(enabled = true) { onCollapse() }
+
+    val currentSong by viewModel.currentSong.collectAsState()
+    val isPlaying by viewModel.isPlaying.collectAsState()
+    val isBuffering by viewModel.isBuffering.collectAsState()
+    val playWhenReady by viewModel.playWhenReady.collectAsState()
+    val progress by viewModel.progress.collectAsState()
+    val duration by viewModel.duration.collectAsState()
+    val shuffleModeEnabled by viewModel.shuffleModeEnabled.collectAsState()
+    val repeatMode by viewModel.repeatMode.collectAsState()
+    val currentQueue by viewModel.currentQueue.collectAsState()
+    val isFavorite by viewModel.isCurrentSongLiked.collectAsState()
+    val lyricsResult by viewModel.lyricsResult.collectAsState()
+    val isLoadingMore by viewModel.isLoadingMore.collectAsState()
+    val localPlaylists by viewModel.localPlaylists.collectAsState()
+
+    var showQueue by remember { mutableStateOf(false) }
+    var showLyrics by remember { mutableStateOf(false) }
+    var showAddToPlaylist by remember { mutableStateOf(false) }
+
+    // Color-block board: two flat tonal fields meeting on a hard edge.
+    val boardTop = MaterialTheme.colorScheme.surfaceContainerLow
+    val boardBottom = MaterialTheme.colorScheme.surfaceContainerLowest
+    val ink = MaterialTheme.colorScheme.onSurface
+    val inkVariant = MaterialTheme.colorScheme.onSurfaceVariant
+    val chipColor = MaterialTheme.colorScheme.secondaryContainer
+    val onChip = MaterialTheme.colorScheme.onSecondaryContainer
+    val accent = MaterialTheme.colorScheme.primary
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        // Board background: hard two-block split, no gradient.
+        Column(modifier = Modifier.fillMaxSize()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(0.45f)
+                    .background(boardTop)
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(0.55f)
+                    .background(boardBottom)
+            )
+        }
+
+        Crossfade(targetState = showQueue, label = "StickerQueueTransition") { queueVisible ->
+            if (queueVisible) {
+                EditorialQueueView(
+                    queue = currentQueue,
+                    currentSong = currentSong,
+                    onSongClick = { song -> viewModel.skipToSong(song) },
+                    onRemoveSong = { index -> viewModel.removeQueueItem(index) },
+                    onLoadMore = onLoadMore,
+                    isLoadingMore = isLoadingMore,
+                    onCollapse = onCollapse,
+                    onBackToPlayer = { showQueue = false },
+                    field = boardBottom,
+                    accent = ink
+                )
+            } else {
+                Column(modifier = Modifier.fillMaxSize()) {
+
+                    // ========== TOP BAR ==========
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .statusBarsPadding()
+                            .padding(horizontal = 20.dp, vertical = 12.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        EditorialCircleButton(
+                            onClick = onCollapse,
+                            accent = chipColor,
+                            field = onChip,
+                            size = 44.dp
+                        ) {
+                            Icon(
+                                Icons.Default.KeyboardArrowDown, "Collapse",
+                                modifier = Modifier.size(26.dp)
+                            )
+                        }
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            EditorialCircleButton(
+                                onClick = { showAddToPlaylist = true },
+                                accent = chipColor,
+                                field = onChip,
+                                size = 44.dp
+                            ) {
+                                Icon(
+                                    Icons.Rounded.PlaylistAdd, "Add to Playlist",
+                                    modifier = Modifier.size(22.dp)
+                                )
+                            }
+                            EditorialCircleButton(
+                                onClick = { showQueue = true },
+                                accent = chipColor,
+                                field = onChip,
+                                size = 44.dp
+                            ) {
+                                Icon(
+                                    Icons.AutoMirrored.Filled.QueueMusic, "Queue",
+                                    modifier = Modifier.size(22.dp)
+                                )
+                            }
+                        }
+                    }
+
+                    // ========== THE STICKER ==========
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f)
+                    ) {
+                        Crossfade(targetState = showLyrics, label = "StickerLyrics") { lyricsVisible ->
+                            if (lyricsVisible) {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .padding(horizontal = 24.dp)
+                                ) {
+                                    SyncedLyricsView(
+                                        lyricsResult = lyricsResult,
+                                        currentPositionMs = progress,
+                                        onSeekTo = { viewModel.seekTo(it) },
+                                        ambientBackground = false,
+                                        primaryColor = accent,
+                                        onSurfaceColor = ink,
+                                        onSurfaceVariantColor = inkVariant
+                                    )
+                                }
+                            } else {
+                                DraggableSticker(
+                                    currentSong = currentSong,
+                                    isPlaying = isPlaying,
+                                    isBuffering = isBuffering && playWhenReady && !isPlaying,
+                                    onPlayPause = { viewModel.togglePlayPause() },
+                                    onLike = { viewModel.toggleCurrentSongLike() },
+                                    onNext = { viewModel.skipToNext() },
+                                    onPrevious = { viewModel.skipToPrevious() },
+                                    ringColor = chipColor,
+                                    placeholderColor = chipColor,
+                                    placeholderIconColor = onChip
+                                )
+                            }
+                        }
+                    }
+
+                    // ========== TITLE / ARTIST ==========
+                    Text(
+                        text = currentSong?.title?.takeIf { !it.startsWith("Unknown") } ?: "Untitled",
+                        style = MaterialTheme.typography.headlineLarge.copy(fontWeight = FontWeight.Black),
+                        color = ink,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 24.dp)
+                    )
+                    val artistName = currentSong?.artist?.takeIf { !it.startsWith("Unknown") }
+                        ?: "Unknown Artist"
+                    Text(
+                        text = artistName.uppercase(),
+                        style = MaterialTheme.typography.labelLarge.copy(letterSpacing = 2.sp),
+                        color = inkVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .align(Alignment.CenterHorizontally)
+                            .clip(RoundedCornerShape(8.dp))
+                            .clickable(enabled = artistName != "Unknown Artist") {
+                                onArtistClick(artistName)
+                            }
+                            .padding(horizontal = 8.dp, vertical = 4.dp)
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    // ========== PROGRESS ==========
+                    Column(modifier = Modifier.padding(horizontal = 24.dp)) {
+                        var scrubPosition by remember { mutableStateOf<Float?>(null) }
+                        val displayedProgress = scrubPosition?.toLong() ?: progress
+                        val fraction = if (duration > 0) {
+                            displayedProgress.toFloat() / duration.toFloat()
+                        } else 0f
+                        val animatedFraction by animateFloatAsState(
+                            targetValue = fraction.coerceIn(0f, 1f),
+                            animationSpec = spring(
+                                dampingRatio = Spring.DampingRatioNoBouncy,
+                                stiffness = Spring.StiffnessLow
+                            ),
+                            label = "StickerProgress"
+                        )
+                        val lineStroke = Stroke(
+                            width = with(LocalDensity.current) { 4.dp.toPx() },
+                            cap = StrokeCap.Round
+                        )
+                        Box(contentAlignment = Alignment.Center) {
+                            LinearWavyProgressIndicator(
+                                progress = { animatedFraction },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(14.dp),
+                                color = accent,
+                                trackColor = inkVariant.copy(alpha = 0.25f),
+                                stroke = lineStroke,
+                                trackStroke = lineStroke,
+                                amplitude = { if (isPlaying) 1f else 0f }
+                            )
+                            Slider(
+                                value = scrubPosition ?: progress.toFloat(),
+                                onValueChange = { scrubPosition = it },
+                                onValueChangeFinished = {
+                                    scrubPosition?.let { viewModel.seekTo(it.toLong()) }
+                                    scrubPosition = null
+                                },
+                                valueRange = 0f..(duration.toFloat().coerceAtLeast(1f)),
+                                colors = SliderDefaults.colors(
+                                    thumbColor = Color.Transparent,
+                                    activeTrackColor = Color.Transparent,
+                                    inactiveTrackColor = Color.Transparent
+                                ),
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        }
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text(
+                                text = formatEditorialTime(displayedProgress),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = inkVariant
+                            )
+                            Text(
+                                text = formatEditorialTime(duration),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = inkVariant
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    // ========== CHIPS ==========
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.CenterHorizontally),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        EditorialCircleButton(
+                            onClick = { viewModel.skipToPrevious() },
+                            accent = chipColor,
+                            field = onChip,
+                            size = 56.dp
+                        ) {
+                            Icon(
+                                Icons.Default.SkipPrevious, "Previous",
+                                modifier = Modifier.size(28.dp)
+                            )
+                        }
+                        EditorialCircleButton(
+                            onClick = { viewModel.skipToNext() },
+                            accent = chipColor,
+                            field = onChip,
+                            size = 56.dp
+                        ) {
+                            Icon(Icons.Default.SkipNext, "Next", modifier = Modifier.size(28.dp))
+                        }
+                        EditorialChip(
+                            checked = isFavorite,
+                            onClick = { viewModel.toggleCurrentSongLike() },
+                            accent = chipColor,
+                            field = onChip
+                        ) {
+                            LikeBurstIcon(isFavorite = isFavorite, iconSize = 20.dp)
+                        }
+                        EditorialChip(
+                            checked = shuffleModeEnabled,
+                            onClick = { viewModel.toggleShuffle() },
+                            accent = chipColor,
+                            field = onChip
+                        ) {
+                            Icon(Icons.Default.Shuffle, "Shuffle", modifier = Modifier.size(20.dp))
+                        }
+                        EditorialChip(
+                            checked = repeatMode != Player.REPEAT_MODE_OFF,
+                            onClick = { viewModel.toggleRepeat() },
+                            accent = chipColor,
+                            field = onChip
+                        ) {
+                            Icon(
+                                if (repeatMode == Player.REPEAT_MODE_ONE) Icons.Default.RepeatOne
+                                else Icons.Default.Repeat,
+                                "Repeat",
+                                modifier = Modifier.size(20.dp)
+                            )
+                        }
+                        EditorialChip(
+                            checked = showLyrics,
+                            onClick = { showLyrics = !showLyrics },
+                            accent = chipColor,
+                            field = onChip
+                        ) {
+                            Icon(Icons.Rounded.Lyrics, "Lyrics", modifier = Modifier.size(20.dp))
+                        }
+                    }
+
+                    Spacer(
+                        modifier = Modifier
+                            .navigationBarsPadding()
+                            .height(8.dp)
+                    )
+                }
+            }
+        }
+    }
+
+    if (showAddToPlaylist) {
+        AddToPlaylistSheet(
+            playlists = localPlaylists,
+            onPlaylistClick = { playlist ->
+                viewModel.addToPlaylist(playlist.id)
+                showAddToPlaylist = false
+            },
+            onCreateNewClick = { name, desc ->
+                viewModel.createPlaylist(name, desc)
+                showAddToPlaylist = false
+            },
+            onDismissRequest = { showAddToPlaylist = false }
+        )
+    }
+}
+
+/**
+ * The grabbable sticker. Tap = play/pause with squash-and-stretch,
+ * double-tap = like with a pop, small drags rubber-band home, committed
+ * horizontal drags peel the sticker away and skip.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun DraggableSticker(
+    currentSong: Song?,
+    isPlaying: Boolean,
+    isBuffering: Boolean,
+    onPlayPause: () -> Unit,
+    onLike: () -> Unit,
+    onNext: () -> Unit,
+    onPrevious: () -> Unit,
+    ringColor: Color,
+    placeholderColor: Color,
+    placeholderIconColor: Color
+) {
+    val dieCuts = remember {
+        listOf(
+            MaterialShapes.Clover4Leaf,
+            MaterialShapes.Sunny,
+            MaterialShapes.Cookie9Sided,
+            MaterialShapes.Flower,
+            MaterialShapes.Gem,
+            MaterialShapes.Puffy
+        )
+    }
+    val polygon = remember(currentSong?.id) {
+        dieCuts[abs(currentSong?.id?.hashCode() ?: 0) % dieCuts.size]
+    }
+    val shape = remember(polygon) { EditorialPolygonShape(polygon) }
+
+    val scope = rememberCoroutineScope()
+    val offset = remember { Animatable(Offset.Zero, Offset.VectorConverter) }
+    val scaleX = remember { Animatable(1f) }
+    val scaleY = remember { Animatable(1f) }
+    var peeling by remember { mutableStateOf(false) }
+
+    val currentOnNext by rememberUpdatedState(onNext)
+    val currentOnPrevious by rememberUpdatedState(onPrevious)
+    val currentOnPlayPause by rememberUpdatedState(onPlayPause)
+    val currentOnLike by rememberUpdatedState(onLike)
+
+    // New track: the fresh sticker slaps on with an overshooting entrance.
+    LaunchedEffect(currentSong?.id) {
+        scaleX.snapTo(0.7f)
+        scaleY.snapTo(0.7f)
+        launch {
+            scaleX.animateTo(
+                1f,
+                spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMediumLow)
+            )
+        }
+        scaleY.animateTo(
+            1f,
+            spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMediumLow)
+        )
+    }
+
+    // Sway while playing, sit straight when paused. The spring chases a
+    // moving target while playing so the pause settle is smooth.
+    val infinite = rememberInfiniteTransition(label = "StickerSway")
+    val sway by infinite.animateFloat(
+        initialValue = -2f,
+        targetValue = 4f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 2200, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "StickerSwayValue"
+    )
+    val tilt by animateFloatAsState(
+        targetValue = if (isPlaying) sway else 0f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioNoBouncy,
+            stiffness = Spring.StiffnessLow
+        ),
+        label = "StickerTilt"
+    )
+
+    BoxWithConstraints(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        if (maxWidth < 50.dp || maxHeight < 50.dp) return@BoxWithConstraints
+        val stickerSize = minOf(maxWidth, maxHeight) * 0.78f
+        val peelThresholdPx = with(LocalDensity.current) { 110.dp.toPx() }
+        val peelDistancePx = with(LocalDensity.current) { maxWidth.toPx() * 1.2f }
+
+        Box(
+            modifier = Modifier
+                .size(stickerSize)
+                .graphicsLayer {
+                    translationX = offset.value.x
+                    translationY = offset.value.y
+                    rotationZ = tilt + offset.value.x / 40f
+                    this.scaleX = scaleX.value
+                    this.scaleY = scaleY.value
+                }
+                .border(width = 7.dp, color = ringColor, shape = shape)
+                .clip(shape)
+                .background(placeholderColor)
+                .pointerInput(Unit) {
+                    detectTapGestures(
+                        onTap = {
+                            currentOnPlayPause()
+                            scope.launch {
+                                scaleX.snapTo(1.12f)
+                                scaleY.snapTo(0.86f)
+                                launch {
+                                    scaleX.animateTo(
+                                        1f,
+                                        spring(
+                                            dampingRatio = Spring.DampingRatioMediumBouncy,
+                                            stiffness = Spring.StiffnessMedium
+                                        )
+                                    )
+                                }
+                                scaleY.animateTo(
+                                    1f,
+                                    spring(
+                                        dampingRatio = Spring.DampingRatioMediumBouncy,
+                                        stiffness = Spring.StiffnessMedium
+                                    )
+                                )
+                            }
+                        },
+                        onDoubleTap = {
+                            currentOnLike()
+                            scope.launch {
+                                scaleX.snapTo(1.18f)
+                                scaleY.snapTo(1.18f)
+                                launch {
+                                    scaleX.animateTo(
+                                        1f,
+                                        spring(
+                                            dampingRatio = Spring.DampingRatioMediumBouncy,
+                                            stiffness = Spring.StiffnessMedium
+                                        )
+                                    )
+                                }
+                                scaleY.animateTo(
+                                    1f,
+                                    spring(
+                                        dampingRatio = Spring.DampingRatioMediumBouncy,
+                                        stiffness = Spring.StiffnessMedium
+                                    )
+                                )
+                            }
+                        }
+                    )
+                }
+                .pointerInput(Unit) {
+                    detectDragGestures(
+                        onDrag = { change, dragAmount ->
+                            change.consume()
+                            if (peeling) return@detectDragGestures
+                            scope.launch { offset.snapTo(offset.value + dragAmount) }
+                        },
+                        onDragEnd = {
+                            if (peeling) return@detectDragGestures
+                            val dx = offset.value.x
+                            if (abs(dx) > peelThresholdPx) {
+                                peeling = true
+                                scope.launch {
+                                    // Peel away in the drag direction, skip,
+                                    // then let the new sticker slap on.
+                                    val direction = if (dx > 0) 1f else -1f
+                                    offset.animateTo(
+                                        Offset(direction * peelDistancePx, offset.value.y),
+                                        tween(durationMillis = 220)
+                                    )
+                                    if (direction > 0) currentOnPrevious() else currentOnNext()
+                                    offset.snapTo(Offset.Zero)
+                                    peeling = false
+                                }
+                            } else {
+                                scope.launch {
+                                    // Rubber-band home, underdamped on purpose.
+                                    offset.animateTo(
+                                        Offset.Zero,
+                                        spring(
+                                            dampingRatio = 0.35f,
+                                            stiffness = Spring.StiffnessLow
+                                        )
+                                    )
+                                }
+                            }
+                        },
+                        onDragCancel = {
+                            if (!peeling) {
+                                scope.launch { offset.animateTo(Offset.Zero, spring()) }
+                            }
+                        }
+                    )
+                },
+            contentAlignment = Alignment.Center
+        ) {
+            val artModel = currentSong?.highResThumbnailUrl
+                ?: currentSong?.thumbnailUrl
+                ?: currentSong?.albumArtUri
+            if (artModel != null) {
+                AsyncImage(
+                    model = artModel,
+                    contentDescription = "Album Art",
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
+                )
+            } else {
+                Icon(
+                    imageVector = Icons.Rounded.MusicNote,
+                    contentDescription = null,
+                    tint = placeholderIconColor,
+                    modifier = Modifier.size(stickerSize * 0.3f)
+                )
+            }
+            if (isBuffering) {
+                LoadingIndicator(
+                    modifier = Modifier.size(40.dp),
+                    color = ringColor,
+                    polygons = listOf(
+                        MaterialShapes.SoftBurst,
+                        MaterialShapes.Cookie9Sided,
+                        MaterialShapes.Pill,
+                        MaterialShapes.Sunny
+                    )
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/StickerPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/StickerPlayerContent.kt
@@ -113,7 +113,8 @@ fun StickerPlayerSheetContent(
     ambientBackground: Boolean = true,
     onCollapse: () -> Unit,
     onLoadMore: () -> Unit = {},
-    onArtistClick: (String) -> Unit = {}
+    onArtistClick: (String) -> Unit = {},
+    onRequestStyleSwitcher: () -> Unit = {}
 ) {
     BackHandler(enabled = true) { onCollapse() }
 
@@ -256,6 +257,7 @@ fun StickerPlayerSheetContent(
                                     onLike = { viewModel.toggleCurrentSongLike() },
                                     onNext = { viewModel.skipToNext() },
                                     onPrevious = { viewModel.skipToPrevious() },
+                                    onLongPress = onRequestStyleSwitcher,
                                     ringColor = chipColor,
                                     placeholderColor = chipColor,
                                     placeholderIconColor = onChip
@@ -469,6 +471,7 @@ private fun DraggableSticker(
     onLike: () -> Unit,
     onNext: () -> Unit,
     onPrevious: () -> Unit,
+    onLongPress: () -> Unit,
     ringColor: Color,
     placeholderColor: Color,
     placeholderIconColor: Color
@@ -498,6 +501,7 @@ private fun DraggableSticker(
     val currentOnPrevious by rememberUpdatedState(onPrevious)
     val currentOnPlayPause by rememberUpdatedState(onPlayPause)
     val currentOnLike by rememberUpdatedState(onLike)
+    val currentOnLongPress by rememberUpdatedState(onLongPress)
 
     // New track: the fresh sticker slaps on with an overshooting entrance.
     LaunchedEffect(currentSong?.id) {
@@ -560,6 +564,7 @@ private fun DraggableSticker(
                 .background(placeholderColor)
                 .pointerInput(Unit) {
                     detectTapGestures(
+                        onLongPress = { currentOnLongPress() },
                         onTap = {
                             currentOnPlayPause()
                             scope.launch {

--- a/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
@@ -55,12 +55,14 @@ import androidx.compose.material.icons.rounded.FolderOff
 import androidx.compose.material.icons.rounded.Info
 import androidx.compose.material.icons.rounded.LightMode
 import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.Newspaper
 import androidx.compose.material.icons.rounded.Palette
 import androidx.compose.material.icons.rounded.PlayCircle
 import androidx.compose.material.icons.rounded.Security
 import androidx.compose.material.icons.rounded.FlashOn
 import androidx.compose.material.icons.rounded.HighQuality
 import androidx.compose.material.icons.rounded.SwipeRight
+import androidx.compose.material.icons.rounded.TextFields
 import androidx.compose.material.icons.rounded.ToggleOn
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -1590,7 +1592,12 @@ private fun ExpressivePlayerStyleSelectItem(
     secondaryTextColor: Color,
     accentColor: Color
 ) {
-    val options = listOf("Classic" to PlayerStyle.CLASSIC, "Gesture" to PlayerStyle.GESTURE)
+    val options = listOf(
+        "Classic" to PlayerStyle.CLASSIC,
+        "Gesture" to PlayerStyle.GESTURE,
+        "Editorial" to PlayerStyle.EDITORIAL,
+        "Poster" to PlayerStyle.POSTER
+    )
     
     Column(
         modifier = Modifier
@@ -1611,10 +1618,12 @@ private fun ExpressivePlayerStyleSelectItem(
                 contentAlignment = Alignment.Center
             ) {
                 Icon(
-                    imageVector = if (currentStyle == PlayerStyle.GESTURE) 
-                        Icons.Rounded.SwipeRight 
-                    else 
-                        Icons.Rounded.PlayCircle,
+                    imageVector = when (currentStyle) {
+                        PlayerStyle.CLASSIC -> Icons.Rounded.PlayCircle
+                        PlayerStyle.GESTURE -> Icons.Rounded.SwipeRight
+                        PlayerStyle.EDITORIAL -> Icons.Rounded.Newspaper
+                        PlayerStyle.POSTER -> Icons.Rounded.TextFields
+                    },
                     contentDescription = null,
                     tint = accentColor,
                     modifier = Modifier.size(26.dp)
@@ -1636,6 +1645,8 @@ private fun ExpressivePlayerStyleSelectItem(
                     text = when (currentStyle) {
                         PlayerStyle.CLASSIC -> "Button controls for playback"
                         PlayerStyle.GESTURE -> "Swipe album art to navigate"
+                        PlayerStyle.EDITORIAL -> "Two-tone magazine layout"
+                        PlayerStyle.POSTER -> "Kinetic type, title as progress"
                     },
                     color = secondaryTextColor,
                     fontSize = 13.sp
@@ -1660,7 +1671,12 @@ private fun ExpressivePlayerStyleSelectItem(
                     icon = {
                         SegmentedButtonDefaults.Icon(active = currentStyle == style) {
                             Icon(
-                                imageVector = if (index == 0) Icons.Rounded.PlayCircle else Icons.Rounded.SwipeRight,
+                                imageVector = when (style) {
+                                    PlayerStyle.CLASSIC -> Icons.Rounded.PlayCircle
+                                    PlayerStyle.GESTURE -> Icons.Rounded.SwipeRight
+                                    PlayerStyle.EDITORIAL -> Icons.Rounded.Newspaper
+                                    PlayerStyle.POSTER -> Icons.Rounded.TextFields
+                                },
                                 contentDescription = null,
                                 modifier = Modifier.size(18.dp)
                             )

--- a/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.material.icons.automirrored.rounded.Logout
 import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import androidx.compose.material.icons.rounded.AccountCircle
 import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.Animation
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.ChevronRight
 import androidx.compose.material.icons.rounded.Close
@@ -1601,7 +1602,8 @@ private val playerStyleOptions = listOf(
     PlayerStyleOption(PlayerStyle.EDITORIAL, "Editorial", "Two-tone magazine layout", Icons.Rounded.Newspaper),
     PlayerStyleOption(PlayerStyle.POSTER, "Poster", "Kinetic type, title as progress", Icons.Rounded.TextFields),
     PlayerStyleOption(PlayerStyle.BENTO, "Bento", "Squishy grid of flat tiles", Icons.Rounded.GridView),
-    PlayerStyleOption(PlayerStyle.STICKER, "Sticker", "Die-cut art with toy physics", Icons.Rounded.Interests)
+    PlayerStyleOption(PlayerStyle.STICKER, "Sticker", "Die-cut art with toy physics", Icons.Rounded.Interests),
+    PlayerStyleOption(PlayerStyle.MORPH, "Morph", "Living shape that breathes", Icons.Rounded.Animation)
 )
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)

--- a/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.material.icons.rounded.Folder
 import androidx.compose.material.icons.rounded.FolderOff
 import androidx.compose.material.icons.rounded.GridView
 import androidx.compose.material.icons.rounded.Info
+import androidx.compose.material.icons.rounded.Interests
 import androidx.compose.material.icons.rounded.LightMode
 import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material.icons.rounded.Newspaper
@@ -1599,7 +1600,8 @@ private val playerStyleOptions = listOf(
     PlayerStyleOption(PlayerStyle.GESTURE, "Gesture", "Swipe album art to navigate", Icons.Rounded.SwipeRight),
     PlayerStyleOption(PlayerStyle.EDITORIAL, "Editorial", "Two-tone magazine layout", Icons.Rounded.Newspaper),
     PlayerStyleOption(PlayerStyle.POSTER, "Poster", "Kinetic type, title as progress", Icons.Rounded.TextFields),
-    PlayerStyleOption(PlayerStyle.BENTO, "Bento", "Squishy grid of flat tiles", Icons.Rounded.GridView)
+    PlayerStyleOption(PlayerStyle.BENTO, "Bento", "Squishy grid of flat tiles", Icons.Rounded.GridView),
+    PlayerStyleOption(PlayerStyle.STICKER, "Sticker", "Die-cut art with toy physics", Icons.Rounded.Interests)
 )
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)

--- a/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -52,6 +54,7 @@ import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.SystemUpdate
 import androidx.compose.material.icons.rounded.Folder
 import androidx.compose.material.icons.rounded.FolderOff
+import androidx.compose.material.icons.rounded.GridView
 import androidx.compose.material.icons.rounded.Info
 import androidx.compose.material.icons.rounded.LightMode
 import androidx.compose.material.icons.rounded.MusicNote
@@ -84,6 +87,7 @@ import androidx.compose.material.icons.rounded.VideoLibrary
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.RadioButton
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
@@ -1583,7 +1587,22 @@ private fun ExpressiveSaveHistoryToggleItem(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
+private data class PlayerStyleOption(
+    val style: PlayerStyle,
+    val label: String,
+    val subtitle: String,
+    val icon: androidx.compose.ui.graphics.vector.ImageVector
+)
+
+private val playerStyleOptions = listOf(
+    PlayerStyleOption(PlayerStyle.CLASSIC, "Classic", "Button controls for playback", Icons.Rounded.PlayCircle),
+    PlayerStyleOption(PlayerStyle.GESTURE, "Gesture", "Swipe album art to navigate", Icons.Rounded.SwipeRight),
+    PlayerStyleOption(PlayerStyle.EDITORIAL, "Editorial", "Two-tone magazine layout", Icons.Rounded.Newspaper),
+    PlayerStyleOption(PlayerStyle.POSTER, "Poster", "Kinetic type, title as progress", Icons.Rounded.TextFields),
+    PlayerStyleOption(PlayerStyle.BENTO, "Bento", "Squishy grid of flat tiles", Icons.Rounded.GridView)
+)
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 private fun ExpressivePlayerStyleSelectItem(
     currentStyle: PlayerStyle,
@@ -1592,13 +1611,9 @@ private fun ExpressivePlayerStyleSelectItem(
     secondaryTextColor: Color,
     accentColor: Color
 ) {
-    val options = listOf(
-        "Classic" to PlayerStyle.CLASSIC,
-        "Gesture" to PlayerStyle.GESTURE,
-        "Editorial" to PlayerStyle.EDITORIAL,
-        "Poster" to PlayerStyle.POSTER
-    )
-    
+    val current = playerStyleOptions.firstOrNull { it.style == currentStyle }
+        ?: playerStyleOptions.first()
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -1618,12 +1633,7 @@ private fun ExpressivePlayerStyleSelectItem(
                 contentAlignment = Alignment.Center
             ) {
                 Icon(
-                    imageVector = when (currentStyle) {
-                        PlayerStyle.CLASSIC -> Icons.Rounded.PlayCircle
-                        PlayerStyle.GESTURE -> Icons.Rounded.SwipeRight
-                        PlayerStyle.EDITORIAL -> Icons.Rounded.Newspaper
-                        PlayerStyle.POSTER -> Icons.Rounded.TextFields
-                    },
+                    imageVector = current.icon,
                     contentDescription = null,
                     tint = accentColor,
                     modifier = Modifier.size(26.dp)
@@ -1642,49 +1652,34 @@ private fun ExpressivePlayerStyleSelectItem(
                 )
                 Spacer(modifier = Modifier.height(2.dp))
                 Text(
-                    text = when (currentStyle) {
-                        PlayerStyle.CLASSIC -> "Button controls for playback"
-                        PlayerStyle.GESTURE -> "Swipe album art to navigate"
-                        PlayerStyle.EDITORIAL -> "Two-tone magazine layout"
-                        PlayerStyle.POSTER -> "Kinetic type, title as progress"
-                    },
+                    text = current.subtitle,
                     color = secondaryTextColor,
                     fontSize = 13.sp
                 )
             }
         }
-        
-        Spacer(modifier = Modifier.height(16.dp))
-        
-        // Segmented Button Row
-        SingleChoiceSegmentedButtonRow(
-            modifier = Modifier.fillMaxWidth()
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // Wrapping chip grid - scales past the point where a segmented row
+        // stops fitting.
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            options.forEachIndexed { index, (label, style) ->
-                SegmentedButton(
-                    selected = currentStyle == style,
-                    onClick = { onStyleSelected(style) },
-                    shape = SegmentedButtonDefaults.itemShape(
-                        index = index,
-                        count = options.size
-                    ),
-                    icon = {
-                        SegmentedButtonDefaults.Icon(active = currentStyle == style) {
-                            Icon(
-                                imageVector = when (style) {
-                                    PlayerStyle.CLASSIC -> Icons.Rounded.PlayCircle
-                                    PlayerStyle.GESTURE -> Icons.Rounded.SwipeRight
-                                    PlayerStyle.EDITORIAL -> Icons.Rounded.Newspaper
-                                    PlayerStyle.POSTER -> Icons.Rounded.TextFields
-                                },
-                                contentDescription = null,
-                                modifier = Modifier.size(18.dp)
-                            )
-                        }
+            playerStyleOptions.forEach { option ->
+                FilterChip(
+                    selected = currentStyle == option.style,
+                    onClick = { onStyleSelected(option.style) },
+                    label = { Text(option.label) },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = option.icon,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp)
+                        )
                     }
-                ) {
-                    Text(label)
-                }
+                )
             }
         }
     }

--- a/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material.icons.rounded.Newspaper
 import androidx.compose.material.icons.rounded.Palette
 import androidx.compose.material.icons.rounded.PlayCircle
+import androidx.compose.material.icons.rounded.RadioButtonChecked
 import androidx.compose.material.icons.rounded.Security
 import androidx.compose.material.icons.rounded.FlashOn
 import androidx.compose.material.icons.rounded.HighQuality
@@ -1603,7 +1604,8 @@ private val playerStyleOptions = listOf(
     PlayerStyleOption(PlayerStyle.POSTER, "Poster", "Kinetic type, title as progress", Icons.Rounded.TextFields),
     PlayerStyleOption(PlayerStyle.BENTO, "Bento", "Squishy grid of flat tiles", Icons.Rounded.GridView),
     PlayerStyleOption(PlayerStyle.STICKER, "Sticker", "Die-cut art with toy physics", Icons.Rounded.Interests),
-    PlayerStyleOption(PlayerStyle.MORPH, "Morph", "Living shape that breathes", Icons.Rounded.Animation)
+    PlayerStyleOption(PlayerStyle.MORPH, "Morph", "Living shape that breathes", Icons.Rounded.Animation),
+    PlayerStyleOption(PlayerStyle.DIAL, "Dial", "Rotary ring, spin to scrub", Icons.Rounded.RadioButtonChecked)
 )
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)

--- a/docs/PLAYER_STYLES_PURE_EXPRESSIVE_CONCEPTS.md
+++ b/docs/PLAYER_STYLES_PURE_EXPRESSIVE_CONCEPTS.md
@@ -264,7 +264,87 @@ squash feedback must commit actions immediately and animate after
 
 ---
 
-## 5. Comparison and slotting
+## 5. EDITORIAL — the two-tone magazine player
+
+**One sentence:** the player is a full-bleed magazine spread in exactly two
+colors — album art die-cut into a scalloped flower shape up top, the title
+set in a huge editorial italic serif below it, and chunky asymmetric pill
+controls where the word "PLAY" itself is the icon.
+
+**Provenance:** this concept is modeled directly on Google's own Material 3
+Expressive announcement mock (the "Serafina" player screen), which makes it
+the most canonical concept in this gallery — it is what the M3 Expressive
+team themselves picked to show the system's ceiling. Every element in that
+mock maps one-to-one onto APIs already pinned in this repo.
+
+**The two-tone discipline (the whole trick):** the entire screen uses
+exactly two colors plus the artwork — a flat mid-tone field (Palette
+dominant swatch harmonized to the scheme, or `primaryContainer`) and one
+high-contrast accent (`primaryFixed`/`secondaryContainer` family) used for
+type, buttons, and the progress line alike. No third color, no tone ladder,
+no outline strokes. Hierarchy comes from size and shape only. This is the
+strictest palette in the gallery and the reason the style reads as print.
+
+**Anatomy (top to bottom, matching the reference for the first ~70%):**
+
+- **Die-cut art (~40% of height):** album art clipped to
+  `MaterialShapes.Flower` / `Puffy` (the scalloped clover of the mock),
+  centered, flat against the field — no ring, no border, the hard clip edge
+  is the composition. On track change the scallop count morphs (Flower to
+  Clover8Leaf to Puffy), so each song gets its own die-cut like Sticker's
+  per-track identity. Tap = play/pause with a single soft morph pulse.
+- **Title (~20%):** one full-bleed line in a display italic serif, accent
+  color, edge-to-edge with tight side margins, auto-fit stepping down for
+  long titles (marquee only as last resort). This is the style's voice and
+  justifies a player-only display typeface layered over the app's type
+  scale; the rest of the screen stays on the standard scale so the serif
+  reads as a deliberate headline, not a theme change.
+- **Control cluster (~15%, asymmetric bento):** the mock's exact trio —
+  a wide **PLAY pill where the label is the word**, morphing between "PLAY"
+  and "PAUSE" (width springs to fit via `animateContentSize`, letters swap
+  with a hard cut); previous and next as large accent circles with
+  field-colored glyphs. The asymmetry (wide pill + two circles, offset rows)
+  is the layout's expressive move — deliberately not a centered symmetric
+  transport row.
+- **Progress line (~10%):** the mock is literally
+  `LinearWavyProgressIndicator` semantics — played portion drawn as a wavy
+  line, remaining portion flat, separated by a tall bar playhead; the wave
+  flattens when paused. Time labels at both ends in `labelLarge` numerals.
+  Scrub by dragging the line, single `seekTo` on release.
+- **The missing 30% (below the reference crop):** artist name as a tappable
+  accent-outlined pill (existing `onArtistClick`); one row of small flat
+  accent chips — favorite (`LikeBurstIcon`), shuffle, repeat, queue — and a
+  lyrics chip that flips the whole spread into `SyncedLyricsView` set in the
+  same serif, turning lyrics into the magazine's body copy.
+
+**Expressive semantics:**
+
+| Element | Meaning |
+|---|---|
+| Wavy vs flat progress line | Playing vs paused, plus position |
+| PLAY/PAUSE word pill | State as language, not iconography |
+| Die-cut scallop morph on track change | New song, new cut |
+| Soft morph pulse on art tap | Play/pause feedback |
+| Serif headline re-typesetting per track | Each song is a new spread |
+
+**Key APIs:** `MaterialShapes.Flower` / `Clover8Leaf` / `Puffy` +
+`Morph` for the die-cut; `LinearWavyProgressIndicator` (stroke ~4dp, its
+default wavy-active/flat-track behavior is exactly the mock);
+`animateContentSize` with `fastSpatialSpec` for the word pill; a bundled
+display serif via `FontFamily` for the headline. Nothing beyond the pinned
+`material3 1.5.0-alpha13` plus one font asset.
+
+**Risk:** the two-tone contract depends on the accent having sufficient
+contrast against the Palette-derived field in both themes — derive the pair
+through the M3 scheme (e.g. container + onContainer-adjacent fixed roles)
+rather than raw Palette output, and fall back to `primaryContainer` /
+`onPrimaryContainer` when the artwork swatch cannot produce a compliant
+pair. Long titles and non-Latin scripts need the same auto-fit and
+font-fallback care as POSTER.
+
+---
+
+## 6. Comparison and slotting
 
 | Concept | Emotional center | Interaction novelty | Build complexity | Enum value |
 |---|---|---|---|---|
@@ -272,8 +352,9 @@ squash feedback must commit actions immediately and animate after
 | BENTO | Behavioral (tactility) | Medium — everything squishes | Medium (weight-animation discipline) | `BENTO` |
 | DIAL | Behavioral/visceral (instrument) | High — rotary physics | High (fling/decay tuning) | `DIAL` |
 | STICKER | Visceral (playfulness) | Medium — drag toy + peel | Medium-high (particles + drag physics) | `STICKER` |
+| EDITORIAL | Reflective/visceral (print identity) | Low — taps, one scrub | Low-medium (die-cut + word pill + wavy line) | `EDITORIAL` |
 
-All four share the Morph doc's integration path: one new content composable
+All five share the Morph doc's integration path: one new content composable
 per style with the standard signature (`viewModel, ambientBackground,
 onCollapse, onLoadMore, onArtistClick`), a `when` branch in
 `ExpandablePlayer`, an enum value, and a new segment in
@@ -282,14 +363,17 @@ onCollapse, onLoadMore, onArtistClick`), a `when` branch in
 be ignored) rather than `ChromaticMistBackground`, which is gradient-based
 and therefore out of contract here.
 
-**Recommendation:** if only one is built next, build POSTER — it is the
-cheapest to implement, the most visually unlike anything shipping in other
-players, and it turns the already-strong `SyncedLyricsView` into a
-first-class citizen instead of a sub-mode.
+**Recommendation:** if only one is built next, build EDITORIAL — it is the
+canonical Google reference realized with components the repo already ships
+(`MaterialShapes` clip, `LinearWavyProgressIndicator`, word-pill button),
+the lowest-risk to execute, and instantly recognizable as "true" M3
+Expressive. POSTER is the strongest second: it shares EDITORIAL's type-first
+philosophy and turns `SyncedLyricsView` into a first-class citizen, so the
+two styles can share the auto-fit headline machinery.
 
 ---
 
-## 6. Sources
+## 7. Sources
 
 - In-repo: `PLAYER_STYLE_MORPH_RESEARCH.md` (constraint framework and
   integration plan), `Material_3_expressive/Shapes.md` / `Motion.md` /
@@ -300,3 +384,7 @@ first-class citizen instead of a sub-mode.
   glanceability findings and the usability guardrail.
 - Material Design blog, "Start building with Material 3 Expressive" —
   motion scheme and component availability at `material3 1.5.0-alpha13`.
+- Google's Material 3 Expressive announcement mock (the "Serafina" player
+  screen) — direct visual reference for the EDITORIAL concept: flat
+  two-tone field, flower die-cut artwork, editorial serif headline, word
+  pill transport, wavy-played/flat-remaining progress line.

--- a/docs/PLAYER_STYLES_PURE_EXPRESSIVE_CONCEPTS.md
+++ b/docs/PLAYER_STYLES_PURE_EXPRESSIVE_CONCEPTS.md
@@ -1,8 +1,9 @@
 # Player Style Concepts: The Pure Expressive Gallery
 
-**Status:** EDITORIAL and POSTER are implemented (`ui/player/EditorialPlayerContent.kt`,
-`ui/player/PosterPlayerContent.kt`, selectable in Settings under Player Style);
-BENTO, DIAL and STICKER remain concepts
+**Status:** All five concepts are implemented and selectable in Settings under
+Player Style (`ui/player/EditorialPlayerContent.kt`, `PosterPlayerContent.kt`,
+`BentoPlayerContent.kt`, `StickerPlayerContent.kt`, `DialPlayerContent.kt`),
+alongside the Morph deep dive (`MorphPlayerContent.kt`)
 **Companion to:** `PLAYER_STYLE_MORPH_RESEARCH.md` (the Morph deep dive)
 **Hard constraints for every concept here:** no gradients, no drop shadows,
 no scrims, no blur. Depth, hierarchy and mood come exclusively from tonal

--- a/docs/PLAYER_STYLES_PURE_EXPRESSIVE_CONCEPTS.md
+++ b/docs/PLAYER_STYLES_PURE_EXPRESSIVE_CONCEPTS.md
@@ -1,6 +1,8 @@
 # Player Style Concepts: The Pure Expressive Gallery
 
-**Status:** Research / concept gallery (no implementation yet)
+**Status:** EDITORIAL and POSTER are implemented (`ui/player/EditorialPlayerContent.kt`,
+`ui/player/PosterPlayerContent.kt`, selectable in Settings under Player Style);
+BENTO, DIAL and STICKER remain concepts
 **Companion to:** `PLAYER_STYLE_MORPH_RESEARCH.md` (the Morph deep dive)
 **Hard constraints for every concept here:** no gradients, no drop shadows,
 no scrims, no blur. Depth, hierarchy and mood come exclusively from tonal

--- a/docs/PLAYER_STYLES_PURE_EXPRESSIVE_CONCEPTS.md
+++ b/docs/PLAYER_STYLES_PURE_EXPRESSIVE_CONCEPTS.md
@@ -1,0 +1,302 @@
+# Player Style Concepts: The Pure Expressive Gallery
+
+**Status:** Research / concept gallery (no implementation yet)
+**Companion to:** `PLAYER_STYLE_MORPH_RESEARCH.md` (the Morph deep dive)
+**Hard constraints for every concept here:** no gradients, no drop shadows,
+no scrims, no blur. Depth, hierarchy and mood come exclusively from tonal
+color roles, shape, typography, and spring motion. This is M3 Expressive
+with nothing to hide behind.
+
+---
+
+## 0. The flat-expressive rulebook
+
+These rules apply to all four concepts and are stricter than the current
+CLASSIC/GESTURE/Morph styles:
+
+1. **No gradient, anywhere.** The existing album containers use vertical
+   gradient overlays for "depth" and `ChromaticMistBackground` is built from
+   blurred gradient clouds — both are banned here. Pure-flat styles run on
+   **solid tonal fields**. Dynamic mood color still comes from the music:
+   Palette (already a dependency) extracts one dominant swatch and the
+   background is a single flat fill harmonized against the M3 scheme, or
+   simply `surfaceContainerLowest` with dynamic color doing the work.
+2. **No elevation.** `shadowElevation = 0` everywhere. Layering is shown by
+   overlap, tonal contrast (`surfaceContainerLow` on `surfaceContainerHigh`),
+   and motion parallax — objects that move at different rates read as
+   different depths without a single shadow.
+3. **Hard edges only.** Two flat colors may meet, but never blend. Progress
+   fills, selection states and "glow" substitutes are hard-edged color
+   boundaries. Where the current styles would crossfade, these styles
+   physically morph, slide, or hard-cut on a spring.
+4. **Every motion is a sentence.** Same principle as Morph: animation is the
+   status display, not garnish. If a spring fires, it is telling the user
+   something about playback state.
+5. **Color roles only.** No raw hex, no white/black constants. `primary`,
+   `primaryContainer`, `secondaryContainer`, `tertiaryContainer` and the
+   surface ladder carry all hierarchy — which also keeps every concept
+   automatically correct in light, dark, and dynamic-color themes.
+
+All concepts consume the existing `PlayerViewModel` state unchanged, slot
+into the `when (playerStyle)` branch of `ExpandablePlayer`, and follow the
+same four-file settings threading as any new `PlayerStyle` value.
+
+---
+
+## 1. POSTER — the kinetic type player
+
+**One sentence:** the player is a Swiss-style gig poster where typography is
+the entire interface — the song title at display scale is the artwork, the
+progress bar, and the play state all at once.
+
+**Why it is cool:** no music app dares to drop the album art. POSTER does.
+The title is set huge (display scale, wrapped over multiple stacked lines,
+left-aligned, tight leading) on a flat tonal field, like a letterpress print
+of the song itself. It is the most reflective-level concept in the gallery:
+the screen becomes a shareable poster of whatever is playing.
+
+**Anatomy:**
+
+- **Background:** one flat color field (Palette dominant swatch harmonized to
+  the scheme, or `surfaceContainerLowest`).
+- **Title block:** `displayLarge`-scale stacked words. While playing, the
+  variable font weight slowly breathes (wght 500 to 700 and back) — type
+  that is literally alive. Paused type freezes at rest weight.
+- **Progress:** a hard-edged "highlighter" fill that sweeps through the
+  title text itself — glyphs behind the playhead are `primary`, glyphs ahead
+  are `onSurface`. Two flat colors, hard boundary, zero gradient. Dragging
+  horizontally anywhere on the title scrubs (single `seekTo` on release,
+  same pattern as the existing styles).
+- **Play state glyph:** a single oversized punctuation mark next to the
+  title — a `MaterialShapes` asterisk-like burst while playing that morphs
+  to a full stop (circle) when paused. Punctuation as playback state.
+- **Artist line:** `headlineSmall`, tappable (existing `onArtistClick`).
+- **Controls:** a one-row `HorizontalFloatingToolbar` that only appears on
+  tap, then hides. The resting screen is pure typography.
+- **Lyrics mode:** the natural home of `SyncedLyricsView` — the poster
+  simply becomes the lyrics, same type system, zero visual mode switch cost.
+
+**Expressive semantics:**
+
+| Element | Meaning |
+|---|---|
+| Breathing font weight | Music is playing |
+| Weight frozen | Paused |
+| Highlighter fill position | Progress |
+| Asterisk/full-stop morph | Play/pause state |
+| Word-by-word spring re-stack on track change | New song is a new poster |
+
+**Key APIs:** variable font animation via `fontVariationSettings` +
+`animateFloatAsState(motionScheme.slowEffectsSpec())`; two-layer text with a
+hard `clipRect` for the fill sweep; `Morph` for the punctuation glyph;
+`AnimatedContent` with spatial springs for the re-stack.
+
+**Risk:** long titles at display scale need an auto-fit step (measure, then
+step down through display/headline sizes). Non-Latin scripts must be tested
+for variable-weight support; fall back to scale breathing where wght axes
+are unavailable.
+
+---
+
+## 2. BENTO — the squish grid player
+
+**One sentence:** the whole screen is a bento box of flat tonal tiles with
+physical mass — pressing any tile squishes the entire grid, and the tiles'
+sizes themselves are the interface hierarchy.
+
+**Why it is cool:** CLASSIC already proves the `ButtonGroup` + `animateWidth`
+squish physics feel great on one row. BENTO generalizes that physics to the
+entire screen: a living layout where every element pushes back. It is the
+most behavioral-level concept — maximal tactility, everything is a target.
+
+**Anatomy (weight-based grid, no fixed sizes):**
+
+- **Art tile** (largest, ~55% height): album art clipped to a big squircle,
+  flat, no overlay. Tap = play/pause; while playing the tile's corner radius
+  slowly oscillates between squircle and rounder squircle — the grid
+  breathes at the layout level, not via scale hacks.
+- **Transport row:** previous / play state / next as three tiles with
+  CLASSIC's exact press physics — the pressed tile expands, neighbors
+  compress, spring back on release.
+- **Progress tile:** a full-width flat tile whose fill is a hard-edged
+  two-tone split (`primaryContainer` played / `surfaceContainerHigh`
+  remaining). The boundary line is the scrubber. `LinearWavyProgressIndicator`
+  is allowed as a stroke on top since it is a flat single-color wave.
+- **Status tiles:** favorite (with the existing `LikeBurstIcon`), shuffle,
+  repeat, queue-peek — small square tiles in `secondaryContainer` /
+  `tertiaryContainer` when checked, surface roles when not. Checked state =
+  color role + corner morph, never elevation.
+- **Queue peek tile:** shows the next song title; tapping expands it — the
+  tile physically grows to swallow the grid and becomes the queue view, then
+  shrinks back (container-transform feel done purely with weight animation).
+
+**Expressive semantics:**
+
+| Element | Meaning |
+|---|---|
+| Grid gap and corner oscillation | Music is playing |
+| Grid perfectly settled | Paused |
+| Tile expand + neighbor compress | Press feedback (mass) |
+| Checked tile color role + rounder corners | Toggle state |
+| Queue tile swallowing the grid | Navigation is a physical expansion |
+
+**Key APIs:** `Modifier.weight` animated via `animateFloatAsState` with
+`fastSpatialSpec` (the `animateWidth` pattern, applied to both axes);
+`animateDpAsState` for corner radii; `ToggleButton` colors; no new
+dependencies.
+
+**Risk:** whole-grid springs must stay layout-cheap — animate weights and
+radii only (no per-frame text relayout inside tiles); keep the grid to a
+fixed tile count.
+
+---
+
+## 3. DIAL — the rotary instrument player
+
+**One sentence:** the player is a precision instrument: one huge flat rotary
+dial that the user physically spins to scrub, flicks to skip, and reads like
+a gauge.
+
+**Why it is cool:** it replaces the most generic element in every music app
+(the horizontal seek bar) with a mechanical object with real fling physics,
+friction, and detents. Strokes, dots, and ticks only — the flattest possible
+aesthetic, and the strongest "this is a device, not a screen" feel.
+
+**Anatomy:**
+
+- **The dial:** a large circle drawn as a flat stroke ring with tick marks.
+  Progress is shown by ticks behind the playhead filling solid `primary`,
+  ticks ahead staying `outlineVariant` — a discrete, hard-edged progress
+  gauge. The whole tick ring slowly rotates while playing (one revolution
+  per track) and halts on pause.
+- **Center puck:** album art clipped to a small `MaterialShapes` polygon at
+  dial center; morphs on play/pause exactly like Morph's hero, but at puck
+  scale. Tap = play/pause.
+- **Rotary scrub:** dragging along the ring rotates it with 1:1 finger
+  tracking plus detent haptics every 30 ticks; release commits one `seekTo`.
+  A hard flick spins the dial with decay physics — spinning past the end
+  detent skips to the next track, past the start detent restarts/previous.
+- **Readout:** current time / duration in `labelLarge` monospaced numerals
+  under the dial, flipping digit-by-digit (hard cuts, no fades).
+- **Controls:** shuffle / repeat / favorite as three small outlined chips
+  below the readout; queue and lyrics behind a long-press on the puck.
+
+**Expressive semantics:**
+
+| Element | Meaning |
+|---|---|
+| Ring rotating | Music is playing |
+| Ring halted | Paused |
+| Filled vs hollow ticks | Progress |
+| Detent haptic cadence | Scrub granularity |
+| Fling past detent | Skip intent (with friction as the cancel affordance) |
+| Puck shape morph | Play/pause state |
+
+**Key APIs:** single `Canvas` for ring + ticks (rotation via
+`graphicsLayer.rotationZ`, no relayout); `Animatable` +
+`splineBasedDecay` for fling; `LocalHapticFeedback` detents; `Morph` for
+the puck. Everything already available at the pinned versions.
+
+**Risk:** rotary scrubbing has a learning curve — first-run hint required,
+and the readout must live-update during rotation so the mapping is obvious.
+Decay tuning decides whether the dial feels like a flywheel or a wet knob;
+budget iteration time for the physics constants.
+
+---
+
+## 4. STICKER — the die-cut playful player
+
+**One sentence:** the album art is die-cut into a `MaterialShapes` sticker
+slapped at a slight angle onto a flat poster board, with a thick flat outline
+ring instead of a shadow — and it behaves like a real sticker: squash on tap,
+fling with spring return, peel on skip.
+
+**Why it is cool:** it is the most visceral-level, personality-forward
+concept — closest to the "Vibrant, Personal, Alive" voice in
+`DesignMindset.md`. The no-shadow constraint becomes the signature look:
+the sticker's "lift" is a thick `secondaryContainer` outline ring plus a
+resting 2-3 degree rotation, which reads as a physical object on a board
+without any elevation.
+
+**Anatomy:**
+
+- **Board:** flat `surfaceContainerLowest` field, optionally split into two
+  hard-edged tonal blocks (top `surfaceContainerLow`, bottom
+  `surfaceContainerLowest`) for composition — a color-block layout, not a
+  gradient.
+- **Sticker:** album art clipped to a rotating pick of `MaterialShapes`
+  polygons (a new shape per track — the shape is part of the song's
+  identity), with a thick flat contrasting border ring. Tap = play/pause
+  with cartoon squash-and-stretch (scale X up while Y down, spring back).
+  While playing the sticker sways almost imperceptibly around its resting
+  angle; paused it sits perfectly straight.
+- **Drag physics:** the sticker is grabbable. Small drags rubber-band back
+  with an underdamped spring (pure toy value — and a pet-the-app moment).
+  A committed horizontal drag "peels" it off screen and the next track's
+  sticker slaps on with an overshooting entrance.
+- **Like burst:** double-tap fires a confetti burst of tiny flat
+  `MaterialShapes` polygons in `primary` / `tertiary` fills (an upscaled
+  sibling of the existing `LikeBurstIcon` pattern) — flat fills, no alpha
+  glow.
+- **Type and controls:** title in `headlineLarge` on the board below the
+  sticker; transport as three flat chips; everything else behind the
+  floating toolbar pattern.
+
+**Expressive semantics:**
+
+| Element | Meaning |
+|---|---|
+| Sticker swaying | Music is playing |
+| Sticker straight and still | Paused |
+| Squash-and-stretch | Play/pause feedback |
+| Peel-off / slap-on | Track change |
+| Per-track die-cut shape | Song identity |
+| Confetti burst | Liked |
+
+**Key APIs:** `Morph` + custom `Shape` for the die-cut; border ring via
+`Modifier.border` with the morph shape; `Animatable(Offset)` with
+`spring(dampingRatio = 0.35f)` for the rubber-band; particle burst via a
+short-lived `Canvas` with flat polygon fills.
+
+**Risk:** the toy factor must never delay function — the peel gesture and
+squash feedback must commit actions immediately and animate after
+(optimistic UI), and the sway must be disabled under reduced motion.
+
+---
+
+## 5. Comparison and slotting
+
+| Concept | Emotional center | Interaction novelty | Build complexity | Enum value |
+|---|---|---|---|---|
+| POSTER | Reflective (identity, shareable) | Low — taps and one scrub gesture | Medium (text fill + variable fonts) | `POSTER` |
+| BENTO | Behavioral (tactility) | Medium — everything squishes | Medium (weight-animation discipline) | `BENTO` |
+| DIAL | Behavioral/visceral (instrument) | High — rotary physics | High (fling/decay tuning) | `DIAL` |
+| STICKER | Visceral (playfulness) | Medium — drag toy + peel | Medium-high (particles + drag physics) | `STICKER` |
+
+All four share the Morph doc's integration path: one new content composable
+per style with the standard signature (`viewModel, ambientBackground,
+onCollapse, onLoadMore, onArtistClick`), a `when` branch in
+`ExpandablePlayer`, an enum value, and a new segment in
+`ExpressivePlayerStyleSelectItem`. Note that for pure-flat styles the
+`ambientBackground` setting should map to the flat Palette color field (or
+be ignored) rather than `ChromaticMistBackground`, which is gradient-based
+and therefore out of contract here.
+
+**Recommendation:** if only one is built next, build POSTER — it is the
+cheapest to implement, the most visually unlike anything shipping in other
+players, and it turns the already-strong `SyncedLyricsView` into a
+first-class citizen instead of a sub-mode.
+
+---
+
+## 6. Sources
+
+- In-repo: `PLAYER_STYLE_MORPH_RESEARCH.md` (constraint framework and
+  integration plan), `Material_3_expressive/Shapes.md` / `Motion.md` /
+  `Toolbars.md`, `docs/DesignMindset.md`, `ui/player/PlayerSheetContent.kt`
+  (squish physics, scrub-on-release), `GesturePlayerContent.kt` (floating
+  toolbar, carousel physics), `ui/components` (`LikeBurstIcon`).
+- Google Design, "Expressive Design: Google's UX Research" — shape/motion
+  glanceability findings and the usability guardrail.
+- Material Design blog, "Start building with Material 3 Expressive" —
+  motion scheme and component availability at `material3 1.5.0-alpha13`.

--- a/docs/PLAYER_STYLE_MORPH_RESEARCH.md
+++ b/docs/PLAYER_STYLE_MORPH_RESEARCH.md
@@ -1,0 +1,271 @@
+# Player Style Research: "Morph" — A Totally Expressive Third Player UI
+
+**Status:** Research / design proposal (no implementation yet)
+**Scope:** A third `PlayerStyle` for the full-screen music player, alongside `CLASSIC` and `GESTURE`
+**Grounding:** Codebase analysis of `ui/player/*`, in-repo M3 Expressive guides (`Material_3_expressive/`, `docs/`), and Google's published Material 3 Expressive research
+
+---
+
+## 1. Why a third style — what the codebase already says
+
+Koda currently ships two full-player styles, selected via `PlayerStyle` in
+`data/ThemePreferences.kt` and branched in `ExpandablePlayer.kt`:
+
+| | CLASSIC (`PlayerSheetContent.kt`) | GESTURE (`GesturePlayerContent.kt`) |
+|---|---|---|
+| Core idea | Button-first control deck | Swipe-first album carousel |
+| Expressive APIs used | `ButtonGroup` + `animateWidth` squish physics, `LinearWavyProgressIndicator`, `LoadingIndicator` with `MaterialShapes` polygons, connected `ToggleButton` group, spring pill toggle | `HorizontalFloatingToolbar` with `StandardFloatingActionButton`, swipeable carousel with rotation/parallax, `CircularWavyProgressIndicator` |
+| Album art | Static rounded-corner square (`RoundedCornerShape(albumSize * 0.15f)`) | Static rounded squares in a carousel |
+| Ambient layer | `ChromaticMistBackground` (Palette-extracted drifting color clouds) | Same |
+| State transitions | `Crossfade` (queue, lyrics, pill) | `Crossfade` / `AnimatedContent` |
+
+Both styles are *expressive at the edges*: the expressive vocabulary (springs,
+wavy indicators, morphing loaders) is applied to the **controls**, while the
+**content** — the album art, the typography, the surfaces — stays a static
+rectangle with a crossfade. The single most characteristic M3 Expressive
+capability, **shape morphing as a first-class state channel**
+(`androidx.graphics:graphics-shapes` is already a dependency, and
+`MaterialShapes` is already imported for loaders), is only used for a 40dp
+loading spinner.
+
+That is the gap the third style fills. Not "more buttons with springs", but a
+player where the expressive system *is* the layout, and every playback state
+is communicated through shape, motion, and color rather than icons.
+
+---
+
+## 2. The idea: "Morph" — one living shape
+
+**Concept in one sentence:** the album art lives inside a single large
+`MaterialShapes` polygon that breathes, rotates, and morphs with playback
+state — the shape *is* the play/pause indicator, the progress display, and the
+hero of the screen; conventional controls only exist as a summonable floating
+toolbar.
+
+### The screen, top to bottom
+
+1. **Ambient layer** — reuse `ChromaticMistBackground` unchanged. It already
+   delivers the "color is borrowed from the music" pillar.
+2. **Hero shape (the protagonist)** — the album art clipped by an animated
+   `Morph` between `MaterialShapes` polygons:
+   - **Playing:** the clip slowly cycles through soft organic polygons
+     (`Cookie12Sided` → `SoftBurst` → `Sunny` → back), with a slow continuous
+     rotation and a subtle "breathing" scale (`infiniteRepeatable`). The art
+     visibly *lives* while music plays.
+   - **Paused:** the shape settles into a plain `Circle`/squircle and the
+     rotation eases to a stop. Silence looks still.
+   - **Buffering:** the existing multi-polygon `LoadingIndicator` language,
+     but applied to the hero clip itself rather than a small spinner.
+   - **Track change:** the outgoing art morphs down/spins out, the incoming
+     art morphs in — a shape-morph transition instead of a crossfade.
+3. **Progress as a ring** — a `CircularWavyProgressIndicator`-style wavy
+   ring wrapped around the hero shape. Wave amplitude is alive while playing
+   and flattens when paused (the same semantic the linear wavy indicator
+   already carries in CLASSIC, promoted to the hero position). Dragging along
+   the ring scrubs; commit a single `seekTo` on release, exactly like the
+   scrub-on-release pattern already used in `PlayerSheetContent` (seeking per
+   drag frame causes rebuffering storms on streamed tracks).
+4. **Hero typography** — title in `displaySmall`/`headlineLarge` weight-bold,
+   left-aligned, allowed to wrap to two lines. Both current styles use
+   conservative centered `headlineMedium`; Morph adopts the M3 Expressive
+   "bold type creates hierarchy" pillar so the text block reads as a poster,
+   not a caption. Artist stays a tappable pill (`onArtistClick` exists on both
+   current styles and is kept).
+5. **Summonable controls** — no permanent button deck. A
+   `HorizontalFloatingToolbar` (already proven in GESTURE) floats at the
+   bottom with the 4–5 secondary actions (shuffle, previous, next, repeat,
+   favorite); it auto-hides after a few seconds of inactivity and springs back
+   on any tap, keeping the resting screen almost furniture-free.
+   Play/pause has no button at all: **tapping the hero shape toggles playback**,
+   and the shape's morph (organic-cycling vs settled circle) is the state
+   feedback. Queue, lyrics, add-to-playlist, sleep timer live behind one
+   overflow action reusing the existing `ExpressiveQueueView`-style surfaces,
+   `SyncedLyricsView`, `AddToPlaylistSheet`, and `SleepTimerDialog`.
+
+### Gestures (consistent with the container)
+
+`ExpandablePlayer` already owns vertical-drag collapse, so Morph only adds:
+
+- **Tap hero:** play/pause (shape morph is the feedback).
+- **Horizontal drag on hero:** skip next/previous with the shape stretching
+  in the drag direction before release (spring-back if under threshold) —
+  the same threshold-plus-spring pattern `ExpandablePlayer` uses for dismiss.
+- **Drag on progress ring:** scrub.
+- **Long-press hero:** peek the queue.
+
+---
+
+## 3. Philosophy — why this is the *totally* expressive style
+
+### 3.1 The M3 Expressive thesis
+
+Material 3 Expressive's core claim (see `Material_3_expressive/Overview.md`)
+is that UI elements are not rigid pixels but "physical objects with mass,
+elasticity, and personality", and that emotion is a design function, not
+decoration. Google's research program behind the system — 46 studies with
+over 18,000 participants, using eye-tracking, surveys, and usability testing —
+reported that well-applied expressive design let participants spot key UI
+elements up to four times faster, raised perceived modernity (+34%),
+subcultural relevance (+32%) and innovation (+30%), and was strongly
+preferred across age groups (87% of 18–24-year-olds). Crucially, the same
+research warns that expressiveness applied *against* usability (hiding or
+displacing a key action) degrades the experience — expression must encode
+meaning, not obscure it.
+
+Morph is designed directly on that finding: every expressive element carries
+a semantic.
+
+| Expressive element | Meaning it encodes |
+|---|---|
+| Hero shape cycling organically | "Music is playing" |
+| Shape settled to a circle | "Paused / at rest" |
+| Wavy ring amplitude | Playback activity + progress position |
+| Shape stretch under horizontal drag | "You are about to skip" (with spring-back = cancel) |
+| Morph-through transition on track change | "This is a new object, not a mutation of the old one" |
+| Toolbar auto-hide | "The music is the interface; controls are guests" |
+
+Nothing animates *because it can*; the animation is the status display. This
+is the M2 → M3E shift the repo's own `docs/DesignMindset.md` frames as
+"Does it work?" → "Does it *feel* right?", and Norman's three levels mapped
+concretely:
+
+- **Visceral** — a living, breathing artwork shape on first open; color mist
+  from the track itself.
+- **Behavioral** — fewer chrome elements than CLASSIC, bigger touch targets
+  (the hero is the play button — effectively the largest touch target
+  possible), interruptible spring physics everywhere so mid-animation input
+  is never ignored.
+- **Reflective** — a player that looks like nothing else; shareable,
+  identity-forming ("my player breathes with the song"). This is the
+  "Differentiation" argument from `Overview.md` and the app's stated voice:
+  *Vibrant, Personal, Alive*.
+
+### 3.2 Design principles for the style
+
+1. **Shape is the protagonist.** One hero shape carries identity and state.
+   No competing decorated containers — everything else is quiet
+   (`surfaceContainer` tones, standard 16dp radii) so the morph reads.
+2. **Motion is a language, not a garnish.** All springs come from
+   `MaterialTheme.motionScheme` (`slowSpatialSpec` for the hero,
+   `fastSpatialSpec`/`fastEffectsSpec` for toolbar and micro-feedback), never
+   hand-tuned tweens — consistent with `Motion.md` and with how
+   `ExpandablePlayer` already animates its expansion.
+3. **Color is borrowed from the music.** Palette-extracted mist +
+   `primaryContainer` accents; the style adds no new color system.
+4. **Type goes hero.** Display-scale title, bold, poster-like block.
+5. **Controls are summoned, never resident.** Floating toolbar with
+   auto-hide; the resting state is art + ring + type only.
+6. **Everything is interruptible.** Springs allow catch-up and retargeting;
+   a user who taps mid-morph gets an immediate retarget, not a queued
+   animation.
+7. **Expression never hides the primary action.** The primary action
+   (play/pause) is the biggest target on screen; skip/scrub have visible,
+   reversible gestures with spring-back cancel. This is the usability guard
+   Google's research flags.
+
+---
+
+## 4. Component mapping (all available at current versions)
+
+`material3 = 1.5.0-alpha13` and `graphics-shapes = 1.0.1` (from
+`gradle/libs.versions.toml`) cover everything below; compiler-level opt-ins
+for `ExperimentalMaterial3ExpressiveApi` are already global.
+
+| Element | API |
+|---|---|
+| Hero clip | `MaterialShapes.*` polygons + `Morph(start, end)` + custom `Shape` (`Outline.Generic(morph.toPath(progress))`) per `Material_3_expressive/Shapes.md` Method 2 |
+| Morph progress / settle | `animateFloatAsState` with `motionScheme.slowSpatialSpec()`; continuous cycle via `rememberInfiniteTransition` |
+| Breathing scale | `rememberInfiniteTransition` + `graphicsLayer { scaleX/scaleY }` (layer-only, no relayout) |
+| Progress ring | `CircularWavyProgressIndicator` (determinate, stroke ~6dp) around the hero, or custom wavy arc via `drawScope` if the component's radius cannot wrap the hero size |
+| Scrub input | Invisible drag surface, local scrub state, single `seekTo` on release (pattern from `PlayerSheetContent.kt`) |
+| Toolbar | `HorizontalFloatingToolbar` + `FloatingToolbarDefaults` (pattern from `GesturePlayerContent.kt`), `AnimatedVisibility` slide+fade with `fastSpatialSpec` |
+| Favorite | existing `LikeBurstIcon` |
+| Buffering | `LoadingIndicator` polygon list applied at hero scale |
+| Queue / lyrics / playlist / timer | reuse `ExpressiveQueueView` pattern, `SyncedLyricsView`, `AddToPlaylistSheet`, `SleepTimerDialog` |
+| Ambient | `ChromaticMistBackground` unchanged |
+
+---
+
+## 5. Integration plan (follows existing conventions exactly)
+
+1. **`data/ThemePreferences.kt`** — add `MORPH` to the `PlayerStyle` enum.
+   Persistence already round-trips by enum name with a `CLASSIC` fallback, so
+   old prefs are safe.
+2. **`ui/player/MorphPlayerContent.kt`** — new file exposing
+   `MorphPlayerSheetContent(viewModel, ambientBackground, onCollapse,
+   onLoadMore, onArtistClick)` — the same signature as
+   `PlayerSheetContent`/`GesturePlayerSheetContent`, consuming only existing
+   `PlayerViewModel` state (no ViewModel changes needed).
+3. **`ExpandablePlayer.kt`** — third branch in the `when (playerStyle)`.
+   Respect the existing performance contract documented there: the expanded
+   layer is measured once at fixed full-screen height; the hero's breathing
+   and morphing must live in `graphicsLayer`/`Canvas` so no per-frame
+   relayout occurs.
+4. **`ui/settings/SettingsScreen.kt`** — extend
+   `ExpressivePlayerStyleSelectItem` from two to three segments
+   (Classic / Gesture / Morph). No new preference plumbing: the
+   `playerStyle` flow, `ThemeViewModel` delegate and `MainActivity`
+   threading already exist.
+
+No data-layer, service, or navigation changes. The style is purely a
+presentation-layer sibling.
+
+---
+
+## 6. Performance and accessibility guardrails
+
+- **Morph cost:** `Morph.toPath()` allocates; compute per frame into a
+  reused `Path` inside a `Canvas`/`drawWithCache`, cache `Morph` pairs with
+  `remember`, and keep the polygon cycle to a small fixed set. The clip shape
+  itself changes via `graphicsLayer` clip, not layout.
+- **Battery:** pause all infinite transitions when `!isPlaying` and when the
+  player is collapsed (`expandProgress == 0`), mirroring how the mist layer
+  is already gated by `enabled`.
+- **Reduced motion:** if system animator scale is 0 (or a future in-app
+  reduce-motion setting), freeze the cycle at a fixed pleasant polygon and
+  express play/pause as a single settle morph only.
+- **Contrast:** hero typography sits on the mist; keep the existing
+  scrim-gradient trick from the current album containers under the text
+  block, and use `onSurface`/`onSurfaceVariant` roles, never raw white.
+- **Touch:** ring scrub band at least 48dp tall; toolbar buttons keep the
+  standard FAB sizing from GESTURE; hero tap target is the whole shape.
+- **Discoverability of hidden controls:** first-run one-time hint chip
+  ("Tap the art to pause, swipe to skip"), consistent with the app's
+  onboarding tone; the toolbar is summoned by any tap, so there is no
+  dead-end state.
+
+---
+
+## 7. Risks and open questions
+
+- **Wavy ring around a non-circular, rotating shape** — wrapping progress
+  around the morphing outline is visually rich but geometrically fiddly;
+  the pragmatic v1 is a circular ring circumscribing the shape's bounds.
+- **Legibility with busy artwork** inside star-like polygons (SoftBurst
+  crops aggressively). Constrain the cycle to high-area polygons
+  (Cookie/Sunny family), keep `ContentScale.Crop` centered.
+- **Auto-hiding the toolbar** trades resting beauty for one extra tap on
+  secondary actions. Mitigation: generous timeout (~5s), always visible
+  while user is interacting, optional "keep controls visible" toggle later
+  if feedback demands it (would follow the standard four-file settings
+  threading).
+- **Tap-to-pause vs tap-to-expand conflict** — none in practice: the hero
+  only exists in the expanded player; the mini player keeps its own
+  play/pause button.
+
+---
+
+## 8. Sources
+
+- In-repo: `Material_3_expressive/Overview.md`, `Motion.md`, `Shapes.md`,
+  `Toolbars.md`; `docs/DesignMindset.md`,
+  `docs/Material3ExpressiveDesignGuide.md`; `ui/player/PlayerSheetContent.kt`,
+  `GesturePlayerContent.kt`, `ExpandablePlayer.kt`,
+  `ChromaticMistBackground.kt`; `data/ThemePreferences.kt`.
+- Google Design, "Expressive Design: Google's UX Research"
+  (design.google/library/expressive-material-design-google-research) — 46
+  studies, 18,000+ participants; glanceability, preference and perception
+  findings.
+- Material Design blog, "Start building with Material 3 Expressive"
+  (m3.material.io/blog/building-with-m3-expressive) — component and
+  motion-scheme availability.

--- a/docs/PLAYER_STYLE_MORPH_RESEARCH.md
+++ b/docs/PLAYER_STYLE_MORPH_RESEARCH.md
@@ -1,6 +1,7 @@
 # Player Style Research: "Morph" — A Totally Expressive Third Player UI
 
-**Status:** Research / design proposal (no implementation yet)
+**Status:** Implemented (`ui/player/MorphPlayerContent.kt`, selectable in
+Settings under Player Style)
 **Scope:** A third `PlayerStyle` for the full-screen music player, alongside `CLASSIC` and `GESTURE`
 **Grounding:** Codebase analysis of `ui/player/*`, in-repo M3 Expressive guides (`Material_3_expressive/`, `docs/`), and Google's published Material 3 Expressive research
 


### PR DESCRIPTION
## What this is

Research docs plus working implementations of **six new Material 3 Expressive player styles**, selectable in Settings under Player Style alongside Classic and Gesture, plus a **live style wheel**: long-press the artwork in any style to switch styles without leaving the player. Five styles follow a strict pure-flat rulebook (no gradients, no shadows, no scrims); Morph keeps the ambient ChromaticMist layer. Each feature landed as its own commit, so every point of this branch builds and is testable.

## The styles

| Style | Commit | Signature |
|---|---|---|
| **Editorial** | `06947f8` | Two-tone magazine layout from the Serafina M3E mock: per-track die-cut art morphing between MaterialShapes, serif italic headline, PLAY/PAUSE word pill, wavy-played/flat-remaining progress line |
| **Poster** | `06947f8` | Kinetic type: title words at display scale fill with a hard-edged accent sweep as progress; drag across the words to scrub; spinning burst glyph morphs to a full stop on pause |
| **Bento** | `3d20e4c` | Squish grid of flat tonal tiles: pressed transport tiles expand while neighbors compress, art tile corners breathe while playing, progress is a hard two-tone fill |
| **Sticker** | `f5d8066` | Die-cut sticker with toy physics: rubber-band drags, peel-to-skip, squash-and-stretch tap, double-tap like, sways while playing |
| **Morph** | `67ce927` | One living shape: art cycles organic cuts while playing and settles to a circle at rest, wrapped by a wavy progress ring; summonable floating toolbar |
| **Dial** | `d201f8e` | Rotary instrument: 60-tick ring spins one revolution per track past a fixed needle; spin the ring to scrub with haptic detents; per-track die-cut center puck |

## The style wheel (`db31f6e`)

Long-press the artwork in **any** style (the title stack in Poster, the center puck in Dial) and a radial wheel blooms out of the press: all eight styles as die-cut MaterialShapes buttons on staggered underdamped springs, ring settling from a counter-rotation, icons upright throughout, haptics on open and pick. Selecting a style **morphs the expanded player live** (Crossfade on the style branch) and persists like the Settings selector. Flat high-alpha overlay, no blur, no gradient scrim; tap outside or Back to dismiss.

## Architecture

- No ViewModel or data-layer changes: each style is a presentation-layer sibling (`ui/player/*PlayerContent.kt`) wired through the standard four-file settings threading.
- The wheel is hosted once in `ExpandablePlayer` above the active style; each style content exposes only an `onRequestStyleSwitcher` hook. The change callback threads MainActivity → HomeScreen → ExpandablePlayer into `ThemeViewModel.setPlayerStyle`.
- Settings selector converted to a wrapping chip grid; shared two-tone building blocks (`EditorialQueueView`, `EditorialChip`, `EditorialCircleButton`, `EditorialMorphShape`, `EditorialPolygonShape`) reused across styles.

## Docs

- `docs/PLAYER_STYLE_MORPH_RESEARCH.md` — Morph deep dive and integration plan
- `docs/PLAYER_STYLES_PURE_EXPRESSIVE_CONCEPTS.md` — the five-concept gallery with the flat-expressive rulebook

## Verification

`compileDebugKotlin` green after each commit (only pre-existing deprecation warnings). Not yet exercised on an emulator — physics constants (Sticker peel threshold, Dial detent feel, Morph cycle pacing, wheel bloom stagger) may want tuning on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMNQ5TdbvPtj3qA3MuC48z