### PR TITLE
Style wheel follow-up: blurred background and hold-to-select

### DIFF
--- a/app/src/main/java/com/ivor/ivormusic/ui/player/BentoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/BentoPlayerContent.kt
@@ -100,10 +100,10 @@ fun BentoPlayerSheetContent(
     ambientBackground: Boolean = true,
     onCollapse: () -> Unit,
     onLoadMore: () -> Unit = {},
-    onArtistClick: (String) -> Unit = {},
-    onRequestStyleSwitcher: () -> Unit = {}
+    onArtistClick: (String) -> Unit = {}
 ) {
     BackHandler(enabled = true) { onCollapse() }
+    val styleWheel = LocalPlayerStyleWheelController.current
 
     val currentSong by viewModel.currentSong.collectAsState()
     val isPlaying by viewModel.isPlaying.collectAsState()
@@ -235,11 +235,9 @@ fun BentoPlayerSheetContent(
                             .clip(RoundedCornerShape(artCorner.dp))
                             .background(tileColor)
                             .pointerInput(Unit) {
-                                detectTapGestures(
-                                    onTap = { viewModel.togglePlayPause() },
-                                    onLongPress = { onRequestStyleSwitcher() }
-                                )
+                                detectTapGestures(onTap = { viewModel.togglePlayPause() })
                             }
+                            .styleWheelHold(styleWheel)
                     ) {
                         Crossfade(targetState = showLyrics, label = "BentoArtLyrics") { lyricsVisible ->
                             if (lyricsVisible) {

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/DialPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/DialPlayerContent.kt
@@ -97,8 +97,7 @@ fun DialPlayerSheetContent(
     ambientBackground: Boolean = true,
     onCollapse: () -> Unit,
     onLoadMore: () -> Unit = {},
-    onArtistClick: (String) -> Unit = {},
-    onRequestStyleSwitcher: () -> Unit = {}
+    onArtistClick: (String) -> Unit = {}
 ) {
     BackHandler(enabled = true) { onCollapse() }
 
@@ -225,8 +224,7 @@ fun DialPlayerSheetContent(
                                     progress = progress,
                                     duration = duration,
                                     onSeekTo = { viewModel.seekTo(it) },
-                                    onPlayPause = { viewModel.togglePlayPause() },
-                                    onLongPress = onRequestStyleSwitcher
+                                    onPlayPause = { viewModel.togglePlayPause() }
                                 )
                             }
                         }
@@ -385,9 +383,9 @@ private fun RotaryDial(
     progress: Long,
     duration: Long,
     onSeekTo: (Long) -> Unit,
-    onPlayPause: () -> Unit,
-    onLongPress: () -> Unit
+    onPlayPause: () -> Unit
 ) {
+    val styleWheel = LocalPlayerStyleWheelController.current
     val tickColor = MaterialTheme.colorScheme.primary
     val tickTrackColor = MaterialTheme.colorScheme.outlineVariant
     val needleColor = MaterialTheme.colorScheme.onSurface
@@ -530,11 +528,9 @@ private fun RotaryDial(
                 .clip(puckShape)
                 .background(MaterialTheme.colorScheme.surfaceContainerHigh)
                 .pointerInput(Unit) {
-                    detectTapGestures(
-                        onTap = { onPlayPause() },
-                        onLongPress = { onLongPress() }
-                    )
-                },
+                    detectTapGestures(onTap = { onPlayPause() })
+                }
+                .styleWheelHold(styleWheel),
             contentAlignment = Alignment.Center
         ) {
             val artModel = currentSong?.highResThumbnailUrl

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/EditorialPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/EditorialPlayerContent.kt
@@ -127,8 +127,7 @@ fun EditorialPlayerSheetContent(
     ambientBackground: Boolean = true,
     onCollapse: () -> Unit,
     onLoadMore: () -> Unit = {},
-    onArtistClick: (String) -> Unit = {},
-    onRequestStyleSwitcher: () -> Unit = {}
+    onArtistClick: (String) -> Unit = {}
 ) {
     BackHandler(enabled = true) { onCollapse() }
 
@@ -202,7 +201,6 @@ fun EditorialPlayerSheetContent(
                     onShowQueue = { showQueue = true },
                     onShowAddToPlaylist = { showAddToPlaylist = true },
                     onArtistClick = onArtistClick,
-                    onRequestStyleSwitcher = onRequestStyleSwitcher,
                     field = field,
                     accent = accent
                 )
@@ -256,7 +254,6 @@ private fun EditorialNowPlayingView(
     onShowQueue: () -> Unit,
     onShowAddToPlaylist: () -> Unit,
     onArtistClick: (String) -> Unit,
-    onRequestStyleSwitcher: () -> Unit,
     field: Color,
     accent: Color
 ) {
@@ -324,7 +321,6 @@ private fun EditorialNowPlayingView(
                         currentSong = currentSong,
                         isPlaying = isPlaying,
                         onTap = onPlayPause,
-                        onLongPress = onRequestStyleSwitcher,
                         accent = accent,
                         field = field
                     )
@@ -607,10 +603,10 @@ private fun EditorialDieCutArt(
     currentSong: Song?,
     isPlaying: Boolean,
     onTap: () -> Unit,
-    onLongPress: () -> Unit,
     accent: Color,
     field: Color
 ) {
+    val styleWheel = LocalPlayerStyleWheelController.current
     val dieCuts = remember {
         listOf(
             MaterialShapes.Flower,
@@ -673,11 +669,9 @@ private fun EditorialDieCutArt(
                 .clip(dieCutShape)
                 .background(accent)
                 .pointerInput(Unit) {
-                    detectTapGestures(
-                        onTap = { onTap() },
-                        onLongPress = { onLongPress() }
-                    )
-                },
+                    detectTapGestures(onTap = { onTap() })
+                }
+                .styleWheelHold(styleWheel),
             contentAlignment = Alignment.Center
         ) {
             val artModel = currentSong?.highResThumbnailUrl

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/ExpandablePlayer.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/ExpandablePlayer.kt
@@ -1,6 +1,7 @@
 package com.ivor.ivormusic.ui.player
 
 import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -16,6 +17,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
@@ -64,10 +66,11 @@ fun ExpandablePlayer(
 
     // Long-pressing the artwork in any style summons the style wheel; it
     // lives here, above whichever style is active, so the player can morph
-    // live underneath it.
-    var showStyleWheel by remember { mutableStateOf(false) }
+    // live underneath it. The controller streams the hold-drag-release
+    // gesture from the artwork into the wheel.
+    val styleWheel = rememberPlayerStyleWheelController()
     LaunchedEffect(isExpanded) {
-        if (!isExpanded) showStyleWheel = false
+        if (!isExpanded) styleWheel.dismiss()
     }
 
     val configuration = LocalConfiguration.current
@@ -253,6 +256,22 @@ fun ExpandablePlayer(
                             .height(expandedHeight)
                             .graphicsLayer { alpha = fullAlpha }
                     ) {
+                        // The live player blurs beneath the style wheel.
+                        val wheelBlur by animateDpAsState(
+                            targetValue = if (styleWheel.isOpen) 24.dp else 0.dp,
+                            animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+                            label = "StyleWheelBlur"
+                        )
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .then(if (wheelBlur > 0.5.dp) Modifier.blur(wheelBlur) else Modifier)
+                        ) {
+                        // Any artwork can host the wheel's hold gesture
+                        // through this local, without per-style plumbing.
+                        CompositionLocalProvider(
+                            LocalPlayerStyleWheelController provides styleWheel
+                        ) {
                         // Crossfade makes a live style swap (from the style
                         // wheel or Settings) a soft morph instead of a cut.
                         Crossfade(
@@ -269,8 +288,7 @@ fun ExpandablePlayer(
                                     onLoadMore = {
                                         viewModel.loadMoreRecommendations()
                                     },
-                                    onArtistClick = onArtistClick,
-                                    onRequestStyleSwitcher = { showStyleWheel = true }
+                                    onArtistClick = onArtistClick
                                 )
                             }
                             PlayerStyle.GESTURE -> {
@@ -281,8 +299,7 @@ fun ExpandablePlayer(
                                     onLoadMore = {
                                         viewModel.loadMoreRecommendations()
                                     },
-                                    onArtistClick = onArtistClick,
-                                    onRequestStyleSwitcher = { showStyleWheel = true }
+                                    onArtistClick = onArtistClick
                                 )
                             }
                             PlayerStyle.EDITORIAL -> {
@@ -293,8 +310,7 @@ fun ExpandablePlayer(
                                     onLoadMore = {
                                         viewModel.loadMoreRecommendations()
                                     },
-                                    onArtistClick = onArtistClick,
-                                    onRequestStyleSwitcher = { showStyleWheel = true }
+                                    onArtistClick = onArtistClick
                                 )
                             }
                             PlayerStyle.POSTER -> {
@@ -305,8 +321,7 @@ fun ExpandablePlayer(
                                     onLoadMore = {
                                         viewModel.loadMoreRecommendations()
                                     },
-                                    onArtistClick = onArtistClick,
-                                    onRequestStyleSwitcher = { showStyleWheel = true }
+                                    onArtistClick = onArtistClick
                                 )
                             }
                             PlayerStyle.BENTO -> {
@@ -317,8 +332,7 @@ fun ExpandablePlayer(
                                     onLoadMore = {
                                         viewModel.loadMoreRecommendations()
                                     },
-                                    onArtistClick = onArtistClick,
-                                    onRequestStyleSwitcher = { showStyleWheel = true }
+                                    onArtistClick = onArtistClick
                                 )
                             }
                             PlayerStyle.STICKER -> {
@@ -329,8 +343,7 @@ fun ExpandablePlayer(
                                     onLoadMore = {
                                         viewModel.loadMoreRecommendations()
                                     },
-                                    onArtistClick = onArtistClick,
-                                    onRequestStyleSwitcher = { showStyleWheel = true }
+                                    onArtistClick = onArtistClick
                                 )
                             }
                             PlayerStyle.MORPH -> {
@@ -341,8 +354,7 @@ fun ExpandablePlayer(
                                     onLoadMore = {
                                         viewModel.loadMoreRecommendations()
                                     },
-                                    onArtistClick = onArtistClick,
-                                    onRequestStyleSwitcher = { showStyleWheel = true }
+                                    onArtistClick = onArtistClick
                                 )
                             }
                             PlayerStyle.DIAL -> {
@@ -353,22 +365,24 @@ fun ExpandablePlayer(
                                     onLoadMore = {
                                         viewModel.loadMoreRecommendations()
                                     },
-                                    onArtistClick = onArtistClick,
-                                    onRequestStyleSwitcher = { showStyleWheel = true }
+                                    onArtistClick = onArtistClick
                                 )
                             }
                         }
                         }
+                        }
+                        }
 
                         androidx.compose.animation.AnimatedVisibility(
-                            visible = showStyleWheel,
+                            visible = styleWheel.isOpen,
                             enter = fadeIn(MaterialTheme.motionScheme.fastEffectsSpec()),
                             exit = fadeOut(MaterialTheme.motionScheme.fastEffectsSpec())
                         ) {
                             PlayerStyleWheel(
                                 currentStyle = playerStyle,
+                                controller = styleWheel,
                                 onStyleSelected = onPlayerStyleChange,
-                                onDismiss = { showStyleWheel = false }
+                                onDismiss = { styleWheel.dismiss() }
                             )
                         }
                     }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/GesturePlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/GesturePlayerContent.kt
@@ -73,8 +73,7 @@ fun GesturePlayerSheetContent(
     ambientBackground: Boolean = true,
     onCollapse: () -> Unit,
     onLoadMore: () -> Unit = {},
-    onArtistClick: (String) -> Unit = {},
-    onRequestStyleSwitcher: () -> Unit = {}
+    onArtistClick: (String) -> Unit = {}
 ) {
     BackHandler(enabled = true) {
         onCollapse()
@@ -167,7 +166,6 @@ fun GesturePlayerSheetContent(
                     onSleepTimerClick = { showSleepTimerDialog = true },
                     onPlayPauseToggle = { viewModel.togglePlayPause() },
                     onSongChange = { song -> viewModel.skipToSong(song) },
-                    onRequestStyleSwitcher = onRequestStyleSwitcher,
 
                     isDownloaded = currentSong?.let { viewModel.isDownloaded(it.id) } ?: false,
                     isDownloading = currentSong?.let { viewModel.isDownloading(it.id) } ?: false,
@@ -237,7 +235,6 @@ private fun GestureNowPlayingView(
     onSleepTimerClick: () -> Unit,
     onPlayPauseToggle: () -> Unit,
     onSongChange: (Song) -> Unit,
-    onRequestStyleSwitcher: () -> Unit,
     isDownloaded: Boolean,
     isDownloading: Boolean,
     isLocalOriginal: Boolean,
@@ -421,8 +418,7 @@ private fun GestureNowPlayingView(
                                         isPlaying = isPlaying,
                                         isBuffering = isBuffering,
                                         onPlayPauseToggle = onPlayPauseToggle,
-                                        onSongChange = onSongChange,
-                                        onLongPress = onRequestStyleSwitcher
+                                        onSongChange = onSongChange
                                     )
                                 } else if (currentSong != null) {
                                     // Single album art
@@ -430,8 +426,7 @@ private fun GestureNowPlayingView(
                                         song = currentSong,
                                         isPlaying = isPlaying,
                                         isBuffering = isBuffering,
-                                        onPlayPauseToggle = onPlayPauseToggle,
-                                        onLongPress = onRequestStyleSwitcher
+                                        onPlayPauseToggle = onPlayPauseToggle
                                     )
                                 }
                             }
@@ -722,9 +717,9 @@ private fun SwipeableAlbumCarousel(
     isPlaying: Boolean,
     isBuffering: Boolean,
     onPlayPauseToggle: () -> Unit,
-    onSongChange: (Song) -> Unit,
-    onLongPress: () -> Unit = {}
+    onSongChange: (Song) -> Unit
 ) {
+    val styleWheel = LocalPlayerStyleWheelController.current
     // The carousel position as a continuous float
     // Position 0 = first song centered, Position 1 = second song centered, etc.
     var targetPosition by remember { mutableFloatStateOf(currentIndex.toFloat()) }
@@ -858,12 +853,11 @@ private fun SwipeableAlbumCarousel(
                             .graphicsLayer { rotationZ = rotation }
                             .then(
                                 if (isCentered) {
-                                    Modifier.pointerInput(Unit) {
-                                        detectTapGestures(
-                                            onTap = { onPlayPauseToggle() },
-                                            onLongPress = { onLongPress() }
-                                        )
-                                    }
+                                    Modifier
+                                        .pointerInput(Unit) {
+                                            detectTapGestures(onTap = { onPlayPauseToggle() })
+                                        }
+                                        .styleWheelHold(styleWheel)
                                 } else Modifier
                             ),
                         shape = RoundedCornerShape(currentCornerRadius),
@@ -954,9 +948,9 @@ private fun SingleAlbumArt(
     song: Song?,
     isPlaying: Boolean,
     isBuffering: Boolean,
-    onPlayPauseToggle: () -> Unit,
-    onLongPress: () -> Unit = {}
+    onPlayPauseToggle: () -> Unit
 ) {
+    val styleWheel = LocalPlayerStyleWheelController.current
     BoxWithConstraints(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center
@@ -975,11 +969,9 @@ private fun SingleAlbumArt(
             modifier = Modifier
                 .size(albumSize)
                 .pointerInput(Unit) {
-                    detectTapGestures(
-                        onTap = { onPlayPauseToggle() },
-                        onLongPress = { onLongPress() }
-                    )
-                },
+                    detectTapGestures(onTap = { onPlayPauseToggle() })
+                }
+                .styleWheelHold(styleWheel),
             shape = RoundedCornerShape(cornerRadius),
             color = MaterialTheme.colorScheme.surfaceContainerHigh,
             shadowElevation = 16.dp

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/MorphPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/MorphPlayerContent.kt
@@ -119,8 +119,7 @@ fun MorphPlayerSheetContent(
     ambientBackground: Boolean = true,
     onCollapse: () -> Unit,
     onLoadMore: () -> Unit = {},
-    onArtistClick: (String) -> Unit = {},
-    onRequestStyleSwitcher: () -> Unit = {}
+    onArtistClick: (String) -> Unit = {}
 ) {
     BackHandler(enabled = true) { onCollapse() }
 
@@ -263,7 +262,6 @@ fun MorphPlayerSheetContent(
                                     onPlayPause = { viewModel.togglePlayPause() },
                                     onNext = { viewModel.skipToNext() },
                                     onPrevious = { viewModel.skipToPrevious() },
-                                    onLongPress = onRequestStyleSwitcher,
                                     ringColor = primaryColor,
                                     ringTrackColor = onSurfaceVariantColor.copy(alpha = 0.2f)
                                 )
@@ -481,7 +479,6 @@ private fun MorphHero(
     onPlayPause: () -> Unit,
     onNext: () -> Unit,
     onPrevious: () -> Unit,
-    onLongPress: () -> Unit,
     ringColor: Color,
     ringTrackColor: Color
 ) {
@@ -568,7 +565,7 @@ private fun MorphHero(
     val currentOnNext by rememberUpdatedState(onNext)
     val currentOnPrevious by rememberUpdatedState(onPrevious)
     val currentOnPlayPause by rememberUpdatedState(onPlayPause)
-    val currentOnLongPress by rememberUpdatedState(onLongPress)
+    val styleWheel = LocalPlayerStyleWheelController.current
 
     BoxWithConstraints(
         modifier = Modifier.fillMaxSize(),
@@ -599,10 +596,7 @@ private fun MorphHero(
                 .clip(heroShape)
                 .background(MaterialTheme.colorScheme.surfaceContainerHigh)
                 .pointerInput(Unit) {
-                    detectTapGestures(
-                        onTap = { currentOnPlayPause() },
-                        onLongPress = { currentOnLongPress() }
-                    )
+                    detectTapGestures(onTap = { currentOnPlayPause() })
                 }
                 .pointerInput(Unit) {
                     detectHorizontalDragGestures(
@@ -629,7 +623,10 @@ private fun MorphHero(
                             scope.launch { dragX.animateTo(0f, spring()) }
                         }
                     )
-                },
+                }
+                // Last in the chain: consumes the post-long-press hold
+                // stream before the tap and skip-drag detectors see it.
+                .styleWheelHold(styleWheel),
             contentAlignment = Alignment.Center
         ) {
             val artModel = currentSong?.highResThumbnailUrl

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -66,8 +65,7 @@ fun PlayerSheetContent(
     ambientBackground: Boolean = true,
     onCollapse: () -> Unit,
     onLoadMore: () -> Unit = {},
-    onArtistClick: (String) -> Unit = {},
-    onRequestStyleSwitcher: () -> Unit = {}
+    onArtistClick: (String) -> Unit = {}
 ) {
     // Handle back press to collapse player instead of quitting app
     BackHandler(enabled = true) {
@@ -164,7 +162,6 @@ fun PlayerSheetContent(
                     onShowQueue = { showQueue = true },
                     onShowAddToPlaylist = { showAddToPlaylist = true },
                     onArtistClick = onArtistClick,
-                    onRequestStyleSwitcher = onRequestStyleSwitcher,
                     viewModel = viewModel,
                     primaryColor = primaryColor,
                     primaryContainerColor = primaryContainerColor,
@@ -222,7 +219,6 @@ private fun ExpressiveNowPlayingView(
     onShowQueue: () -> Unit,
     onShowAddToPlaylist: () -> Unit,
     onArtistClick: (String) -> Unit,
-    onRequestStyleSwitcher: () -> Unit,
     viewModel: PlayerViewModel,
     primaryColor: Color,
     primaryContainerColor: Color,
@@ -388,14 +384,11 @@ private fun ExpressiveNowPlayingView(
                         
                         Box(contentAlignment = Alignment.Center) {
                             // Main album art container with expressive squircle shape
+                            val styleWheel = LocalPlayerStyleWheelController.current
                             Surface(
                                 modifier = Modifier
                                     .size(albumSize)
-                                    .pointerInput(Unit) {
-                                        detectTapGestures(
-                                            onLongPress = { onRequestStyleSwitcher() }
-                                        )
-                                    },
+                                    .styleWheelHold(styleWheel),
                                 shape = RoundedCornerShape(cornerRadius),
                                 color = MaterialTheme.colorScheme.surfaceContainerHigh
                             ) {

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerStyleWheel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerStyleWheel.kt
@@ -3,8 +3,12 @@ package com.ivor.ivormusic.ui.player
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitLongPressOrCancellation
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -31,13 +35,23 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.input.pointer.positionChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
@@ -46,6 +60,8 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.graphics.shapes.RoundedPolygon
 import com.ivor.ivormusic.data.PlayerStyle
+import kotlin.math.abs
+import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.roundToInt
 import kotlin.math.sin
@@ -55,8 +71,12 @@ import kotlinx.coroutines.launch
 /**
  * The style wheel: long-press the artwork in any player style and every
  * style blooms out of the press point as its own die-cut MaterialShapes
- * button, arranged in a ring. Tap one and the player morphs into that
- * style live.
+ * button, arranged in a ring, while the live player blurs beneath it.
+ *
+ * Two ways to pick:
+ * - Keep holding after the long-press, drag toward a style (it grows and
+ *   ticks as you aim), and release on it - one continuous gesture.
+ * - Or release in the center: the wheel stays open, tap a style.
  *
  * Expressive contract:
  * - Shape signals identity: each style is cut into the polygon that best
@@ -64,9 +84,9 @@ import kotlinx.coroutines.launch
  *   Morph is a soft burst, ...).
  * - Motion is physics: items bloom outward on staggered underdamped
  *   springs with visible overshoot while the whole ring settles from a
- *   slight counter-rotation; icons stay upright throughout.
- * - The overlay is a flat high-alpha surface, no blur, no gradient scrim.
- * - Haptics mark the open (long-press) and the pick (confirm).
+ *   slight counter-rotation.
+ * - Haptics mark the open (long-press), each aim change (tick), and the
+ *   pick (confirm).
  */
 internal data class PlayerStyleWheelEntry(
     val style: PlayerStyle,
@@ -74,6 +94,93 @@ internal data class PlayerStyleWheelEntry(
     val icon: ImageVector,
     val polygon: RoundedPolygon
 )
+
+/**
+ * Bridges the artwork's hold gesture into the wheel. The artwork opens the
+ * wheel on long-press and keeps streaming drag deltas while the finger is
+ * down; the wheel turns the accumulated offset into an aimed item and
+ * commits it when the finger lifts.
+ */
+class PlayerStyleWheelController {
+    var isOpen by mutableStateOf(false)
+        private set
+    var isHolding by mutableStateOf(false)
+        private set
+    var dragOffset by mutableStateOf(Offset.Zero)
+        private set
+
+    /** Incremented on every hold release so the wheel can commit the aim. */
+    var releaseTick by mutableIntStateOf(0)
+        private set
+
+    fun openFromHold() {
+        isOpen = true
+        isHolding = true
+        dragOffset = Offset.Zero
+    }
+
+    fun dragBy(delta: Offset) {
+        if (isHolding) dragOffset += delta
+    }
+
+    fun releaseHold() {
+        if (!isHolding) return
+        isHolding = false
+        releaseTick++
+    }
+
+    fun dismiss() {
+        isOpen = false
+        isHolding = false
+        dragOffset = Offset.Zero
+    }
+}
+
+@Composable
+fun rememberPlayerStyleWheelController(): PlayerStyleWheelController =
+    remember { PlayerStyleWheelController() }
+
+/**
+ * Provided by ExpandablePlayer around the active style content so any
+ * artwork can host the hold gesture without per-style plumbing. Null when
+ * no wheel is available (previews, standalone usage).
+ */
+val LocalPlayerStyleWheelController =
+    staticCompositionLocalOf<PlayerStyleWheelController?> { null }
+
+/**
+ * Hold gesture for artwork: long-press opens the style wheel and, while
+ * the finger stays down, streams drag deltas to it; the release commits
+ * the aimed style. Consumes the post-long-press stream (including the up)
+ * so sibling tap/drag detectors on the same artwork stay quiet. A no-op
+ * when no controller is provided.
+ */
+fun Modifier.styleWheelHold(controller: PlayerStyleWheelController?): Modifier {
+    if (controller == null) return this
+    return this.pointerInput(controller) {
+        awaitEachGesture {
+            val down = awaitFirstDown(requireUnconsumed = false)
+            val longPress = awaitLongPressOrCancellation(down.id)
+            if (longPress != null) {
+                controller.openFromHold()
+                while (true) {
+                    val event = awaitPointerEvent()
+                    val change = event.changes.firstOrNull { it.id == longPress.id }
+                        ?: event.changes.first()
+                    if (change.changedToUpIgnoreConsumed()) {
+                        change.consume()
+                        controller.releaseHold()
+                        break
+                    }
+                    if (change.positionChanged()) {
+                        controller.dragBy(change.positionChange())
+                        change.consume()
+                    }
+                }
+            }
+        }
+    }
+}
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -94,16 +201,58 @@ internal fun rememberPlayerStyleWheelEntries(): List<PlayerStyleWheelEntry> = re
 @Composable
 fun PlayerStyleWheel(
     currentStyle: PlayerStyle,
+    controller: PlayerStyleWheelController,
     onStyleSelected: (PlayerStyle) -> Unit,
     onDismiss: () -> Unit
 ) {
     BackHandler(enabled = true) { onDismiss() }
     val entries = rememberPlayerStyleWheelEntries()
     val haptics = LocalHapticFeedback.current
+    val density = LocalDensity.current
 
     // Mark the open with the long-press haptic the gesture earned.
     LaunchedEffect(Unit) {
         haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+    }
+
+    // Aim: while the finger is still down, the accumulated drag direction
+    // picks the nearest item once it clears a dead zone around the center.
+    val aimThresholdPx = with(density) { 56.dp.toPx() }
+    val aimedIndex: Int? = if (
+        controller.isHolding &&
+        controller.dragOffset.getDistance() > aimThresholdPx
+    ) {
+        val dragAngle = Math.toDegrees(
+            atan2(controller.dragOffset.y.toDouble(), controller.dragOffset.x.toDouble())
+        ).toFloat()
+        entries.indices.minByOrNull { index ->
+            val itemAngle = (index * 360f / entries.size) - 90f
+            var diff = abs(dragAngle - itemAngle) % 360f
+            if (diff > 180f) diff = 360f - diff
+            diff
+        }
+    } else null
+
+    // Tick as the aim moves between items.
+    LaunchedEffect(aimedIndex) {
+        if (aimedIndex != null) {
+            haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+        }
+    }
+
+    // Releasing the hold commits the aim; releasing in the dead zone keeps
+    // the wheel open for tap selection.
+    val currentAimedIndex by rememberUpdatedState(aimedIndex)
+    val currentOnStyleSelected by rememberUpdatedState(onStyleSelected)
+    val currentOnDismiss by rememberUpdatedState(onDismiss)
+    LaunchedEffect(controller.releaseTick) {
+        if (controller.releaseTick == 0) return@LaunchedEffect
+        val aimed = currentAimedIndex
+        if (aimed != null) {
+            haptics.performHapticFeedback(HapticFeedbackType.Confirm)
+            currentOnStyleSelected(entries[aimed].style)
+            currentOnDismiss()
+        }
     }
 
     // Staggered radial bloom: every item springs outward with overshoot.
@@ -134,12 +283,13 @@ fun PlayerStyleWheel(
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        // Flat dismiss field: solid high-alpha surface, no blur, no scrim
-        // gradient. First child, so item touches never reach it.
+        // Light tint over the blurred player beneath (ExpandablePlayer
+        // blurs the live content while the wheel is open). First child, so
+        // item touches never reach it.
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.96f))
+                .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.45f))
                 .pointerInput(Unit) {
                     detectTapGestures(onTap = { onDismiss() })
                 }
@@ -150,21 +300,22 @@ fun PlayerStyleWheel(
             contentAlignment = Alignment.Center
         ) {
             val radius = minOf(maxWidth, maxHeight) * 0.36f
-            val radiusPx = with(LocalDensity.current) { radius.toPx() }
-            val ringRotation = (1f - wheelSettle.value) * -24f
+            val radiusPx = with(density) { radius.toPx() }
 
-            // Center readout: what you are on now.
+            // Center readout: what you are on, or what you are aiming at.
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Text(
-                    text = "Player style",
+                    text = if (aimedIndex != null) "Release for" else "Player style",
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center
                 )
                 Text(
-                    text = entries.firstOrNull { it.style == currentStyle }?.label ?: "",
+                    text = aimedIndex?.let { entries[it].label }
+                        ?: (entries.firstOrNull { it.style == currentStyle }?.label ?: ""),
                     style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
-                    color = MaterialTheme.colorScheme.onSurface,
+                    color = if (aimedIndex != null) MaterialTheme.colorScheme.primary
+                    else MaterialTheme.colorScheme.onSurface,
                     textAlign = TextAlign.Center
                 )
             }
@@ -172,12 +323,26 @@ fun PlayerStyleWheel(
             entries.forEachIndexed { index, entry ->
                 val progress = bloom[index].value
                 val angleRad = Math.toRadians((index * 360.0 / entries.size) - 90.0)
-                val itemX = (cos(angleRad) * radiusPx * progress * wheelRotationCos(ringRotation) -
-                    sin(angleRad) * radiusPx * progress * wheelRotationSin(ringRotation)).roundToInt()
-                val itemY = (sin(angleRad) * radiusPx * progress * wheelRotationCos(ringRotation) +
-                    cos(angleRad) * radiusPx * progress * wheelRotationSin(ringRotation)).roundToInt()
+                val itemX = (cos(angleRad) * radiusPx * progress).roundToInt()
+                val itemY = (sin(angleRad) * radiusPx * progress).roundToInt()
                 val selected = entry.style == currentStyle
+                val aimed = aimedIndex == index
                 val itemShape = remember(entry.polygon) { EditorialPolygonShape(entry.polygon) }
+
+                // Aimed items grow toward the finger; the emphasis is a
+                // spring, so sweeping the aim feels alive.
+                val emphasis by animateFloatAsState(
+                    targetValue = when {
+                        aimed -> 1.28f
+                        selected -> 1.12f
+                        else -> 1f
+                    },
+                    animationSpec = spring(
+                        dampingRatio = Spring.DampingRatioMediumBouncy,
+                        stiffness = Spring.StiffnessMedium
+                    ),
+                    label = "WheelItemEmphasis"
+                )
 
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
@@ -185,7 +350,7 @@ fun PlayerStyleWheel(
                         .offset { IntOffset(itemX, itemY) }
                         .graphicsLayer {
                             alpha = progress.coerceIn(0f, 1f)
-                            val scale = progress * (if (selected) 1.12f else 1f)
+                            val scale = progress * emphasis
                             scaleX = scale
                             scaleY = scale
                         }
@@ -198,9 +363,12 @@ fun PlayerStyleWheel(
                         },
                         modifier = Modifier.size(64.dp),
                         shape = itemShape,
-                        color = if (selected) MaterialTheme.colorScheme.primary
-                        else MaterialTheme.colorScheme.surfaceContainerHigh,
-                        contentColor = if (selected) MaterialTheme.colorScheme.onPrimary
+                        color = when {
+                            aimed -> MaterialTheme.colorScheme.primary
+                            selected -> MaterialTheme.colorScheme.primary
+                            else -> MaterialTheme.colorScheme.surfaceContainerHigh
+                        },
+                        contentColor = if (aimed || selected) MaterialTheme.colorScheme.onPrimary
                         else MaterialTheme.colorScheme.onSurface
                     ) {
                         Box(contentAlignment = Alignment.Center) {
@@ -215,7 +383,7 @@ fun PlayerStyleWheel(
                     Text(
                         text = entry.label,
                         style = MaterialTheme.typography.labelMedium,
-                        color = if (selected) MaterialTheme.colorScheme.primary
+                        color = if (aimed || selected) MaterialTheme.colorScheme.primary
                         else MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
@@ -223,9 +391,3 @@ fun PlayerStyleWheel(
         }
     }
 }
-
-private fun wheelRotationCos(degrees: Float): Float =
-    cos(Math.toRadians(degrees.toDouble())).toFloat()
-
-private fun wheelRotationSin(degrees: Float): Float =
-    sin(Math.toRadians(degrees.toDouble())).toFloat()

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PosterPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PosterPlayerContent.kt
@@ -19,7 +19,6 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -104,8 +103,7 @@ fun PosterPlayerSheetContent(
     ambientBackground: Boolean = true,
     onCollapse: () -> Unit,
     onLoadMore: () -> Unit = {},
-    onArtistClick: (String) -> Unit = {},
-    onRequestStyleSwitcher: () -> Unit = {}
+    onArtistClick: (String) -> Unit = {}
 ) {
     BackHandler(enabled = true) { onCollapse() }
 
@@ -246,7 +244,6 @@ fun PosterPlayerSheetContent(
                                     progress = progress,
                                     duration = duration,
                                     onSeekTo = { viewModel.seekTo(it) },
-                                    onLongPress = onRequestStyleSwitcher,
                                     ink = ink,
                                     accent = accent
                                 )
@@ -410,10 +407,10 @@ private fun PosterTitleStack(
     progress: Long,
     duration: Long,
     onSeekTo: (Long) -> Unit,
-    onLongPress: () -> Unit,
     ink: Color,
     accent: Color
 ) {
+    val styleWheel = LocalPlayerStyleWheelController.current
     val allWords = remember(title) { title.trim().split(Regex("\\s+")).filter { it.isNotBlank() } }
     val words = remember(allWords) {
         if (allWords.size > 5) allWords.take(4) + "…" else allWords.ifEmpty { listOf("Untitled") }
@@ -444,9 +441,6 @@ private fun PosterTitleStack(
             .padding(horizontal = 24.dp)
             .onSizeChanged { stackWidthPx = it.width.toFloat().coerceAtLeast(1f) }
             .pointerInput(Unit) {
-                detectTapGestures(onLongPress = { onLongPress() })
-            }
-            .pointerInput(Unit) {
                 detectHorizontalDragGestures(
                     onDragStart = {
                         scrubFraction = if (liveDuration > 0) {
@@ -464,7 +458,11 @@ private fun PosterTitleStack(
                             .coerceIn(0f, 1f)
                     }
                 )
-            },
+            }
+            // Last in the chain: processes the pointer stream first, so the
+            // post-long-press hold-drag is consumed before the scrub
+            // detector can see it.
+            .styleWheelHold(styleWheel),
         verticalArrangement = Arrangement.Center
     ) {
         val wordStyle = when {

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/StickerPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/StickerPlayerContent.kt
@@ -113,8 +113,7 @@ fun StickerPlayerSheetContent(
     ambientBackground: Boolean = true,
     onCollapse: () -> Unit,
     onLoadMore: () -> Unit = {},
-    onArtistClick: (String) -> Unit = {},
-    onRequestStyleSwitcher: () -> Unit = {}
+    onArtistClick: (String) -> Unit = {}
 ) {
     BackHandler(enabled = true) { onCollapse() }
 
@@ -257,7 +256,6 @@ fun StickerPlayerSheetContent(
                                     onLike = { viewModel.toggleCurrentSongLike() },
                                     onNext = { viewModel.skipToNext() },
                                     onPrevious = { viewModel.skipToPrevious() },
-                                    onLongPress = onRequestStyleSwitcher,
                                     ringColor = chipColor,
                                     placeholderColor = chipColor,
                                     placeholderIconColor = onChip
@@ -471,7 +469,6 @@ private fun DraggableSticker(
     onLike: () -> Unit,
     onNext: () -> Unit,
     onPrevious: () -> Unit,
-    onLongPress: () -> Unit,
     ringColor: Color,
     placeholderColor: Color,
     placeholderIconColor: Color
@@ -501,7 +498,7 @@ private fun DraggableSticker(
     val currentOnPrevious by rememberUpdatedState(onPrevious)
     val currentOnPlayPause by rememberUpdatedState(onPlayPause)
     val currentOnLike by rememberUpdatedState(onLike)
-    val currentOnLongPress by rememberUpdatedState(onLongPress)
+    val styleWheel = LocalPlayerStyleWheelController.current
 
     // New track: the fresh sticker slaps on with an overshooting entrance.
     LaunchedEffect(currentSong?.id) {
@@ -564,7 +561,6 @@ private fun DraggableSticker(
                 .background(placeholderColor)
                 .pointerInput(Unit) {
                     detectTapGestures(
-                        onLongPress = { currentOnLongPress() },
                         onTap = {
                             currentOnPlayPause()
                             scope.launch {
@@ -656,7 +652,10 @@ private fun DraggableSticker(
                             }
                         }
                     )
-                },
+                }
+                // Last in the chain: consumes the post-long-press hold
+                // stream before the tap and drag detectors see it.
+                .styleWheelHold(styleWheel),
             contentAlignment = Alignment.Center
         ) {
             val artModel = currentSong?.highResThumbnailUrl


### PR DESCRIPTION
## What this is

Follow-up to #62, which was merged just before this commit landed on the branch — it contains the final style wheel polish that missed the merge.

## Changes

- **Blurred background**: the live player content blurs beneath the style wheel (animated 0 to 24dp RenderEffect blur ramping with the theme's motion spec), and the overlay tint drops from a 96% solid to a light 45% wash so the player shows through. minSdk 31 means RenderEffect blur is available on every supported device.
- **Hold-to-select**: the wheel is now one continuous gesture. Keep holding after the long-press, drag toward a style — past a 56dp dead zone the aimed shape grows on a bouncy spring, fills primary, ticks haptically per aim change, and the center readout previews "Release for [Style]". Release commits with a confirm haptic; releasing inside the dead zone keeps the wheel open for tap selection.
- **Plumbing**: a `PlayerStyleWheelController` provided via CompositionLocal streams the hold-drag-release from the artwork into the wheel, replacing the per-style `onRequestStyleSwitcher` callback threading. The shared `Modifier.styleWheelHold` sits last in each artwork's modifier chain so it consumes the post-long-press stream before sibling tap/drag detectors see it — releasing in the center does not toggle play/pause, and Poster's scrub / Sticker's drag stay quiet while aiming.

## Verification

`compileDebugKotlin` green. Tunables worth feeling out on device: the 56dp aim dead zone and the 24dp blur strength.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMNQ5TdbvPtj3qA3MuC48z

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMNQ5TdbvPtj3qA3MuC48z)_