### PR TITLE
Add YouTube Shorts to video mode

### DIFF
--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -58,6 +58,7 @@ class MainActivity : ComponentActivity() {
             val playerStyle by themeViewModel.playerStyle.collectAsState()
             val saveVideoHistory by themeViewModel.saveVideoHistory.collectAsState()
             val timedCommentsEnabled by themeViewModel.timedCommentsEnabled.collectAsState()
+            val shortsEnabled by themeViewModel.shortsEnabled.collectAsState()
             val defaultVideoQuality by themeViewModel.defaultVideoQuality.collectAsState()
             val excludedFolders by themeViewModel.excludedFolders.collectAsState()
             val oemFixEnabled by themeViewModel.oemFixEnabled.collectAsState()
@@ -105,6 +106,8 @@ class MainActivity : ComponentActivity() {
                         onSaveVideoHistoryToggle = { themeViewModel.setSaveVideoHistory(it) },
                         timedCommentsEnabled = timedCommentsEnabled,
                         onTimedCommentsToggle = { themeViewModel.setTimedCommentsEnabled(it) },
+                        shortsEnabled = shortsEnabled,
+                        onShortsEnabledToggle = { themeViewModel.setShortsEnabled(it) },
                         defaultVideoQuality = defaultVideoQuality,
                         onDefaultVideoQualityChange = { themeViewModel.setDefaultVideoQuality(it) },
                         excludedFolders = excludedFolders,
@@ -157,6 +160,8 @@ fun MusicApp(
     onSaveVideoHistoryToggle: (Boolean) -> Unit,
     timedCommentsEnabled: Boolean,
     onTimedCommentsToggle: (Boolean) -> Unit,
+    shortsEnabled: Boolean,
+    onShortsEnabledToggle: (Boolean) -> Unit,
     defaultVideoQuality: String,
     onDefaultVideoQualityChange: (String) -> Unit,
     excludedFolders: Set<String>,
@@ -215,6 +220,8 @@ fun MusicApp(
                     onVideoModeToggle = onVideoModeToggle,
                     homeModeToggleEnabled = homeModeToggleEnabled,
                     onHomeModeToggleEnabledChange = onHomeModeToggleEnabledChange,
+                    shortsEnabled = shortsEnabled,
+                    onShortsEnabledToggle = onShortsEnabledToggle,
                     playerStyle = playerStyle,
                     onPlayerStyleChange = onPlayerStyleChange,
                     crossfadeEnabled = crossfadeEnabled,
@@ -253,6 +260,7 @@ fun MusicApp(
                         videoPlayerViewModel.exoPlayer?.pause()
                         shortsPlayerViewModel.open(shorts, index)
                     },
+                    shortsEnabled = shortsEnabled,
                     loadLocalSongs = loadLocalSongs,
                     excludedFolders = excludedFolders,
                     ambientBackground = ambientBackground,
@@ -290,6 +298,8 @@ fun MusicApp(
                     onSaveVideoHistoryToggle = onSaveVideoHistoryToggle,
                     timedCommentsEnabled = timedCommentsEnabled,
                     onTimedCommentsToggle = onTimedCommentsToggle,
+                    shortsEnabled = shortsEnabled,
+                    onShortsEnabledToggle = onShortsEnabledToggle,
                     defaultVideoQuality = defaultVideoQuality,
                     onDefaultVideoQualityChange = onDefaultVideoQualityChange,
                     excludedFolders = excludedFolders,

--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -192,7 +192,8 @@ fun MusicApp(
     val homeViewModel: HomeViewModel = viewModel()
     
     val videoPlayerViewModel: com.ivor.ivormusic.ui.video.VideoPlayerViewModel = viewModel()
-    
+    val shortsPlayerViewModel: com.ivor.ivormusic.ui.shorts.ShortsPlayerViewModel = viewModel()
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -245,6 +246,12 @@ fun MusicApp(
                     onNavigateToUpdate = { navController.navigate("update") },
                     onNavigateToVideoPlayer = { video ->
                         videoPlayerViewModel.playVideo(video)
+                    },
+                    onOpenShorts = { shorts, index ->
+                        // Shorts take over the screen; pause the video player
+                        // so the two ExoPlayers don't fight for audio focus
+                        videoPlayerViewModel.exoPlayer?.pause()
+                        shortsPlayerViewModel.open(shorts, index)
                     },
                     loadLocalSongs = loadLocalSongs,
                     excludedFolders = excludedFolders,
@@ -392,6 +399,11 @@ fun MusicApp(
         com.ivor.ivormusic.ui.video.VideoPlayerOverlay(
             viewModel = videoPlayerViewModel,
             timedCommentsEnabled = timedCommentsEnabled
+        )
+
+        // Shorts sit above everything, including the video player overlay
+        com.ivor.ivormusic.ui.shorts.ShortsPlayerOverlay(
+            viewModel = shortsPlayerViewModel
         )
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/data/ShortsItem.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/ShortsItem.kt
@@ -1,0 +1,39 @@
+package com.ivor.ivormusic.data
+
+/**
+ * One YouTube Short in a feed or swipe sequence.
+ *
+ * Shelf items (shortsLockupViewModel) carry title/view count; entries from
+ * reel_watch_sequence carry only the id and thumbnail — the player enriches
+ * them from the watch-next response once the Short is actually opened.
+ */
+data class ShortsItem(
+    val videoId: String,
+    val title: String = "",
+    val viewCount: String = "",
+    val thumbnailUrl: String? = null,
+    /**
+     * Params seeding the endless reel_watch_sequence feed starting at this
+     * Short. Present on shelf items, absent on sequence entries.
+     */
+    val sequenceParams: String? = null
+) {
+    /** Portrait first-frame thumbnail YouTube serves for every Short. */
+    val portraitThumbnailUrl: String
+        get() = thumbnailUrl ?: "https://i.ytimg.com/vi/$videoId/frame0.jpg"
+
+    fun toVideoItem(): VideoItem = VideoItem(
+        videoId = videoId,
+        title = title.ifBlank { "Short" },
+        channelName = "",
+        thumbnailUrl = portraitThumbnailUrl,
+        duration = 0L,
+        viewCount = viewCount
+    )
+}
+
+/** One page of the endless Shorts feed plus the token for the next page. */
+data class ShortsFeedPage(
+    val items: List<ShortsItem>,
+    val continuation: String?
+)

--- a/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
@@ -43,6 +43,9 @@ class ThemePreferences(context: Context) {
     private val _timedCommentsEnabled = MutableStateFlow(getTimedCommentsEnabledPreference())
     val timedCommentsEnabled: StateFlow<Boolean> = _timedCommentsEnabled.asStateFlow()
 
+    private val _shortsEnabled = MutableStateFlow(getShortsEnabledPreference())
+    val shortsEnabled: StateFlow<Boolean> = _shortsEnabled.asStateFlow()
+
     private val _defaultVideoQuality = MutableStateFlow(getDefaultVideoQualityPreference())
     val defaultVideoQuality: StateFlow<String> = _defaultVideoQuality.asStateFlow()
     
@@ -88,6 +91,7 @@ class ThemePreferences(context: Context) {
         private const val KEY_PLAYER_STYLE = "player_style"
         private const val KEY_SAVE_VIDEO_HISTORY = "save_video_history"
         private const val KEY_TIMED_COMMENTS_ENABLED = "timed_comments_enabled"
+        private const val KEY_SHORTS_ENABLED = "shorts_enabled"
         private const val KEY_DEFAULT_VIDEO_QUALITY = "default_video_quality"
 
         /** Sentinel meaning "highest available quality". */
@@ -333,6 +337,30 @@ class ThemePreferences(context: Context) {
      */
     fun toggleSaveVideoHistory() {
         setSaveVideoHistory(!_saveVideoHistory.value)
+    }
+
+    /**
+     * Get the stored Shorts preference. Defaults to false: short-form feeds
+     * are engineered to be compulsive, so Shorts stay hidden until the user
+     * deliberately opts in.
+     */
+    private fun getShortsEnabledPreference(): Boolean {
+        return prefs.getBoolean(KEY_SHORTS_ENABLED, false)
+    }
+
+    /**
+     * Fresh read of the Shorts preference straight from SharedPreferences —
+     * ViewModels hold their own ThemePreferences instances, so their StateFlow
+     * copy goes stale when the toggle flips through the settings screen.
+     */
+    fun isShortsEnabled(): Boolean = getShortsEnabledPreference()
+
+    /**
+     * Save Shorts preference and update the flow.
+     */
+    fun setShortsEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_SHORTS_ENABLED, enabled).apply()
+        _shortsEnabled.value = enabled
     }
 
     /**

--- a/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
@@ -2532,6 +2532,147 @@ class YouTubeRepository(private val context: Context) {
     }
     
     // ============================================================
+    // YouTube Shorts (www.youtube.com): shelf feed + endless
+    // reel_watch_sequence pager. Shapes verified against the live
+    // API July 2026.
+    // ============================================================
+
+    /**
+     * Shorts for the video home shelf. Logged in: the personalized Shorts
+     * shelf inside the FEwhat_to_watch home response (postWatchApi signs the
+     * call, so the shelf matches the account's recommendations). Logged out
+     * or shelf missing: an InnerTube search seeded from local watch history,
+     * which surfaces the same shortsLockupViewModel items.
+     */
+    suspend fun getShortsFeed(): List<ShortsItem> = withContext(Dispatchers.IO) {
+        if (sessionManager.isLoggedIn()) {
+            try {
+                val body = org.json.JSONObject()
+                    .put("context", webContext())
+                    .put("browseId", "FEwhat_to_watch")
+                val raw = postWatchApi("browse", body)
+                if (raw != null) {
+                    val shorts = parseShortsLockups(org.json.JSONObject(raw))
+                    if (shorts.isNotEmpty()) return@withContext shorts
+                }
+                android.util.Log.w("YouTubeRepo", "No Shorts shelf on home, using search fallback")
+            } catch (e: Exception) {
+                android.util.Log.e("YouTubeRepo", "Shorts home shelf failed", e)
+            }
+        }
+        try {
+            val seedChannel = videoHistoryRepository.getHistory()
+                .firstOrNull { it.channelName.isNotBlank() && it.channelName != "Unknown Channel" }
+                ?.channelName
+            val query = seedChannel?.let { "$it shorts" } ?: "trending shorts"
+            val body = org.json.JSONObject()
+                .put("context", webContext())
+                .put("query", query)
+            val raw = postWatchApi("search", body) ?: return@withContext emptyList()
+            parseShortsLockups(org.json.JSONObject(raw))
+        } catch (e: Exception) {
+            android.util.Log.e("YouTubeRepo", "Shorts search fallback failed", e)
+            emptyList()
+        }
+    }
+
+    /**
+     * One page of the endless swipe feed from reel/reel_watch_sequence.
+     * [sequenceParams] is either a shelf item's seed params or the
+     * continuation token of a previous page (the endpoint accepts both in
+     * the same field). Signed calls return the personalized sequence.
+     * Entries carry no title/views — the player enriches the current Short
+     * from its watch-next call.
+     */
+    suspend fun getShortsSequence(sequenceParams: String): ShortsFeedPage = withContext(Dispatchers.IO) {
+        try {
+            val body = org.json.JSONObject()
+                .put("context", webContext())
+                .put("sequenceParams", sequenceParams)
+            val raw = postWatchApi("reel/reel_watch_sequence", body)
+                ?: return@withContext ShortsFeedPage(emptyList(), null)
+            val root = org.json.JSONObject(raw)
+
+            val items = mutableListOf<ShortsItem>()
+            val entries = root.optJSONArray("entries")
+            if (entries != null) {
+                for (i in 0 until entries.length()) {
+                    val reel = entries.optJSONObject(i)
+                        ?.optJSONObject("command")
+                        ?.optJSONObject("reelWatchEndpoint") ?: continue
+                    parseReelWatchEndpoint(reel)?.let { items.add(it) }
+                }
+            }
+            val continuation = root.optJSONObject("continuationEndpoint")
+                ?.optJSONObject("continuationCommand")
+                ?.optString("token")?.takeIf { it.isNotBlank() }
+            ShortsFeedPage(items, continuation)
+        } catch (e: Exception) {
+            android.util.Log.e("YouTubeRepo", "getShortsSequence failed", e)
+            ShortsFeedPage(emptyList(), null)
+        }
+    }
+
+    /** All shortsLockupViewModels of a response, deduped, in shelf order. */
+    private fun parseShortsLockups(root: org.json.JSONObject): List<ShortsItem> {
+        val lockups = mutableListOf<org.json.JSONObject>()
+        findObjectsByKey(root, "shortsLockupViewModel", lockups)
+        return lockups.mapNotNull { parseShortsLockup(it) }
+            .distinctBy { it.videoId }
+            .take(30)
+    }
+
+    /**
+     * shortsLockupViewModel: videoId + sequenceParams live in
+     * onTap.innertubeCommand.reelWatchEndpoint, title/views in
+     * overlayMetadata.primaryText/secondaryText, portrait thumbnail in the
+     * reelWatchEndpoint (1080x1920 frame0).
+     */
+    private fun parseShortsLockup(lockup: org.json.JSONObject): ShortsItem? {
+        return try {
+            val reel = lockup.optJSONObject("onTap")
+                ?.optJSONObject("innertubeCommand")
+                ?.optJSONObject("reelWatchEndpoint") ?: return null
+            val base = parseReelWatchEndpoint(reel) ?: return null
+
+            val overlay = lockup.optJSONObject("overlayMetadata")
+            val title = overlay?.optJSONObject("primaryText")?.optString("content")
+                ?.takeIf { it.isNotBlank() } ?: ""
+            val viewCount = overlay?.optJSONObject("secondaryText")?.optString("content")
+                ?.takeIf { it.isNotBlank() } ?: ""
+
+            // Prefer the lockup's own thumbnailViewModel (sized variants) over
+            // the reel endpoint's single 1080x1920 frame
+            val sources = lockup.optJSONObject("thumbnailViewModel")
+                ?.optJSONObject("image")?.optJSONArray("sources")
+            val lockupThumb = sources?.optJSONObject(sources.length() - 1)
+                ?.optString("url")?.takeIf { it.isNotBlank() }
+
+            base.copy(
+                title = title,
+                viewCount = viewCount,
+                thumbnailUrl = lockupThumb ?: base.thumbnailUrl
+            )
+        } catch (e: Exception) {
+            android.util.Log.w("YouTubeRepo", "parseShortsLockup failed", e)
+            null
+        }
+    }
+
+    /** reelWatchEndpoint: videoId, portrait thumbnail and sequence seed. */
+    private fun parseReelWatchEndpoint(reel: org.json.JSONObject): ShortsItem? {
+        val videoId = reel.optString("videoId").takeIf { it.length == 11 } ?: return null
+        val thumbs = reel.optJSONObject("thumbnail")?.optJSONArray("thumbnails")
+        val thumbnailUrl = thumbs?.optJSONObject(0)?.optString("url")
+            ?.takeIf { it.isNotBlank() }
+        return ShortsItem(
+            videoId = videoId,
+            thumbnailUrl = thumbnailUrl,
+            sequenceParams = reel.optString("sequenceParams").takeIf { it.isNotBlank() }
+        )
+    }
+
+    // ============================================================
     // Video library (www.youtube.com): user playlists, Watch Later,
     // Liked videos. Shapes verified against the live API July 2026.
     // ============================================================

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeScreen.kt
@@ -145,6 +145,7 @@ fun HomeScreen(
     onNavigateToUpdate: () -> Unit = {},
     onNavigateToVideoPlayer: (VideoItem) -> Unit = {},
     onOpenShorts: (List<com.ivor.ivormusic.data.ShortsItem>, Int) -> Unit = { _, _ -> },
+    shortsEnabled: Boolean = false,
     loadLocalSongs: Boolean = true,
     excludedFolders: Set<String> = emptySet(),
     ambientBackground: Boolean = true,
@@ -215,6 +216,14 @@ fun HomeScreen(
     LaunchedEffect(videoMode) {
         if (videoMode) {
             viewModel.loadTrendingVideos()
+        }
+    }
+
+    // Fetch the Shorts shelf when the user opts in mid-session (the load
+    // itself also gates on the preference)
+    LaunchedEffect(videoMode, shortsEnabled) {
+        if (videoMode && shortsEnabled) {
+            viewModel.loadShortsFeed()
         }
     }
 
@@ -326,7 +335,7 @@ fun HomeScreen(
                                         // Navigate to video player screen
                                         onNavigateToVideoPlayer(video)
                                     },
-                                    shorts = shortsFeed,
+                                    shorts = if (shortsEnabled) shortsFeed else emptyList(),
                                     onShortClick = { index -> onOpenShorts(shortsFeed, index) },
                                     onProfileClick = onProfileClick,
                                     onSettingsClick = onNavigateToSettings,

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeScreen.kt
@@ -144,6 +144,7 @@ fun HomeScreen(
     onNavigateToStats: () -> Unit = {},
     onNavigateToUpdate: () -> Unit = {},
     onNavigateToVideoPlayer: (VideoItem) -> Unit = {},
+    onOpenShorts: (List<com.ivor.ivormusic.data.ShortsItem>, Int) -> Unit = { _, _ -> },
     loadLocalSongs: Boolean = true,
     excludedFolders: Set<String> = emptySet(),
     ambientBackground: Boolean = true,
@@ -208,6 +209,7 @@ fun HomeScreen(
     // Video mode state
     val trendingVideos by viewModel.trendingVideos.collectAsState()
     val isVideoLoading by viewModel.isVideoLoading.collectAsState()
+    val shortsFeed by viewModel.shortsFeed.collectAsState()
     
     // Load videos when video mode is enabled
     LaunchedEffect(videoMode) {
@@ -324,6 +326,8 @@ fun HomeScreen(
                                         // Navigate to video player screen
                                         onNavigateToVideoPlayer(video)
                                     },
+                                    shorts = shortsFeed,
+                                    onShortClick = { index -> onOpenShorts(shortsFeed, index) },
                                     onProfileClick = onProfileClick,
                                     onSettingsClick = onNavigateToSettings,
                                     onDownloadsClick = onNavigateToDownloads,

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
@@ -128,6 +128,9 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     
     private val _historyVideos = MutableStateFlow<List<VideoItem>>(emptyList())
     val historyVideos: StateFlow<List<VideoItem>> = _historyVideos.asStateFlow()
+
+    private val _shortsFeed = MutableStateFlow<List<com.ivor.ivormusic.data.ShortsItem>>(emptyList())
+    val shortsFeed: StateFlow<List<com.ivor.ivormusic.data.ShortsItem>> = _shortsFeed.asStateFlow()
     
     private val _isHistoryLoading = MutableStateFlow(false)
     val isHistoryLoading: StateFlow<Boolean> = _isHistoryLoading.asStateFlow()
@@ -534,8 +537,10 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
 
     /**
      * Load trending/recommended videos for video mode home screen.
+     * Also refreshes the Shorts shelf in parallel.
      */
     fun loadTrendingVideos() {
+        loadShortsFeed()
         viewModelScope.launch {
             _isVideoLoading.value = true
             try {
@@ -547,6 +552,23 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
                 // Handle error silently
             } finally {
                 _isVideoLoading.value = false
+            }
+        }
+    }
+
+    /**
+     * Load the Shorts shelf (personalized when logged in, search-seeded
+     * otherwise). Failures leave the previous shelf in place.
+     */
+    fun loadShortsFeed() {
+        viewModelScope.launch {
+            try {
+                val shorts = youtubeRepository.getShortsFeed()
+                if (shorts.isNotEmpty()) {
+                    _shortsFeed.value = shorts
+                }
+            } catch (e: Exception) {
+                // Keep whatever shelf we already have
             }
         }
     }

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
@@ -28,6 +28,7 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     private val searchHistoryRepository = com.ivor.ivormusic.data.SearchHistoryRepository(application)
     private val recommendationEngine = com.ivor.ivormusic.data.RecommendationEngine(application, youtubeRepository)
     private val videoHistoryRepository = com.ivor.ivormusic.data.VideoHistoryRepository(application)
+    private val themePreferences = com.ivor.ivormusic.data.ThemePreferences(application)
 
     private val _songs = MutableStateFlow<List<Song>>(emptyList())
     val songs: StateFlow<List<Song>> = _songs.asStateFlow()
@@ -558,9 +559,12 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
 
     /**
      * Load the Shorts shelf (personalized when logged in, search-seeded
-     * otherwise). Failures leave the previous shelf in place.
+     * otherwise). No-op unless the user opted into Shorts — fresh pref read,
+     * since the settings screen toggles through its own ThemePreferences
+     * instance. Failures leave the previous shelf in place.
      */
     fun loadShortsFeed() {
+        if (!themePreferences.isShortsEnabled()) return
         viewModelScope.launch {
             try {
                 val shorts = youtubeRepository.getShortsFeed()

--- a/app/src/main/java/com/ivor/ivormusic/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/onboarding/OnboardingScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.ArrowForward
 import androidx.compose.material.icons.rounded.Album
+import androidx.compose.material.icons.rounded.Bolt
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.CloudSync
@@ -59,6 +60,7 @@ import androidx.compose.material.icons.rounded.Palette
 import androidx.compose.material.icons.rounded.PhoneAndroid
 import androidx.compose.material.icons.rounded.ToggleOn
 import androidx.compose.material.icons.rounded.Tune
+import androidx.compose.material.icons.rounded.WarningAmber
 import androidx.compose.material.icons.rounded.Videocam
 import androidx.compose.material.icons.rounded.Wallpaper
 import androidx.compose.material3.Button
@@ -131,6 +133,8 @@ fun OnboardingScreen(
     onVideoModeToggle: (Boolean) -> Unit,
     homeModeToggleEnabled: Boolean = true,
     onHomeModeToggleEnabledChange: (Boolean) -> Unit = {},
+    shortsEnabled: Boolean = false,
+    onShortsEnabledToggle: (Boolean) -> Unit = {},
     playerStyle: PlayerStyle,
     onPlayerStyleChange: (PlayerStyle) -> Unit,
     crossfadeEnabled: Boolean,
@@ -271,6 +275,8 @@ fun OnboardingScreen(
                         )
                         3 -> VideoModePage(
                             videoMode = videoMode,
+                            shortsEnabled = shortsEnabled,
+                            onShortsEnabledToggle = onShortsEnabledToggle,
                             onVideoModeToggle = onVideoModeToggle,
                             homeModeToggleEnabled = homeModeToggleEnabled,
                             onHomeModeToggleEnabledChange = onHomeModeToggleEnabledChange
@@ -569,7 +575,9 @@ private fun VideoModePage(
     videoMode: Boolean,
     onVideoModeToggle: (Boolean) -> Unit,
     homeModeToggleEnabled: Boolean,
-    onHomeModeToggleEnabledChange: (Boolean) -> Unit
+    onHomeModeToggleEnabledChange: (Boolean) -> Unit,
+    shortsEnabled: Boolean,
+    onShortsEnabledToggle: (Boolean) -> Unit
 ) {
     OnboardingPageScaffold(
         icon = Icons.Rounded.Videocam,
@@ -593,7 +601,49 @@ private fun VideoModePage(
             onCheckedChange = onHomeModeToggleEnabledChange
         )
 
+        SettingSwitchRow(
+            icon = Icons.Rounded.Bolt,
+            title = "Shorts",
+            subtitle = "A Shorts shelf and vertical swipe player in video mode",
+            checked = shortsEnabled,
+            onCheckedChange = onShortsEnabledToggle
+        )
+
+        ShortsWarningCard()
+
         HintText("Off keeps a cleaner, music-first layout. The video player stays available either way.")
+    }
+}
+
+/**
+ * Deliberate friction before enabling Shorts: endless short-form feeds are
+ * engineered to be compulsive, so Koda ships them off and warns before the
+ * user opts in.
+ */
+@Composable
+private fun ShortsWarningCard() {
+    Surface(
+        shape = RoundedCornerShape(24.dp),
+        color = MaterialTheme.colorScheme.errorContainer,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 18.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.WarningAmber,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onErrorContainer,
+                modifier = Modifier.size(24.dp)
+            )
+            Spacer(modifier = Modifier.width(14.dp))
+            Text(
+                text = "Endless short-form feeds are designed to keep you scrolling. Shorts stay off unless you choose them, and you can turn them off again any time in Settings.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.material.icons.automirrored.rounded.Comment
 import androidx.compose.material.icons.automirrored.rounded.Logout
 import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import androidx.compose.material.icons.rounded.AccountCircle
+import androidx.compose.material.icons.rounded.Bolt
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Animation
 import androidx.compose.material.icons.rounded.CheckCircle
@@ -198,6 +199,8 @@ fun SettingsScreen(
     onSaveVideoHistoryToggle: (Boolean) -> Unit,
     timedCommentsEnabled: Boolean,
     onTimedCommentsToggle: (Boolean) -> Unit,
+    shortsEnabled: Boolean,
+    onShortsEnabledToggle: (Boolean) -> Unit,
     defaultVideoQuality: String,
     onDefaultVideoQualityChange: (String) -> Unit,
     excludedFolders: Set<String>,
@@ -709,6 +712,16 @@ fun SettingsScreen(
                         ExpressiveTimedCommentsToggleItem(
                             enabled = timedCommentsEnabled,
                             onToggle = onTimedCommentsToggle,
+                            textColor = textColor,
+                            secondaryTextColor = secondaryTextColor,
+                            accentColor = accentColor
+                        )
+
+                        SettingsDivider()
+
+                        ExpressiveShortsToggleItem(
+                            enabled = shortsEnabled,
+                            onToggle = onShortsEnabledToggle,
                             textColor = textColor,
                             secondaryTextColor = secondaryTextColor,
                             accentColor = accentColor
@@ -1583,6 +1596,95 @@ private fun ExpressiveTimedCommentsToggleItem(
             Text(
                 text = if (enabled) "Timestamped comments briefly appear over videos" else "Adds a comments button to the video player",
                 color = secondaryTextColor,
+                fontSize = 13.sp
+            )
+        }
+
+        // Switch
+        Switch(
+            checked = enabled,
+            onCheckedChange = onToggle,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = Color.White,
+                checkedTrackColor = accentColor,
+                uncheckedThumbColor = Color.White,
+                uncheckedTrackColor = secondaryTextColor.copy(alpha = 0.3f),
+                uncheckedBorderColor = Color.Transparent,
+                checkedBorderColor = Color.Transparent
+            )
+        )
+    }
+}
+
+/**
+ * Opt-in toggle for YouTube Shorts, off by default. The subtitle carries a
+ * deliberate warning: short-form feeds are engineered to be compulsive, so
+ * the user should choose them consciously rather than get them by default.
+ */
+@Composable
+private fun ExpressiveShortsToggleItem(
+    enabled: Boolean,
+    onToggle: (Boolean) -> Unit,
+    textColor: Color,
+    secondaryTextColor: Color,
+    accentColor: Color
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.97f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
+        label = "scale"
+    )
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .scale(scale)
+            .clip(RoundedCornerShape(18.dp))
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null
+            ) { onToggle(!enabled) }
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // Icon
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .clip(RoundedCornerShape(14.dp))
+                .background(accentColor.copy(alpha = 0.12f)),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.Bolt,
+                contentDescription = null,
+                tint = accentColor,
+                modifier = Modifier.size(26.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        // Text
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = "Shorts",
+                color = textColor,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = if (enabled) {
+                    "Shorts shelf shown in video mode. Mind your screen time"
+                } else {
+                    "Off by default. Endless short-form feeds are designed to keep you scrolling"
+                },
+                color = if (enabled) MaterialTheme.colorScheme.error.copy(alpha = 0.9f)
+                    else secondaryTextColor,
                 fontSize = 13.sp
             )
         }

--- a/app/src/main/java/com/ivor/ivormusic/ui/shorts/ShortsPlayerOverlay.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/shorts/ShortsPlayerOverlay.kt
@@ -1,0 +1,573 @@
+package com.ivor.ivormusic.ui.shorts
+
+import android.content.Intent
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.pager.VerticalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.outlined.ThumbDown
+import androidx.compose.material.icons.outlined.ThumbUp
+import androidx.compose.material.icons.rounded.ChatBubble
+import androidx.compose.material.icons.rounded.ErrorOutline
+import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Share
+import androidx.compose.material.icons.rounded.ThumbDown
+import androidx.compose.material.icons.rounded.ThumbUp
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.ui.AspectRatioFrameLayout
+import androidx.media3.ui.PlayerView
+import coil.compose.AsyncImage
+import com.ivor.ivormusic.data.LikeStatus
+import com.ivor.ivormusic.ui.video.CommentsSheet
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive as coroutineIsActive
+
+/**
+ * Fullscreen vertical-swipe Shorts player, layered above the NavHost like
+ * VideoPlayerOverlay. One shared ExoPlayer follows the settled pager page;
+ * neighbouring pages show their portrait thumbnails.
+ */
+@androidx.annotation.OptIn(UnstableApi::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun ShortsPlayerOverlay(viewModel: ShortsPlayerViewModel) {
+    val isActive by viewModel.isActive.collectAsState()
+    if (!isActive) return
+
+    val context = LocalContext.current
+    val activity = context as? androidx.activity.ComponentActivity
+
+    val shorts by viewModel.shorts.collectAsState()
+    val currentVideo by viewModel.currentVideo.collectAsState()
+    val isPlaying by viewModel.isPlaying.collectAsState()
+    val isBuffering by viewModel.isBuffering.collectAsState()
+    val playbackError by viewModel.playbackError.collectAsState()
+    val engagement by viewModel.engagement.collectAsState()
+    val isLoggedIn by viewModel.isLoggedIn.collectAsState()
+
+    val comments by viewModel.comments.collectAsState()
+    val commentReplies by viewModel.replies.collectAsState()
+    val loadingReplyIds by viewModel.loadingReplyIds.collectAsState()
+    val isCommentsLoading by viewModel.isCommentsLoading.collectAsState()
+    val isLoadingMoreComments by viewModel.isLoadingMoreComments.collectAsState()
+    val canComment by viewModel.canComment.collectAsState()
+    val isPostingComment by viewModel.isPostingComment.collectAsState()
+
+    var showCommentsSheet by remember { mutableStateOf(false) }
+    var showSignInDialog by remember { mutableStateOf(false) }
+
+    fun requireLogin(action: () -> Unit) {
+        if (isLoggedIn) action() else showSignInDialog = true
+    }
+
+    BackHandler { viewModel.close() }
+
+    // Keep the screen awake while a Short is playing
+    DisposableEffect(isPlaying) {
+        val window = activity?.window
+        if (isPlaying) {
+            window?.addFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        } else {
+            window?.clearFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+        onDispose {
+            window?.clearFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+    }
+
+    // The whole overlay leaves composition on close, so this pager (and its
+    // initial page) is recreated fresh on every open
+    val pagerState = rememberPagerState(
+        initialPage = viewModel.currentIndex.value
+    ) { shorts.size }
+
+    LaunchedEffect(pagerState) {
+        snapshotFlow { pagerState.settledPage }.collect { page ->
+            viewModel.onPageSelected(page)
+        }
+    }
+
+    // Thin playback progress bar at the very bottom, YouTube-style
+    var progress by remember { mutableFloatStateOf(0f) }
+    LaunchedEffect(currentVideo) {
+        progress = 0f
+        while (coroutineIsActive) {
+            val player = viewModel.exoPlayer
+            val duration = player?.duration ?: 0L
+            progress = if (duration > 0) {
+                (player?.currentPosition ?: 0L).toFloat() / duration.toFloat()
+            } else 0f
+            delay(250)
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black)
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null
+            ) { /* consume clicks so the app underneath stays inert */ }
+    ) {
+        VerticalPager(
+            state = pagerState,
+            modifier = Modifier.fillMaxSize(),
+            beyondViewportPageCount = 1
+        ) { page ->
+            val item = shorts[page]
+            val isCurrent = page == pagerState.settledPage
+
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black)
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null
+                    ) { if (isCurrent) viewModel.togglePlayPause() }
+            ) {
+                // Portrait thumbnail behind the surface: visible on
+                // neighbouring pages and while the current one buffers
+                AsyncImage(
+                    model = item.portraitThumbnailUrl,
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
+                )
+
+                if (isCurrent && playbackError == null) {
+                    AndroidView(
+                        factory = { ctx ->
+                            PlayerView(ctx).apply {
+                                useController = false
+                                resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM
+                            }
+                        },
+                        update = { pv -> pv.player = viewModel.exoPlayer },
+                        onRelease = { pv -> pv.player = null },
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
+
+                if (isCurrent) {
+                    // Buffering: expressive shape-morphing loader
+                    AnimatedVisibility(
+                        visible = isBuffering && playbackError == null,
+                        enter = fadeIn(),
+                        exit = fadeOut(),
+                        modifier = Modifier.align(Alignment.Center)
+                    ) {
+                        LoadingIndicator(
+                            modifier = Modifier.size(56.dp),
+                            color = Color.White
+                        )
+                    }
+
+                    // Paused badge with a springy pop
+                    AnimatedVisibility(
+                        visible = !isPlaying && !isBuffering && playbackError == null,
+                        enter = scaleIn(
+                            initialScale = 0.6f,
+                            animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
+                        ) + fadeIn(),
+                        exit = scaleOut(targetScale = 0.6f) + fadeOut(),
+                        modifier = Modifier.align(Alignment.Center)
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(72.dp)
+                                .clip(CircleShape)
+                                .background(Color.Black.copy(alpha = 0.55f)),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                imageVector = Icons.Rounded.PlayArrow,
+                                contentDescription = "Play",
+                                tint = Color.White,
+                                modifier = Modifier.size(40.dp)
+                            )
+                        }
+                    }
+
+                    if (playbackError != null) {
+                        Column(
+                            modifier = Modifier.align(Alignment.Center),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            Icon(
+                                imageVector = Icons.Rounded.ErrorOutline,
+                                contentDescription = null,
+                                tint = Color.White,
+                                modifier = Modifier.size(48.dp)
+                            )
+                            Spacer(modifier = Modifier.height(12.dp))
+                            Text(
+                                text = playbackError?.message ?: "Playback failed",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = Color.White.copy(alpha = 0.85f)
+                            )
+                            Spacer(modifier = Modifier.height(16.dp))
+                            Button(
+                                onClick = { viewModel.retryCurrent() },
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = Color.White,
+                                    contentColor = Color.Black
+                                )
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Rounded.Refresh,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(18.dp)
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text("Retry")
+                            }
+                        }
+                    }
+                }
+
+                // Bottom scrim for metadata + action legibility
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(260.dp)
+                        .align(Alignment.BottomCenter)
+                        .background(
+                            Brush.verticalGradient(
+                                colors = listOf(Color.Transparent, Color.Black.copy(alpha = 0.7f))
+                            )
+                        )
+                )
+            }
+        }
+
+        // Top scrim + bar
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(140.dp)
+                .background(
+                    Brush.verticalGradient(
+                        colors = listOf(Color.Black.copy(alpha = 0.55f), Color.Transparent)
+                    )
+                )
+        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .windowInsetsPadding(WindowInsets.statusBars)
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(
+                onClick = { viewModel.close() },
+                shapes = IconButtonDefaults.shapes(),
+                colors = IconButtonDefaults.iconButtonColors(
+                    containerColor = Color.Black.copy(alpha = 0.35f),
+                    contentColor = Color.White
+                )
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                    contentDescription = "Close Shorts"
+                )
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "Shorts",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = Color.White
+            )
+        }
+
+        // Metadata (bottom-left) + action rail (bottom-right)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter)
+                .windowInsetsPadding(WindowInsets.navigationBars)
+                .padding(start = 16.dp, end = 8.dp, bottom = 12.dp),
+            verticalAlignment = Alignment.Bottom
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                val video = currentVideo
+                if (video != null && video.channelName.isNotBlank()) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Box(
+                            modifier = Modifier
+                                .size(36.dp)
+                                .clip(CircleShape)
+                                .background(Color.White.copy(alpha = 0.2f)),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            if (!video.channelIconUrl.isNullOrBlank()) {
+                                AsyncImage(
+                                    model = video.channelIconUrl,
+                                    contentDescription = null,
+                                    modifier = Modifier.fillMaxSize(),
+                                    contentScale = ContentScale.Crop
+                                )
+                            } else {
+                                Icon(
+                                    imageVector = Icons.Rounded.Person,
+                                    contentDescription = null,
+                                    tint = Color.White,
+                                    modifier = Modifier.size(20.dp)
+                                )
+                            }
+                        }
+                        Spacer(modifier = Modifier.width(10.dp))
+                        Text(
+                            text = video.channelName,
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.SemiBold,
+                            color = Color.White,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f, fill = false)
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        val isSubscribed = engagement?.isSubscribed == true
+                        Button(
+                            onClick = { requireLogin { viewModel.toggleSubscribe() } },
+                            colors = if (isSubscribed) {
+                                ButtonDefaults.buttonColors(
+                                    containerColor = Color.White.copy(alpha = 0.2f),
+                                    contentColor = Color.White
+                                )
+                            } else {
+                                ButtonDefaults.buttonColors(
+                                    containerColor = Color.White,
+                                    contentColor = Color.Black
+                                )
+                            },
+                            contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                                horizontal = 14.dp, vertical = 6.dp
+                            ),
+                            modifier = Modifier.height(32.dp)
+                        ) {
+                            Text(
+                                text = if (isSubscribed) "Subscribed" else "Subscribe",
+                                style = MaterialTheme.typography.labelMedium,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(10.dp))
+                }
+                if (video != null && video.title.isNotBlank()) {
+                    Text(
+                        text = video.title,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = Color.White,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(14.dp)
+            ) {
+                val likeStatus = engagement?.likeStatus ?: LikeStatus.INDIFFERENT
+                ShortsAction(
+                    icon = if (likeStatus == LikeStatus.LIKE) Icons.Rounded.ThumbUp
+                        else Icons.Outlined.ThumbUp,
+                    label = engagement?.likeCount ?: "Like",
+                    active = likeStatus == LikeStatus.LIKE,
+                    contentDescription = "Like",
+                    onClick = { requireLogin { viewModel.toggleLike() } }
+                )
+                ShortsAction(
+                    icon = if (likeStatus == LikeStatus.DISLIKE) Icons.Rounded.ThumbDown
+                        else Icons.Outlined.ThumbDown,
+                    label = "Dislike",
+                    active = likeStatus == LikeStatus.DISLIKE,
+                    contentDescription = "Dislike",
+                    onClick = { requireLogin { viewModel.toggleDislike() } }
+                )
+                ShortsAction(
+                    icon = Icons.Rounded.ChatBubble,
+                    label = "Comments",
+                    contentDescription = "Comments",
+                    onClick = {
+                        viewModel.ensureCommentsLoaded()
+                        showCommentsSheet = true
+                    }
+                )
+                ShortsAction(
+                    icon = Icons.Rounded.Share,
+                    label = "Share",
+                    contentDescription = "Share",
+                    onClick = {
+                        val videoId = currentVideo?.videoId ?: return@ShortsAction
+                        val send = Intent(Intent.ACTION_SEND).apply {
+                            type = "text/plain"
+                            putExtra(Intent.EXTRA_TEXT, "https://youtube.com/shorts/$videoId")
+                        }
+                        context.startActivity(Intent.createChooser(send, "Share Short"))
+                    }
+                )
+            }
+        }
+
+        // Thin progress line hugging the bottom edge
+        LinearProgressIndicator(
+            progress = { progress.coerceIn(0f, 1f) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(2.dp)
+                .align(Alignment.BottomCenter),
+            color = MaterialTheme.colorScheme.primary,
+            trackColor = Color.White.copy(alpha = 0.25f),
+            drawStopIndicator = {}
+        )
+    }
+
+    if (showCommentsSheet) {
+        CommentsSheet(
+            comments = comments,
+            replies = commentReplies,
+            loadingReplyIds = loadingReplyIds,
+            isLoading = isCommentsLoading,
+            isLoadingMore = isLoadingMoreComments,
+            commentsAvailable = engagement?.commentsToken != null,
+            canComment = canComment,
+            isPosting = isPostingComment,
+            onLoadMore = { viewModel.loadMoreComments() },
+            onLoadReplies = { viewModel.loadReplies(it) },
+            onPostComment = { viewModel.postComment(it) },
+            onPostReply = { target, threadParent, text ->
+                viewModel.postReply(target, threadParent, text)
+            },
+            onLikeComment = { comment -> requireLogin { viewModel.toggleCommentLike(comment) } },
+            onDeleteComment = { comment -> viewModel.deleteComment(comment) },
+            onDismiss = { showCommentsSheet = false }
+        )
+    }
+
+    if (showSignInDialog) {
+        com.ivor.ivormusic.ui.auth.YouTubeAuthDialog(
+            onDismiss = { showSignInDialog = false },
+            onAuthSuccess = {
+                showSignInDialog = false
+                viewModel.onLoginStateChanged()
+            }
+        )
+    }
+}
+
+/**
+ * One button of the right-hand action rail: circular translucent icon
+ * button with a spring scale bump when it becomes active, label underneath.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun ShortsAction(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    contentDescription: String,
+    active: Boolean = false,
+    onClick: () -> Unit
+) {
+    val scale by animateFloatAsState(
+        targetValue = if (active) 1.12f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
+        label = "actionScale"
+    )
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        IconButton(
+            onClick = onClick,
+            shapes = IconButtonDefaults.shapes(),
+            colors = IconButtonDefaults.iconButtonColors(
+                containerColor = Color.Black.copy(alpha = 0.35f),
+                contentColor = if (active) MaterialTheme.colorScheme.primary else Color.White
+            ),
+            modifier = Modifier
+                .size(48.dp)
+                .scale(scale)
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = contentDescription,
+                modifier = Modifier.size(24.dp)
+            )
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Medium,
+            color = Color.White,
+            maxLines = 1
+        )
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/shorts/ShortsPlayerOverlay.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/shorts/ShortsPlayerOverlay.kt
@@ -3,9 +3,12 @@ package com.ivor.ivormusic.ui.shorts
 import android.content.Intent
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
@@ -27,10 +30,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.outlined.ThumbDown
@@ -47,13 +52,17 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
-import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.LinearWavyProgressIndicator
 import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialShapes
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.toShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -67,12 +76,14 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -83,12 +94,19 @@ import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.LikeStatus
 import com.ivor.ivormusic.ui.video.CommentsSheet
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.isActive as coroutineIsActive
 
 /**
  * Fullscreen vertical-swipe Shorts player, layered above the NavHost like
  * VideoPlayerOverlay. One shared ExoPlayer follows the settled pager page;
  * neighbouring pages show their portrait thumbnails.
+ *
+ * Speaks Koda's Material 3 Expressive dialect: a floating tonal pill for the
+ * action rail (like FloatingPillNavBar), secondaryContainer active states, a
+ * Burst-shape flash on like (LikeBurstIcon pattern), MaterialShapes for the
+ * pause badge and channel avatar, and a wavy progress line that flattens
+ * while paused.
  */
 @androidx.annotation.OptIn(UnstableApi::class)
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -150,7 +168,7 @@ fun ShortsPlayerOverlay(viewModel: ShortsPlayerViewModel) {
         }
     }
 
-    // Thin playback progress bar at the very bottom, YouTube-style
+    // Playback progress for the wavy line at the bottom
     var progress by remember { mutableFloatStateOf(0f) }
     LaunchedEffect(currentVideo) {
         progress = 0f
@@ -214,20 +232,29 @@ fun ShortsPlayerOverlay(viewModel: ShortsPlayerViewModel) {
                 }
 
                 if (isCurrent) {
-                    // Buffering: expressive shape-morphing loader
+                    // Buffering: the expressive shape-morphing loader on a
+                    // tonal puck so it reads on any video frame
                     AnimatedVisibility(
                         visible = isBuffering && playbackError == null,
                         enter = fadeIn(),
                         exit = fadeOut(),
                         modifier = Modifier.align(Alignment.Center)
                     ) {
-                        LoadingIndicator(
-                            modifier = Modifier.size(56.dp),
-                            color = Color.White
-                        )
+                        Box(
+                            modifier = Modifier
+                                .size(72.dp)
+                                .clip(CircleShape)
+                                .background(MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.92f)),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            LoadingIndicator(
+                                modifier = Modifier.size(44.dp),
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        }
                     }
 
-                    // Paused badge with a springy pop
+                    // Paused badge: expressive cookie shape with a springy pop
                     AnimatedVisibility(
                         visible = !isPlaying && !isBuffering && playbackError == null,
                         enter = scaleIn(
@@ -239,58 +266,69 @@ fun ShortsPlayerOverlay(viewModel: ShortsPlayerViewModel) {
                     ) {
                         Box(
                             modifier = Modifier
-                                .size(72.dp)
-                                .clip(CircleShape)
-                                .background(Color.Black.copy(alpha = 0.55f)),
+                                .size(80.dp)
+                                .clip(MaterialShapes.Cookie12Sided.toShape())
+                                .background(MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.95f)),
                             contentAlignment = Alignment.Center
                         ) {
                             Icon(
                                 imageVector = Icons.Rounded.PlayArrow,
                                 contentDescription = "Play",
-                                tint = Color.White,
+                                tint = MaterialTheme.colorScheme.onPrimaryContainer,
                                 modifier = Modifier.size(40.dp)
                             )
                         }
                     }
 
                     if (playbackError != null) {
-                        Column(
-                            modifier = Modifier.align(Alignment.Center),
-                            horizontalAlignment = Alignment.CenterHorizontally
+                        Surface(
+                            modifier = Modifier
+                                .align(Alignment.Center)
+                                .padding(horizontal = 32.dp),
+                            shape = RoundedCornerShape(28.dp),
+                            color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.95f)
                         ) {
-                            Icon(
-                                imageVector = Icons.Rounded.ErrorOutline,
-                                contentDescription = null,
-                                tint = Color.White,
-                                modifier = Modifier.size(48.dp)
-                            )
-                            Spacer(modifier = Modifier.height(12.dp))
-                            Text(
-                                text = playbackError?.message ?: "Playback failed",
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = Color.White.copy(alpha = 0.85f)
-                            )
-                            Spacer(modifier = Modifier.height(16.dp))
-                            Button(
-                                onClick = { viewModel.retryCurrent() },
-                                colors = ButtonDefaults.buttonColors(
-                                    containerColor = Color.White,
-                                    contentColor = Color.Black
-                                )
+                            Column(
+                                modifier = Modifier.padding(24.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally
                             ) {
-                                Icon(
-                                    imageVector = Icons.Rounded.Refresh,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(18.dp)
+                                Box(
+                                    modifier = Modifier
+                                        .size(56.dp)
+                                        .clip(MaterialShapes.Cookie9Sided.toShape())
+                                        .background(MaterialTheme.colorScheme.errorContainer),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Rounded.ErrorOutline,
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.onErrorContainer,
+                                        modifier = Modifier.size(28.dp)
+                                    )
+                                }
+                                Spacer(modifier = Modifier.height(14.dp))
+                                Text(
+                                    text = playbackError?.message ?: "Playback failed",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                    textAlign = TextAlign.Center
                                 )
-                                Spacer(modifier = Modifier.width(8.dp))
-                                Text("Retry")
+                                Spacer(modifier = Modifier.height(16.dp))
+                                FilledTonalButton(onClick = { viewModel.retryCurrent() }) {
+                                    Icon(
+                                        imageVector = Icons.Rounded.Refresh,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(18.dp)
+                                    )
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    Text("Retry")
+                                }
                             }
                         }
                     }
                 }
 
-                // Bottom scrim for metadata + action legibility
+                // Bottom scrim for metadata legibility
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -298,7 +336,7 @@ fun ShortsPlayerOverlay(viewModel: ShortsPlayerViewModel) {
                         .align(Alignment.BottomCenter)
                         .background(
                             Brush.verticalGradient(
-                                colors = listOf(Color.Transparent, Color.Black.copy(alpha = 0.7f))
+                                colors = listOf(Color.Transparent, Color.Black.copy(alpha = 0.65f))
                             )
                         )
                 )
@@ -312,7 +350,7 @@ fun ShortsPlayerOverlay(viewModel: ShortsPlayerViewModel) {
                 .height(140.dp)
                 .background(
                     Brush.verticalGradient(
-                        colors = listOf(Color.Black.copy(alpha = 0.55f), Color.Transparent)
+                        colors = listOf(Color.Black.copy(alpha = 0.5f), Color.Transparent)
                     )
                 )
         )
@@ -327,8 +365,8 @@ fun ShortsPlayerOverlay(viewModel: ShortsPlayerViewModel) {
                 onClick = { viewModel.close() },
                 shapes = IconButtonDefaults.shapes(),
                 colors = IconButtonDefaults.iconButtonColors(
-                    containerColor = Color.Black.copy(alpha = 0.35f),
-                    contentColor = Color.White
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.9f),
+                    contentColor = MaterialTheme.colorScheme.onSurface
                 )
             ) {
                 Icon(
@@ -336,7 +374,7 @@ fun ShortsPlayerOverlay(viewModel: ShortsPlayerViewModel) {
                     contentDescription = "Close Shorts"
                 )
             }
-            Spacer(modifier = Modifier.width(8.dp))
+            Spacer(modifier = Modifier.width(10.dp))
             Text(
                 text = "Shorts",
                 style = MaterialTheme.typography.titleLarge,
@@ -345,24 +383,26 @@ fun ShortsPlayerOverlay(viewModel: ShortsPlayerViewModel) {
             )
         }
 
-        // Metadata (bottom-left) + action rail (bottom-right)
+        // Metadata (bottom-left) + floating action pill (bottom-right)
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .align(Alignment.BottomCenter)
                 .windowInsetsPadding(WindowInsets.navigationBars)
-                .padding(start = 16.dp, end = 8.dp, bottom = 12.dp),
+                .padding(start = 16.dp, end = 10.dp, bottom = 18.dp),
             verticalAlignment = Alignment.Bottom
         ) {
             Column(modifier = Modifier.weight(1f)) {
                 val video = currentVideo
                 if (video != null && video.channelName.isNotBlank()) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
+                        // Expressive avatar, cookie-clipped like the design
+                        // guide's shaped avatars
                         Box(
                             modifier = Modifier
-                                .size(36.dp)
-                                .clip(CircleShape)
-                                .background(Color.White.copy(alpha = 0.2f)),
+                                .size(38.dp)
+                                .clip(MaterialShapes.Cookie9Sided.toShape())
+                                .background(MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.8f)),
                             contentAlignment = Alignment.Center
                         ) {
                             if (!video.channelIconUrl.isNullOrBlank()) {
@@ -376,7 +416,7 @@ fun ShortsPlayerOverlay(viewModel: ShortsPlayerViewModel) {
                                 Icon(
                                     imageVector = Icons.Rounded.Person,
                                     contentDescription = null,
-                                    tint = Color.White,
+                                    tint = MaterialTheme.colorScheme.onSurface,
                                     modifier = Modifier.size(20.dp)
                                 )
                             }
@@ -397,19 +437,19 @@ fun ShortsPlayerOverlay(viewModel: ShortsPlayerViewModel) {
                             onClick = { requireLogin { viewModel.toggleSubscribe() } },
                             colors = if (isSubscribed) {
                                 ButtonDefaults.buttonColors(
-                                    containerColor = Color.White.copy(alpha = 0.2f),
-                                    contentColor = Color.White
+                                    containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.92f),
+                                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer
                                 )
                             } else {
                                 ButtonDefaults.buttonColors(
-                                    containerColor = Color.White,
-                                    contentColor = Color.Black
+                                    containerColor = MaterialTheme.colorScheme.primary,
+                                    contentColor = MaterialTheme.colorScheme.onPrimary
                                 )
                             },
                             contentPadding = androidx.compose.foundation.layout.PaddingValues(
-                                horizontal = 14.dp, vertical = 6.dp
+                                horizontal = 16.dp, vertical = 6.dp
                             ),
-                            modifier = Modifier.height(32.dp)
+                            modifier = Modifier.height(34.dp)
                         ) {
                             Text(
                                 text = if (isSubscribed) "Subscribed" else "Subscribe",
@@ -433,62 +473,76 @@ fun ShortsPlayerOverlay(viewModel: ShortsPlayerViewModel) {
 
             Spacer(modifier = Modifier.width(12.dp))
 
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(14.dp)
+            // Floating tonal pill, same language as FloatingPillNavBar
+            val likeStatus = engagement?.likeStatus ?: LikeStatus.INDIFFERENT
+            Surface(
+                shape = RoundedCornerShape(32.dp),
+                color = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.92f)
             ) {
-                val likeStatus = engagement?.likeStatus ?: LikeStatus.INDIFFERENT
-                ShortsAction(
-                    icon = if (likeStatus == LikeStatus.LIKE) Icons.Rounded.ThumbUp
-                        else Icons.Outlined.ThumbUp,
-                    label = engagement?.likeCount ?: "Like",
-                    active = likeStatus == LikeStatus.LIKE,
-                    contentDescription = "Like",
-                    onClick = { requireLogin { viewModel.toggleLike() } }
-                )
-                ShortsAction(
-                    icon = if (likeStatus == LikeStatus.DISLIKE) Icons.Rounded.ThumbDown
-                        else Icons.Outlined.ThumbDown,
-                    label = "Dislike",
-                    active = likeStatus == LikeStatus.DISLIKE,
-                    contentDescription = "Dislike",
-                    onClick = { requireLogin { viewModel.toggleDislike() } }
-                )
-                ShortsAction(
-                    icon = Icons.Rounded.ChatBubble,
-                    label = "Comments",
-                    contentDescription = "Comments",
-                    onClick = {
-                        viewModel.ensureCommentsLoaded()
-                        showCommentsSheet = true
-                    }
-                )
-                ShortsAction(
-                    icon = Icons.Rounded.Share,
-                    label = "Share",
-                    contentDescription = "Share",
-                    onClick = {
-                        val videoId = currentVideo?.videoId ?: return@ShortsAction
-                        val send = Intent(Intent.ACTION_SEND).apply {
-                            type = "text/plain"
-                            putExtra(Intent.EXTRA_TEXT, "https://youtube.com/shorts/$videoId")
+                Column(
+                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 10.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(2.dp)
+                ) {
+                    ShortsAction(
+                        icon = if (likeStatus == LikeStatus.LIKE) Icons.Rounded.ThumbUp
+                            else Icons.Outlined.ThumbUp,
+                        label = engagement?.likeCount ?: "Like",
+                        active = likeStatus == LikeStatus.LIKE,
+                        burstOnActivate = true,
+                        contentDescription = "Like",
+                        onClick = { requireLogin { viewModel.toggleLike() } }
+                    )
+                    ShortsAction(
+                        icon = if (likeStatus == LikeStatus.DISLIKE) Icons.Rounded.ThumbDown
+                            else Icons.Outlined.ThumbDown,
+                        label = "Dislike",
+                        active = likeStatus == LikeStatus.DISLIKE,
+                        contentDescription = "Dislike",
+                        onClick = { requireLogin { viewModel.toggleDislike() } }
+                    )
+                    ShortsAction(
+                        icon = Icons.Rounded.ChatBubble,
+                        label = "Comments",
+                        contentDescription = "Comments",
+                        onClick = {
+                            viewModel.ensureCommentsLoaded()
+                            showCommentsSheet = true
                         }
-                        context.startActivity(Intent.createChooser(send, "Share Short"))
-                    }
-                )
+                    )
+                    ShortsAction(
+                        icon = Icons.Rounded.Share,
+                        label = "Share",
+                        contentDescription = "Share",
+                        onClick = {
+                            val videoId = currentVideo?.videoId ?: return@ShortsAction
+                            val send = Intent(Intent.ACTION_SEND).apply {
+                                type = "text/plain"
+                                putExtra(Intent.EXTRA_TEXT, "https://youtube.com/shorts/$videoId")
+                            }
+                            context.startActivity(Intent.createChooser(send, "Share Short"))
+                        }
+                    )
+                }
             }
         }
 
-        // Thin progress line hugging the bottom edge
-        LinearProgressIndicator(
+        // Wavy playback progress, Koda's player signature; the wave settles
+        // flat while paused
+        val waveAmplitude by animateFloatAsState(
+            targetValue = if (isPlaying) 1f else 0f,
+            animationSpec = spring(dampingRatio = Spring.DampingRatioNoBouncy),
+            label = "waveAmplitude"
+        )
+        LinearWavyProgressIndicator(
             progress = { progress.coerceIn(0f, 1f) },
             modifier = Modifier
                 .fillMaxWidth()
-                .height(2.dp)
+                .height(12.dp)
                 .align(Alignment.BottomCenter),
             color = MaterialTheme.colorScheme.primary,
             trackColor = Color.White.copy(alpha = 0.25f),
-            drawStopIndicator = {}
+            amplitude = { waveAmplitude }
         )
     }
 
@@ -526,48 +580,102 @@ fun ShortsPlayerOverlay(viewModel: ShortsPlayerViewModel) {
 }
 
 /**
- * One button of the right-hand action rail: circular translucent icon
- * button with a spring scale bump when it becomes active, label underneath.
+ * One row of the floating action pill: a circular icon target that fills
+ * with secondaryContainer while active (FloatingPillNavBar's selected
+ * treatment), a springy icon pop, and — for the like action — a one-shot
+ * Burst-shape flash borrowed from LikeBurstIcon.
  */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun ShortsAction(
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    icon: ImageVector,
     label: String,
     contentDescription: String,
     active: Boolean = false,
+    burstOnActivate: Boolean = false,
     onClick: () -> Unit
 ) {
-    val scale by animateFloatAsState(
-        targetValue = if (active) 1.12f else 1f,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
-        label = "actionScale"
-    )
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        IconButton(
-            onClick = onClick,
-            shapes = IconButtonDefaults.shapes(),
-            colors = IconButtonDefaults.iconButtonColors(
-                containerColor = Color.Black.copy(alpha = 0.35f),
-                contentColor = if (active) MaterialTheme.colorScheme.primary else Color.White
-            ),
+    val iconScale = remember { Animatable(1f) }
+    val burstProgress = remember { Animatable(0f) }
+    var isInitial by remember { mutableStateOf(true) }
+
+    LaunchedEffect(active) {
+        if (isInitial) {
+            isInitial = false
+            return@LaunchedEffect
+        }
+        if (active) {
+            launch {
+                iconScale.snapTo(0.5f)
+                iconScale.animateTo(
+                    targetValue = 1f,
+                    animationSpec = spring(
+                        dampingRatio = Spring.DampingRatioMediumBouncy,
+                        stiffness = Spring.StiffnessMedium
+                    )
+                )
+            }
+            if (burstOnActivate) {
+                burstProgress.snapTo(0.01f)
+                burstProgress.animateTo(1f, tween(durationMillis = 450, easing = FastOutSlowInEasing))
+                burstProgress.snapTo(0f)
+            }
+        }
+    }
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .clip(RoundedCornerShape(24.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+    ) {
+        Box(
             modifier = Modifier
-                .size(48.dp)
-                .scale(scale)
+                .size(44.dp)
+                .clip(CircleShape)
+                .background(
+                    if (active) MaterialTheme.colorScheme.secondaryContainer
+                    else Color.Transparent
+                ),
+            contentAlignment = Alignment.Center
         ) {
+            val p = burstProgress.value
+            if (p > 0f) {
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .graphicsLayer {
+                            scaleX = 0.3f + p * 1.2f
+                            scaleY = 0.3f + p * 1.2f
+                            alpha = 1f - p
+                        }
+                        .clip(MaterialShapes.Burst.toShape())
+                        .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.35f))
+                )
+            }
             Icon(
                 imageVector = icon,
                 contentDescription = contentDescription,
-                modifier = Modifier.size(24.dp)
+                tint = if (active) MaterialTheme.colorScheme.onSecondaryContainer
+                    else MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier
+                    .size(22.dp)
+                    .graphicsLayer {
+                        scaleX = iconScale.value
+                        scaleY = iconScale.value
+                    }
             )
         }
-        Spacer(modifier = Modifier.height(4.dp))
         Text(
             text = label,
             style = MaterialTheme.typography.labelSmall,
             fontWeight = FontWeight.Medium,
-            color = Color.White,
-            maxLines = 1
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.widthIn(max = 64.dp)
         )
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/shorts/ShortsPlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/shorts/ShortsPlayerViewModel.kt
@@ -1,0 +1,547 @@
+package com.ivor.ivormusic.ui.shorts
+
+import android.content.Context
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.exoplayer.DefaultLoadControl
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.MergingMediaSource
+import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import com.ivor.ivormusic.data.CommentItem
+import com.ivor.ivormusic.data.LikeStatus
+import com.ivor.ivormusic.data.ShortsItem
+import com.ivor.ivormusic.data.ThemePreferences
+import com.ivor.ivormusic.data.VideoEngagement
+import com.ivor.ivormusic.data.VideoItem
+import com.ivor.ivormusic.data.VideoQuality
+import com.ivor.ivormusic.data.YouTubeRepository
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/**
+ * Player for the vertical Shorts feed. Owns its own ExoPlayer (like
+ * VideoPlayerViewModel) so Shorts, regular video and music playback stay
+ * independent — audio focus keeps them from playing over each other.
+ *
+ * Streams resolve through the same ANDROID_VR /player pipeline as regular
+ * videos (Shorts are ordinary videos server-side), and engagement, metadata
+ * and comments come from the same single watch-next call per Short.
+ */
+@UnstableApi
+class ShortsPlayerViewModel(application: android.app.Application) : AndroidViewModel(application) {
+
+    private val context: Context get() = getApplication()
+    private val youtubeRepository = YouTubeRepository(context)
+    private val themePreferences = ThemePreferences(context)
+    private val videoHistoryRepository = com.ivor.ivormusic.data.VideoHistoryRepository(context)
+
+    private var _exoPlayer: ExoPlayer? = null
+    val exoPlayer: ExoPlayer? get() = _exoPlayer
+
+    // ---------------- Feed / pager state ----------------
+
+    private val _shorts = MutableStateFlow<List<ShortsItem>>(emptyList())
+    val shorts: StateFlow<List<ShortsItem>> = _shorts.asStateFlow()
+
+    private val _currentIndex = MutableStateFlow(0)
+    val currentIndex: StateFlow<Int> = _currentIndex.asStateFlow()
+
+    private val _isActive = MutableStateFlow(false)
+    val isActive: StateFlow<Boolean> = _isActive.asStateFlow()
+
+    private val _isPlaying = MutableStateFlow(false)
+    val isPlaying: StateFlow<Boolean> = _isPlaying.asStateFlow()
+
+    private val _isBuffering = MutableStateFlow(false)
+    val isBuffering: StateFlow<Boolean> = _isBuffering.asStateFlow()
+
+    private val _playbackError = MutableStateFlow<Throwable?>(null)
+    val playbackError: StateFlow<Throwable?> = _playbackError.asStateFlow()
+
+    /** Metadata of the current Short, enriched by watch-next (title, channel, avatar). */
+    private val _currentVideo = MutableStateFlow<VideoItem?>(null)
+    val currentVideo: StateFlow<VideoItem?> = _currentVideo.asStateFlow()
+
+    // Sequence continuation for the endless feed; null until known/exhausted
+    private var nextSequenceParams: String? = null
+    private var isLoadingMore = false
+    private var playJob: Job? = null
+    private var historyReportJob: Job? = null
+
+    // ---------------- Engagement ----------------
+
+    private val _engagement = MutableStateFlow<VideoEngagement?>(null)
+    val engagement: StateFlow<VideoEngagement?> = _engagement.asStateFlow()
+
+    private val _isLoggedIn = MutableStateFlow(youtubeRepository.isLoggedIn())
+    val isLoggedIn: StateFlow<Boolean> = _isLoggedIn.asStateFlow()
+
+    // ---------------- Comments (same shape VideoPlayerViewModel exposes,
+    // so CommentsSheet is reused as-is) ----------------
+
+    private val _comments = MutableStateFlow<List<CommentItem>>(emptyList())
+    val comments: StateFlow<List<CommentItem>> = _comments.asStateFlow()
+
+    private val _isCommentsLoading = MutableStateFlow(false)
+    val isCommentsLoading: StateFlow<Boolean> = _isCommentsLoading.asStateFlow()
+
+    private val _isLoadingMoreComments = MutableStateFlow(false)
+    val isLoadingMoreComments: StateFlow<Boolean> = _isLoadingMoreComments.asStateFlow()
+
+    private val _replies = MutableStateFlow<Map<String, List<CommentItem>>>(emptyMap())
+    val replies: StateFlow<Map<String, List<CommentItem>>> = _replies.asStateFlow()
+
+    private val _loadingReplyIds = MutableStateFlow<Set<String>>(emptySet())
+    val loadingReplyIds: StateFlow<Set<String>> = _loadingReplyIds.asStateFlow()
+
+    private var commentsNextToken: String? = null
+    private var commentsLoadedForVideoId: String? = null
+    private val _createCommentParams = MutableStateFlow<String?>(null)
+
+    val canComment: StateFlow<Boolean> = combine(
+        _isLoggedIn, _createCommentParams
+    ) { loggedIn, params -> loggedIn && params != null }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    private val _isPostingComment = MutableStateFlow(false)
+    val isPostingComment: StateFlow<Boolean> = _isPostingComment.asStateFlow()
+
+    init {
+        // Same tuned LoadControl as the video player: first frame after ~1.5s
+        // buffered. Audio focus + becoming-noisy pause music/video playback
+        // instead of playing over them (and vice versa).
+        val loadControl = DefaultLoadControl.Builder()
+            .setBufferDurationsMs(30_000, 60_000, 1_500, 3_000)
+            .setPrioritizeTimeOverSizeThresholds(true)
+            .build()
+
+        _exoPlayer = ExoPlayer.Builder(context)
+            .setLoadControl(loadControl)
+            .setWakeMode(C.WAKE_MODE_NETWORK)
+            .setAudioAttributes(AudioAttributes.DEFAULT, true)
+            .setHandleAudioBecomingNoisy(true)
+            .build().apply {
+                playWhenReady = true
+                // Shorts loop, YouTube-style
+                repeatMode = Player.REPEAT_MODE_ONE
+                addListener(object : Player.Listener {
+                    override fun onIsPlayingChanged(isPlaying: Boolean) {
+                        _isPlaying.value = isPlaying
+                    }
+
+                    override fun onPlaybackStateChanged(playbackState: Int) {
+                        _isBuffering.value = playbackState == Player.STATE_BUFFERING
+                    }
+                })
+            }
+    }
+
+    /**
+     * Open the Shorts player on a shelf: [items] become the initial pager
+     * feed, [startIndex] is the tapped Short. The tapped item's
+     * sequenceParams seed the endless feed once the user swipes near the end.
+     */
+    fun open(items: List<ShortsItem>, startIndex: Int) {
+        if (items.isEmpty()) return
+        val index = startIndex.coerceIn(0, items.size - 1)
+        _shorts.value = items
+        _currentIndex.value = index
+        nextSequenceParams = items[index].sequenceParams
+            ?: items.firstNotNullOfOrNull { it.sequenceParams }
+        _isActive.value = true
+        _isLoggedIn.value = youtubeRepository.isLoggedIn()
+        playIndex(index)
+    }
+
+    /** Called by the pager when the user settles on a page. */
+    fun onPageSelected(index: Int) {
+        if (!_isActive.value) return
+        if (index != _currentIndex.value) {
+            _currentIndex.value = index
+            playIndex(index)
+        }
+        maybeLoadMore(index)
+    }
+
+    fun close() {
+        _isActive.value = false
+        playJob?.cancel()
+        historyReportJob?.cancel()
+        _exoPlayer?.stop()
+        _exoPlayer?.clearMediaItems()
+        _currentVideo.value = null
+        _playbackError.value = null
+    }
+
+    fun togglePlayPause() {
+        if (_isPlaying.value) _exoPlayer?.pause() else _exoPlayer?.play()
+    }
+
+    /** Pause without closing (e.g. app backgrounded while a Short is open). */
+    fun pause() {
+        _exoPlayer?.pause()
+    }
+
+    /** Re-attempt playback of the current Short after an error. */
+    fun retryCurrent() {
+        playIndex(_currentIndex.value)
+    }
+
+    private fun playIndex(index: Int) {
+        val item = _shorts.value.getOrNull(index) ?: return
+        playJob?.cancel()
+        historyReportJob?.cancel()
+
+        _playbackError.value = null
+        _currentVideo.value = item.toVideoItem()
+        resetEngagementState()
+
+        // Phase 1: streams only, playback ASAP (same two-phase pattern and
+        // 15s stuck-buffering guard as VideoPlayerViewModel.playVideo)
+        playJob = viewModelScope.launch {
+            try {
+                _exoPlayer?.stop()
+                _exoPlayer?.clearMediaItems()
+                kotlinx.coroutines.withTimeout(15_000L) {
+                    val qualities = youtubeRepository.getVideoStreamQualities(item.videoId)
+                    if (_currentIndex.value != index) return@withTimeout
+                    if (qualities.isNotEmpty()) {
+                        loadQuality(pickDefaultQuality(qualities))
+                        _exoPlayer?.play()
+                    } else {
+                        val streamUrl = youtubeRepository.getVideoStreamUrl(item.videoId)
+                        if (streamUrl != null) {
+                            val source = ProgressiveMediaSource.Factory(dataSourceFactoryFor(streamUrl))
+                                .createMediaSource(MediaItem.fromUri(streamUrl))
+                            _exoPlayer?.setMediaSource(source)
+                            _exoPlayer?.prepare()
+                            _exoPlayer?.play()
+                        } else {
+                            _playbackError.value = Exception("Unable to load this Short")
+                        }
+                    }
+                }
+            } catch (e: kotlinx.coroutines.TimeoutCancellationException) {
+                _playbackError.value = Exception("Connection timed out. Please check your internet.")
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _playbackError.value = e
+            }
+        }
+
+        // Phase 2: one watch-next call fills engagement + real metadata
+        // (title, channel, avatar) — sequence entries arrive with id only
+        viewModelScope.launch {
+            try {
+                val watchNext = youtubeRepository.getWatchNextData(item.videoId, item.toVideoItem())
+                if (_currentIndex.value != index) return@launch
+                _engagement.value = watchNext.engagement
+                if (watchNext.updatedVideoItem != null) {
+                    _currentVideo.value = watchNext.updatedVideoItem
+                }
+            } catch (e: Exception) {
+                android.util.Log.w("ShortsPlayerVM", "watch-next failed for ${item.videoId}", e)
+            }
+        }
+
+        // History: Shorts are short, report after 5s of actual playback
+        historyReportJob = viewModelScope.launch {
+            kotlinx.coroutines.delay(5_000)
+            var waitedMs = 0
+            while (!_isPlaying.value && waitedMs < 30_000) {
+                kotlinx.coroutines.delay(1_000)
+                waitedMs += 1_000
+            }
+            // Fresh pref read: Settings toggles through its own instance
+            if (_isPlaying.value && themePreferences.isSaveVideoHistoryEnabled()) {
+                val watched = _currentVideo.value?.takeIf { it.videoId == item.videoId }
+                    ?: item.toVideoItem()
+                videoHistoryRepository.addVideo(watched)
+                youtubeRepository.reportVideoPlayback(item.videoId)
+            }
+        }
+    }
+
+    /** Extend the feed when the pager nears its end. Dedupes repeated ids. */
+    private fun maybeLoadMore(index: Int) {
+        val params = nextSequenceParams ?: return
+        if (isLoadingMore || index < _shorts.value.size - 4) return
+        isLoadingMore = true
+        viewModelScope.launch {
+            try {
+                val page = youtubeRepository.getShortsSequence(params)
+                val known = _shorts.value.mapTo(HashSet()) { it.videoId }
+                val fresh = page.items.filter { it.videoId !in known }
+                if (fresh.isNotEmpty()) {
+                    _shorts.value = _shorts.value + fresh
+                }
+                // A page of only duplicates still advances the continuation,
+                // so the next trigger asks for genuinely new entries
+                nextSequenceParams = page.continuation
+            } finally {
+                isLoadingMore = false
+            }
+        }
+    }
+
+    // ---------------- Playback helpers (same conventions as the video player) ----------------
+
+    /**
+     * Data source factory whose User-Agent matches the client that issued the
+     * stream URL — googlevideo answers 403 on a UA mismatch.
+     */
+    private fun dataSourceFactoryFor(url: String): DefaultDataSource.Factory {
+        val userAgent = YouTubeRepository.uaForPlaybackUri(android.net.Uri.parse(url))
+        val httpFactory = DefaultHttpDataSource.Factory()
+            .setUserAgent(userAgent)
+            .setAllowCrossProtocolRedirects(true)
+        return DefaultDataSource.Factory(context, httpFactory)
+    }
+
+    /**
+     * Starting quality from the Default Video Quality setting (fresh pref
+     * read), like VideoPlayerViewModel.pickDefaultQuality. The list is sorted
+     * highest-first, so the first label at or below the target height wins.
+     */
+    private fun pickDefaultQuality(qualities: List<VideoQuality>): VideoQuality {
+        fun height(label: String): Int = label.takeWhile { it.isDigit() }.toIntOrNull() ?: 0
+        val preferred = themePreferences.getDefaultVideoQuality()
+        if (preferred == ThemePreferences.VIDEO_QUALITY_AUTO) {
+            return qualities.firstOrNull { height(it.resolution) > 0 } ?: qualities.first()
+        }
+        val targetHeight = height(preferred)
+        return qualities.firstOrNull { height(it.resolution) in 1..targetHeight }
+            ?: qualities.lastOrNull { height(it.resolution) > 0 }
+            ?: qualities.first()
+    }
+
+    private fun loadQuality(quality: VideoQuality) {
+        val dataSourceFactory = dataSourceFactoryFor(quality.url)
+        val audioUrl = quality.audioUrl
+        if (audioUrl != null) {
+            val videoSource = ProgressiveMediaSource.Factory(dataSourceFactory)
+                .createMediaSource(MediaItem.fromUri(quality.url))
+            val audioSource = ProgressiveMediaSource.Factory(dataSourceFactory)
+                .createMediaSource(MediaItem.fromUri(audioUrl))
+            _exoPlayer?.setMediaSource(MergingMediaSource(true, videoSource, audioSource))
+        } else {
+            val source = ProgressiveMediaSource.Factory(dataSourceFactory)
+                .createMediaSource(MediaItem.fromUri(quality.url))
+            _exoPlayer?.setMediaSource(source)
+        }
+        _exoPlayer?.prepare()
+    }
+
+    // ---------------- Engagement actions (optimistic with rollback) ----------------
+
+    /** Re-check login state and refresh engagement (call after a sign-in). */
+    fun onLoginStateChanged() {
+        _isLoggedIn.value = youtubeRepository.isLoggedIn()
+        val video = _currentVideo.value ?: return
+        viewModelScope.launch {
+            _engagement.value = youtubeRepository.getVideoEngagement(video.videoId)
+        }
+    }
+
+    fun toggleLike() = rate { current ->
+        if (current == LikeStatus.LIKE) LikeStatus.INDIFFERENT else LikeStatus.LIKE
+    }
+
+    fun toggleDislike() = rate { current ->
+        if (current == LikeStatus.DISLIKE) LikeStatus.INDIFFERENT else LikeStatus.DISLIKE
+    }
+
+    private fun rate(target: (LikeStatus) -> LikeStatus) {
+        val current = _engagement.value ?: return
+        val newStatus = target(current.likeStatus)
+        _engagement.value = current.copy(likeStatus = newStatus)
+        viewModelScope.launch {
+            val ok = youtubeRepository.rateVideo(current.videoId, newStatus)
+            if (!ok && _engagement.value?.videoId == current.videoId) {
+                _engagement.value = _engagement.value?.copy(likeStatus = current.likeStatus)
+            }
+        }
+    }
+
+    fun toggleSubscribe() {
+        val current = _engagement.value ?: return
+        val channelId = current.channelId ?: return
+        val subscribe = !current.isSubscribed
+        _engagement.value = current.copy(isSubscribed = subscribe)
+        viewModelScope.launch {
+            val ok = youtubeRepository.setSubscribed(channelId, subscribe)
+            if (!ok && _engagement.value?.videoId == current.videoId) {
+                _engagement.value = _engagement.value?.copy(isSubscribed = current.isSubscribed)
+            }
+        }
+    }
+
+    // ---------------- Comments ----------------
+
+    private fun resetEngagementState() {
+        _engagement.value = null
+        _comments.value = emptyList()
+        _replies.value = emptyMap()
+        _loadingReplyIds.value = emptySet()
+        commentsNextToken = null
+        commentsLoadedForVideoId = null
+        _createCommentParams.value = null
+        _isLoggedIn.value = youtubeRepository.isLoggedIn()
+    }
+
+    fun ensureCommentsLoaded() {
+        val video = _currentVideo.value ?: return
+        if (commentsLoadedForVideoId == video.videoId || _isCommentsLoading.value) return
+        val token = _engagement.value?.commentsToken ?: return
+        _isCommentsLoading.value = true
+        viewModelScope.launch {
+            try {
+                val page = youtubeRepository.getCommentsPage(token)
+                if (_currentVideo.value?.videoId == video.videoId && page != null) {
+                    _comments.value = page.comments
+                    commentsNextToken = page.nextPageToken
+                    commentsLoadedForVideoId = video.videoId
+                    _createCommentParams.value = page.createCommentParams
+                }
+            } finally {
+                _isCommentsLoading.value = false
+            }
+        }
+    }
+
+    fun loadMoreComments() {
+        val video = _currentVideo.value ?: return
+        val token = commentsNextToken ?: return
+        if (_isLoadingMoreComments.value || _isCommentsLoading.value) return
+        _isLoadingMoreComments.value = true
+        viewModelScope.launch {
+            try {
+                val page = youtubeRepository.getCommentsPage(token)
+                if (_currentVideo.value?.videoId == video.videoId && page != null) {
+                    val known = _comments.value.mapTo(HashSet()) { it.commentId }
+                    _comments.value = _comments.value + page.comments.filter { it.commentId !in known }
+                    commentsNextToken = page.nextPageToken
+                }
+            } finally {
+                _isLoadingMoreComments.value = false
+            }
+        }
+    }
+
+    fun loadReplies(comment: CommentItem) {
+        val video = _currentVideo.value ?: return
+        val token = comment.repliesToken ?: return
+        if (_replies.value.containsKey(comment.commentId) ||
+            comment.commentId in _loadingReplyIds.value
+        ) return
+        _loadingReplyIds.value = _loadingReplyIds.value + comment.commentId
+        viewModelScope.launch {
+            try {
+                val page = youtubeRepository.getCommentsPage(token)
+                if (_currentVideo.value?.videoId == video.videoId && page != null) {
+                    _replies.value = _replies.value + (comment.commentId to page.comments)
+                }
+            } finally {
+                _loadingReplyIds.value = _loadingReplyIds.value - comment.commentId
+            }
+        }
+    }
+
+    fun postComment(text: String) {
+        val video = _currentVideo.value ?: return
+        val params = _createCommentParams.value ?: return
+        val trimmed = text.trim()
+        if (trimmed.isEmpty() || _isPostingComment.value) return
+        _isPostingComment.value = true
+        viewModelScope.launch {
+            try {
+                val created = youtubeRepository.createComment(params, trimmed)
+                if (created != null && _currentVideo.value?.videoId == video.videoId) {
+                    _comments.value = listOf(created) + _comments.value
+                }
+            } finally {
+                _isPostingComment.value = false
+            }
+        }
+    }
+
+    fun postReply(target: CommentItem, threadParent: CommentItem, text: String) {
+        val video = _currentVideo.value ?: return
+        val params = target.replyParams ?: return
+        val trimmed = text.trim()
+        if (trimmed.isEmpty() || _isPostingComment.value) return
+        _isPostingComment.value = true
+        viewModelScope.launch {
+            try {
+                val created = youtubeRepository.createCommentReply(params, trimmed)
+                if (created != null && _currentVideo.value?.videoId == video.videoId) {
+                    val existing = _replies.value[threadParent.commentId]
+                    if (existing != null || threadParent.repliesToken == null) {
+                        _replies.value = _replies.value +
+                            (threadParent.commentId to (existing ?: emptyList()) + created)
+                    } else {
+                        loadReplies(threadParent)
+                    }
+                }
+            } finally {
+                _isPostingComment.value = false
+            }
+        }
+    }
+
+    fun toggleCommentLike(comment: CommentItem) {
+        val action = (if (comment.isLiked) comment.unlikeParams else comment.likeParams) ?: return
+        val toggled = comment.copy(isLiked = !comment.isLiked)
+        replaceComment(toggled)
+        viewModelScope.launch {
+            if (!youtubeRepository.performCommentAction(action)) {
+                replaceComment(comment)
+            }
+        }
+    }
+
+    fun deleteComment(comment: CommentItem) {
+        val action = comment.deleteParams ?: return
+        val previousComments = _comments.value
+        val previousReplies = _replies.value
+        _comments.value = _comments.value.filterNot { it.commentId == comment.commentId }
+        _replies.value = _replies.value
+            .mapValues { (_, list) -> list.filterNot { it.commentId == comment.commentId } }
+            .filterKeys { it != comment.commentId }
+        viewModelScope.launch {
+            if (!youtubeRepository.performCommentAction(action)) {
+                _comments.value = previousComments
+                _replies.value = previousReplies
+            }
+        }
+    }
+
+    private fun replaceComment(updated: CommentItem) {
+        _comments.value = _comments.value.map {
+            if (it.commentId == updated.commentId) updated else it
+        }
+        _replies.value = _replies.value.mapValues { (_, list) ->
+            list.map { if (it.commentId == updated.commentId) updated else it }
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        _exoPlayer?.release()
+        _exoPlayer = null
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/shorts/ShortsPlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/shorts/ShortsPlayerViewModel.kt
@@ -81,6 +81,97 @@ class ShortsPlayerViewModel(application: android.app.Application) : AndroidViewM
     private var playJob: Job? = null
     private var historyReportJob: Job? = null
 
+    // ---------------- Background prefetch ----------------
+    // Swiping must not show a loading spinner, so stream URLs for the next
+    // few Shorts (and one behind, for swipe-back) resolve in the background
+    // the moment a Short is opened or settled on. Watch-next payloads for
+    // the immediate next Shorts are warmed too, so the title/channel/like
+    // rail appears instantly. Both caches are LRU-capped; googlevideo URLs
+    // stay valid for hours, far beyond a browsing session's needs.
+
+    private val qualitiesCache = object : LinkedHashMap<String, List<VideoQuality>>(16, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, List<VideoQuality>>) =
+            size > 30
+    }
+    private val watchNextCache = object : LinkedHashMap<String, com.ivor.ivormusic.data.WatchNextData>(16, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, com.ivor.ivormusic.data.WatchNextData>) =
+            size > 20
+    }
+    private val prefetchingIds = java.util.Collections.synchronizedSet(mutableSetOf<String>())
+    private val prefetchSemaphore = kotlinx.coroutines.sync.Semaphore(2)
+
+    private fun cachedQualities(videoId: String): List<VideoQuality>? =
+        synchronized(qualitiesCache) { qualitiesCache[videoId] }
+
+    private fun cacheQualities(videoId: String, qualities: List<VideoQuality>) {
+        if (qualities.isEmpty()) return
+        synchronized(qualitiesCache) { qualitiesCache[videoId] = qualities }
+    }
+
+    private fun cachedWatchNext(videoId: String): com.ivor.ivormusic.data.WatchNextData? =
+        synchronized(watchNextCache) { watchNextCache[videoId] }
+
+    private fun cacheWatchNext(videoId: String, data: com.ivor.ivormusic.data.WatchNextData) {
+        synchronized(watchNextCache) { watchNextCache[videoId] = data }
+    }
+
+    /**
+     * Warm the caches around [index]: stream URLs for the next
+     * [STREAM_PREFETCH_AHEAD] Shorts plus the previous one, watch-next for
+     * the next [WATCH_NEXT_PREFETCH_AHEAD]. Bounded to two concurrent
+     * fetches so prefetch never starves the playing Short's buffer.
+     */
+    private fun prefetchAround(index: Int) {
+        val list = _shorts.value
+        val streamTargets =
+            ((index + 1)..(index + STREAM_PREFETCH_AHEAD)).mapNotNull { list.getOrNull(it) } +
+                listOfNotNull(list.getOrNull(index - 1))
+        for (item in streamTargets) {
+            val id = item.videoId
+            if (cachedQualities(id) != null || !prefetchingIds.add("s:$id")) continue
+            viewModelScope.launch {
+                try {
+                    prefetchSemaphore.acquire()
+                    try {
+                        // Skip if a later prefetch/playback already filled it
+                        if (cachedQualities(id) == null) {
+                            cacheQualities(id, youtubeRepository.getVideoStreamQualities(id))
+                        }
+                    } finally {
+                        prefetchSemaphore.release()
+                    }
+                } catch (e: Exception) {
+                    android.util.Log.w("ShortsPlayerVM", "stream prefetch failed for $id", e)
+                } finally {
+                    prefetchingIds.remove("s:$id")
+                }
+            }
+        }
+
+        val watchNextTargets =
+            ((index + 1)..(index + WATCH_NEXT_PREFETCH_AHEAD)).mapNotNull { list.getOrNull(it) }
+        for (item in watchNextTargets) {
+            val id = item.videoId
+            if (cachedWatchNext(id) != null || !prefetchingIds.add("w:$id")) continue
+            viewModelScope.launch {
+                try {
+                    prefetchSemaphore.acquire()
+                    try {
+                        if (cachedWatchNext(id) == null) {
+                            cacheWatchNext(id, youtubeRepository.getWatchNextData(id, item.toVideoItem()))
+                        }
+                    } finally {
+                        prefetchSemaphore.release()
+                    }
+                } catch (e: Exception) {
+                    android.util.Log.w("ShortsPlayerVM", "watch-next prefetch failed for $id", e)
+                } finally {
+                    prefetchingIds.remove("w:$id")
+                }
+            }
+        }
+    }
+
     // ---------------- Engagement ----------------
 
     private val _engagement = MutableStateFlow<VideoEngagement?>(null)
@@ -164,6 +255,7 @@ class ShortsPlayerViewModel(application: android.app.Application) : AndroidViewM
         _isActive.value = true
         _isLoggedIn.value = youtubeRepository.isLoggedIn()
         playIndex(index)
+        prefetchAround(index)
     }
 
     /** Called by the pager when the user settles on a page. */
@@ -173,6 +265,7 @@ class ShortsPlayerViewModel(application: android.app.Application) : AndroidViewM
             _currentIndex.value = index
             playIndex(index)
         }
+        prefetchAround(index)
         maybeLoadMore(index)
     }
 
@@ -210,13 +303,16 @@ class ShortsPlayerViewModel(application: android.app.Application) : AndroidViewM
         resetEngagementState()
 
         // Phase 1: streams only, playback ASAP (same two-phase pattern and
-        // 15s stuck-buffering guard as VideoPlayerViewModel.playVideo)
+        // 15s stuck-buffering guard as VideoPlayerViewModel.playVideo).
+        // Prefetched Shorts skip the network entirely and start immediately.
         playJob = viewModelScope.launch {
             try {
                 _exoPlayer?.stop()
                 _exoPlayer?.clearMediaItems()
                 kotlinx.coroutines.withTimeout(15_000L) {
-                    val qualities = youtubeRepository.getVideoStreamQualities(item.videoId)
+                    val qualities = cachedQualities(item.videoId)
+                        ?: youtubeRepository.getVideoStreamQualities(item.videoId)
+                            .also { cacheQualities(item.videoId, it) }
                     if (_currentIndex.value != index) return@withTimeout
                     if (qualities.isNotEmpty()) {
                         loadQuality(pickDefaultQuality(qualities))
@@ -244,10 +340,13 @@ class ShortsPlayerViewModel(application: android.app.Application) : AndroidViewM
         }
 
         // Phase 2: one watch-next call fills engagement + real metadata
-        // (title, channel, avatar) — sequence entries arrive with id only
+        // (title, channel, avatar) — sequence entries arrive with id only.
+        // Prefetched payloads make the metadata and like rail appear at once.
         viewModelScope.launch {
             try {
-                val watchNext = youtubeRepository.getWatchNextData(item.videoId, item.toVideoItem())
+                val watchNext = cachedWatchNext(item.videoId)
+                    ?: youtubeRepository.getWatchNextData(item.videoId, item.toVideoItem())
+                        .also { cacheWatchNext(item.videoId, it) }
                 if (_currentIndex.value != index) return@launch
                 _engagement.value = watchNext.engagement
                 if (watchNext.updatedVideoItem != null) {
@@ -288,6 +387,9 @@ class ShortsPlayerViewModel(application: android.app.Application) : AndroidViewM
                 val fresh = page.items.filter { it.videoId !in known }
                 if (fresh.isNotEmpty()) {
                     _shorts.value = _shorts.value + fresh
+                    // Newly appended entries may fall inside the prefetch
+                    // window of the Short being watched right now
+                    prefetchAround(_currentIndex.value)
                 }
                 // A page of only duplicates still advances the continuation,
                 // so the next trigger asks for genuinely new entries
@@ -537,6 +639,14 @@ class ShortsPlayerViewModel(application: android.app.Application) : AndroidViewM
         _replies.value = _replies.value.mapValues { (_, list) ->
             list.map { if (it.commentId == updated.commentId) updated else it }
         }
+    }
+
+    companion object {
+        /** Stream URLs resolved ahead of the current Short (plus one behind). */
+        private const val STREAM_PREFETCH_AHEAD = 5
+
+        /** Watch-next payloads (metadata + engagement) warmed ahead. */
+        private const val WATCH_NEXT_PREFETCH_AHEAD = 2
     }
 
     override fun onCleared() {

--- a/app/src/main/java/com/ivor/ivormusic/ui/theme/ThemeViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/theme/ThemeViewModel.kt
@@ -24,6 +24,7 @@ class ThemeViewModel(application: Application) : AndroidViewModel(application) {
     val playerStyle: StateFlow<PlayerStyle> = themePreferences.playerStyle
     val saveVideoHistory: StateFlow<Boolean> = themePreferences.saveVideoHistory
     val timedCommentsEnabled: StateFlow<Boolean> = themePreferences.timedCommentsEnabled
+    val shortsEnabled: StateFlow<Boolean> = themePreferences.shortsEnabled
     val defaultVideoQuality: StateFlow<String> = themePreferences.defaultVideoQuality
     val excludedFolders: StateFlow<Set<String>> = themePreferences.excludedFolders
     
@@ -91,6 +92,10 @@ class ThemeViewModel(application: Application) : AndroidViewModel(application) {
 
     fun setTimedCommentsEnabled(enabled: Boolean) {
         themePreferences.setTimedCommentsEnabled(enabled)
+    }
+
+    fun setShortsEnabled(enabled: Boolean) {
+        themePreferences.setShortsEnabled(enabled)
     }
 
     fun setDefaultVideoQuality(quality: String) {

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoHomeContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoHomeContent.kt
@@ -63,7 +63,15 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.rounded.Bolt
+import androidx.compose.ui.draw.scale
 import coil.compose.AsyncImage
+import com.ivor.ivormusic.data.ShortsItem
 import com.ivor.ivormusic.data.VideoItem
 import com.ivor.ivormusic.ui.components.MusicVideoToggle
 import com.ivor.ivormusic.ui.components.MusicVideoToggleState
@@ -80,6 +88,8 @@ fun VideoHomeContent(
     videos: List<VideoItem>,
     isLoading: Boolean,
     onVideoClick: (VideoItem) -> Unit,
+    shorts: List<ShortsItem> = emptyList(),
+    onShortClick: (Int) -> Unit = {},
     onProfileClick: () -> Unit,
     onSettingsClick: () -> Unit,
     onDownloadsClick: () -> Unit = {},
@@ -197,8 +207,29 @@ fun VideoHomeContent(
                     }
                 }
                 
-                // Video cards
-                items(videos) { video ->
+                // Video cards, with the Shorts shelf slotted in after the
+                // first two like the YouTube home feed
+                val leadingVideos = if (shorts.isEmpty()) videos else videos.take(2)
+                val trailingVideos = if (shorts.isEmpty()) emptyList() else videos.drop(2)
+
+                items(leadingVideos) { video ->
+                    VideoCard(
+                        video = video,
+                        onClick = { onVideoClick(video) },
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
+                }
+
+                if (shorts.isNotEmpty()) {
+                    item {
+                        ShortsShelf(
+                            shorts = shorts,
+                            onShortClick = onShortClick
+                        )
+                    }
+                }
+
+                items(trailingVideos) { video ->
                     VideoCard(
                         video = video,
                         onClick = { onVideoClick(video) },
@@ -367,6 +398,133 @@ private fun VideoTopBarSection(
                     videoMode = videoMode,
                     onVideoModeChange = onVideoModeToggle,
                     state = modeToggleState
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Horizontal Shorts shelf: header with a bolt icon chip plus a row of
+ * portrait 9:16 cards. Tapping a card opens the fullscreen Shorts player.
+ */
+@Composable
+fun ShortsShelf(
+    shorts: List<ShortsItem>,
+    onShortClick: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(36.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Bolt,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(24.dp)
+                )
+            }
+            Spacer(modifier = Modifier.width(10.dp))
+            Text(
+                text = "Shorts",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        LazyRow(
+            contentPadding = PaddingValues(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            itemsIndexed(shorts, key = { _, item -> item.videoId }) { index, item ->
+                ShortsCard(
+                    item = item,
+                    onClick = { onShortClick(index) }
+                )
+            }
+        }
+    }
+}
+
+/**
+ * One portrait Shorts card with a press-scale spring, bottom gradient and
+ * title/view-count overlay.
+ */
+@Composable
+private fun ShortsCard(
+    item: ShortsItem,
+    onClick: () -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.95f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
+        label = "shortsCardScale"
+    )
+
+    Box(
+        modifier = Modifier
+            .width(150.dp)
+            .aspectRatio(9f / 16f)
+            .scale(scale)
+            .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .clickable(interactionSource = interactionSource, indication = null, onClick = onClick)
+    ) {
+        AsyncImage(
+            model = item.portraitThumbnailUrl,
+            contentDescription = item.title,
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Crop
+        )
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(96.dp)
+                .align(Alignment.BottomCenter)
+                .background(
+                    Brush.verticalGradient(
+                        colors = listOf(Color.Transparent, Color.Black.copy(alpha = 0.75f))
+                    )
+                )
+        )
+
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(10.dp)
+        ) {
+            if (item.title.isNotBlank()) {
+                Text(
+                    text = item.title,
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color.White,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            if (item.viewCount.isNotBlank()) {
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = item.viewCount,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = Color.White.copy(alpha = 0.75f),
+                    maxLines = 1
                 )
             }
         }

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoHomeContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoHomeContent.kt
@@ -63,13 +63,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsPressedAsState
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.rounded.Bolt
-import androidx.compose.ui.draw.scale
+import androidx.compose.material3.MaterialShapes
+import androidx.compose.material3.carousel.HorizontalMultiBrowseCarousel
+import androidx.compose.material3.carousel.rememberCarouselState
+import androidx.compose.material3.toShape
 import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.ShortsItem
 import com.ivor.ivormusic.data.VideoItem
@@ -405,9 +403,12 @@ private fun VideoTopBarSection(
 }
 
 /**
- * Horizontal Shorts shelf: header with a bolt icon chip plus a row of
- * portrait 9:16 cards. Tapping a card opens the fullscreen Shorts player.
+ * Shorts shelf: an expressive bolt badge header plus the same
+ * MultiBrowseCarousel treatment the music home uses for albums — masked
+ * items that morph between sizes as they scroll. Tapping a card opens the
+ * fullscreen Shorts player.
  */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ShortsShelf(
     shorts: List<ShortsItem>,
@@ -421,19 +422,19 @@ fun ShortsShelf(
         ) {
             Box(
                 modifier = Modifier
-                    .size(36.dp)
-                    .clip(RoundedCornerShape(12.dp))
-                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)),
+                    .size(38.dp)
+                    .clip(MaterialShapes.Cookie9Sided.toShape())
+                    .background(MaterialTheme.colorScheme.primaryContainer),
                 contentAlignment = Alignment.Center
             ) {
                 Icon(
                     imageVector = Icons.Rounded.Bolt,
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(24.dp)
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    modifier = Modifier.size(22.dp)
                 )
             }
-            Spacer(modifier = Modifier.width(10.dp))
+            Spacer(modifier = Modifier.width(12.dp))
             Text(
                 text = "Shorts",
                 style = MaterialTheme.typography.titleLarge,
@@ -444,88 +445,67 @@ fun ShortsShelf(
 
         Spacer(modifier = Modifier.height(8.dp))
 
-        LazyRow(
-            contentPadding = PaddingValues(horizontal = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(10.dp)
-        ) {
-            itemsIndexed(shorts, key = { _, item -> item.videoId }) { index, item ->
-                ShortsCard(
-                    item = item,
-                    onClick = { onShortClick(index) }
-                )
-            }
-        }
-    }
-}
-
-/**
- * One portrait Shorts card with a press-scale spring, bottom gradient and
- * title/view-count overlay.
- */
-@Composable
-private fun ShortsCard(
-    item: ShortsItem,
-    onClick: () -> Unit
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    val isPressed by interactionSource.collectIsPressedAsState()
-    val scale by animateFloatAsState(
-        targetValue = if (isPressed) 0.95f else 1f,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
-        label = "shortsCardScale"
-    )
-
-    Box(
-        modifier = Modifier
-            .width(150.dp)
-            .aspectRatio(9f / 16f)
-            .scale(scale)
-            .clip(RoundedCornerShape(16.dp))
-            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-            .clickable(interactionSource = interactionSource, indication = null, onClick = onClick)
-    ) {
-        AsyncImage(
-            model = item.portraitThumbnailUrl,
-            contentDescription = item.title,
-            modifier = Modifier.fillMaxSize(),
-            contentScale = ContentScale.Crop
-        )
-
-        Box(
+        val carouselState = rememberCarouselState { shorts.size }
+        HorizontalMultiBrowseCarousel(
+            state = carouselState,
+            preferredItemWidth = 160.dp,
+            itemSpacing = 8.dp,
+            contentPadding = PaddingValues(horizontal = 20.dp),
             modifier = Modifier
                 .fillMaxWidth()
-                .height(96.dp)
-                .align(Alignment.BottomCenter)
-                .background(
-                    Brush.verticalGradient(
-                        colors = listOf(Color.Transparent, Color.Black.copy(alpha = 0.75f))
-                    )
+                .height(280.dp)
+        ) { index ->
+            val item = shorts[index]
+            Box(
+                modifier = Modifier
+                    .maskClip(MaterialTheme.shapes.large)
+                    .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                    .clickable { onShortClick(index) }
+            ) {
+                AsyncImage(
+                    model = item.portraitThumbnailUrl,
+                    contentDescription = item.title,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
                 )
-        )
 
-        Column(
-            modifier = Modifier
-                .align(Alignment.BottomStart)
-                .padding(10.dp)
-        ) {
-            if (item.title.isNotBlank()) {
-                Text(
-                    text = item.title,
-                    style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.SemiBold,
-                    color = Color.White,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(96.dp)
+                        .align(Alignment.BottomCenter)
+                        .background(
+                            Brush.verticalGradient(
+                                colors = listOf(Color.Transparent, Color.Black.copy(alpha = 0.75f))
+                            )
+                        )
                 )
-            }
-            if (item.viewCount.isNotBlank()) {
-                Spacer(modifier = Modifier.height(2.dp))
-                Text(
-                    text = item.viewCount,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = Color.White.copy(alpha = 0.75f),
-                    maxLines = 1
-                )
+
+                Column(
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(12.dp)
+                ) {
+                    if (item.title.isNotBlank()) {
+                        Text(
+                            text = item.title,
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.SemiBold,
+                            color = Color.White,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                    if (item.viewCount.isNotBlank()) {
+                        Spacer(modifier = Modifier.height(2.dp))
+                        Text(
+                            text = item.viewCount,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = Color.White.copy(alpha = 0.75f),
+                            maxLines = 1
+                        )
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## What

YouTube Shorts in video mode — **strictly opt-in, off by default**: a Shorts shelf on the video home feed plus a fullscreen vertical-swipe player, fully wired into the user's login.

## Opt-in by design

Short-form feeds are engineered to be compulsive, so Koda ships with Shorts **disabled**:

- New `shortsEnabled` preference (default `false`) threaded through `ThemePreferences` → `ThemeViewModel` → `MainActivity` → `SettingsScreen`, following the repo's standard settings recipe (incl. the fresh-read helper for decision-time checks).
- **Settings → Content Mode**: a "Shorts" switch whose subtitle warns about endless scrolling; while enabled the subtitle turns error-colored as a standing reminder.
- **Onboarding (Video mode page)**: a Shorts switch plus a persistent warning card (`errorContainer` + `WarningAmber`) explaining why it ships off and that it can be changed any time in Settings.
- Gating on both ends: `HomeViewModel.loadShortsFeed()` no-ops unless opted in (fresh pref read), and the shelf renders only while the setting is on — turning it off hides Shorts instantly with no refetch.


Closes #65 
## How it works

### Data layer (`YouTubeRepository`, shapes probe-verified against the live API July 2026)
- `getShortsFeed()` — logged in: parses the personalized Shorts shelf (`shortsLockupViewModel`s) out of the signed `FEwhat_to_watch` home response. Logged out / no shelf: InnerTube search fallback seeded from local watch history (`"<last channel> shorts"`, else `"trending shorts"`), which surfaces the same lockup shape.
- `getShortsSequence(sequenceParams)` — the endless swipe feed via `reel/reel_watch_sequence`; the response's continuation token re-POSTs in the same `sequenceParams` field (verified live). All calls go through `postWatchApi`, so they carry Cookie + SAPISIDHASH when logged in → personalized sequence.
- New `ShortsItem`/`ShortsFeedPage` models. Sequence entries arrive id-only; metadata is enriched at play time, keeping tap-time network minimal.

### Playback (`ShortsPlayerViewModel`)
- Shorts are ordinary videos server-side, so streams resolve through the existing ANDROID_VR `/player` path (`getVideoStreamQualities`), with the same two-phase load as the video player: streams first (15s stuck-buffering guard), then **one** watch-next call for engagement + real title/channel/avatar.
- Own looping ExoPlayer (REPEAT_MODE_ONE, same tuned LoadControl, audio focus so music/video/Shorts never play over each other).
- Like/dislike/subscribe (optimistic with rollback), comments (full `CommentsSheet` reuse incl. replies/posting/deleting), watch-history reporting after 5s — all through the existing authenticated repository methods, so **everything works with the user's YouTube login**; logged-out taps get the existing sign-in dialog.
- Feed auto-extends 4 pages before the end, deduped by videoId.

### UI (Material 3 Expressive, matching neighboring code)
- `ShortsShelf`: bolt-icon header chip + horizontal row of 9:16 cards (16dp corners, bottom gradient, press-scale spring), slotted after the first two feed videos like YouTube home.
- `ShortsPlayerOverlay`: `VerticalPager` layered above the NavHost — portrait thumbnail behind the surface while buffering, shape-morphing `LoadingIndicator`, springy pause badge, right action rail (like count / dislike / comments / share), channel + Subscribe row, thin bottom progress line, error state with retry, keep-screen-on while playing.

## Testing

Not built locally (CI builds). InnerTube endpoints and response shapes were probed live before writing the parsers (anonymous session); the logged-in home-shelf shape should be confirmed on-device with the emulator cookie workflow from CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PbnGu16HZ63uuJX8N2EBWj