### PR TITLE
Keep screen awake during video playback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 .\gradlew assembleRelease        # needs KEYSTORE_PASSWORD / KEY_ALIAS / KEY_PASSWORD env vars
 ```
 
+- **Never compile or build (any `gradlew`/`gradle` invocation) unless the user explicitly asks for it.** Finish the code changes and stop — the user decides when to build.
 - There is no meaningful test suite (only the template instrumented test). Verification = compile + run on emulator.
 - Emulator: `emulator -avd Pixel_8_API36` (tools are on PATH), then `adb wait-for-device`. `Agents.md` documents an older `E:\sdk` setup — the current SDK lives at `E:\Android\Sdk`.
 - Version bumps happen in `app/build.gradle.kts` (`versionCode` / `versionName`). Dependency versions live only in `gradle/libs.versions.toml`.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <!-- Android 16+ Live Updates (Live Activities) -->
     <uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS" />

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerOverlay.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerOverlay.kt
@@ -62,6 +62,21 @@ fun VideoPlayerOverlay(
 
     if (currentVideo == null) return
 
+    // Keep the screen awake while a video is actually playing (mini, full or
+    // fullscreen). Cleared when paused, when the player closes, or in system
+    // PiP (the PiP window should not block the lock screen timeout).
+    DisposableEffect(isPlaying, isInPipMode) {
+        val window = activity?.window
+        if (isPlaying && !isInPipMode) {
+            window?.addFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        } else {
+            window?.clearFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+        onDispose {
+            window?.clearFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+    }
+
     // Update PiP Params (Active when video is present)
     val packageName = context.packageName
     val pipPlayAction = "$packageName.PIP_PLAY"

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
@@ -3,6 +3,8 @@ package com.ivor.ivormusic.ui.video
 import android.content.Context
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MimeTypes
 import androidx.media3.common.Player
@@ -149,8 +151,18 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
             .setPrioritizeTimeOverSizeThresholds(true)
             .build()
 
-        // Initialize ExoPlayer
-        _exoPlayer = ExoPlayer.Builder(context).setLoadControl(loadControl).build().apply {
+        // Initialize ExoPlayer.
+        // WAKE_MODE_NETWORK holds CPU + WiFi locks while playing: without it,
+        // locking the screen lets the device sleep, the network stalls, the
+        // buffer drains and playback dies in a stuck-buffering state.
+        // Audio focus + becoming-noisy mirror MusicService, so video playback
+        // pauses the music player (and vice versa) instead of playing over it.
+        _exoPlayer = ExoPlayer.Builder(context)
+            .setLoadControl(loadControl)
+            .setWakeMode(C.WAKE_MODE_NETWORK)
+            .setAudioAttributes(AudioAttributes.DEFAULT, true)
+            .setHandleAudioBecomingNoisy(true)
+            .build().apply {
             playWhenReady = true
             addListener(object : Player.Listener {
                 override fun onIsPlayingChanged(isPlaying: Boolean) {


### PR DESCRIPTION
## Summary
Adds screen wake-lock support for video playback to prevent the device from sleeping mid-stream, which would cause network stalls and playback to hang in a buffering state.

## Changes

- **VideoPlayerViewModel.kt**: Configure ExoPlayer with `WAKE_MODE_NETWORK` to hold CPU + WiFi locks during playback, and set audio attributes + audio-becoming-noisy handling to pause music playback when video plays (and vice versa), mirroring MusicService behavior.

- **VideoPlayerOverlay.kt**: Add `DisposableEffect` to manage `FLAG_KEEP_SCREEN_ON` window flag based on playback state — keeps screen awake when video is actively playing (mini, full, or fullscreen mode), but clears the flag when paused, player closes, or in system PiP mode (to avoid blocking lock screen timeout).

- **AndroidManifest.xml**: Add `WAKE_LOCK` permission required by ExoPlayer's `WAKE_MODE_NETWORK`.

- **CLAUDE.md**: Add guidance to never compile/build unless explicitly requested by the user.

## Implementation Details

The wake-lock strategy uses two complementary mechanisms:
1. **ExoPlayer-level**: `setWakeMode(C.WAKE_MODE_NETWORK)` holds system locks while the player is active.
2. **Window-level**: `FLAG_KEEP_SCREEN_ON` prevents screen timeout during active playback, with proper cleanup on pause/close/PiP.

Audio focus is configured to respect the existing music player — video playback will pause music and vice versa, consistent with the app's dual-pipeline architecture.

https://claude.ai/code/session_01XXatAtEhnfttqXbWgd8J5B