### PR TITLE
Fix visitorData bot-check handling and stream URL caching

### DIFF
--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -205,9 +205,19 @@ fun MusicApp(
         PlayerViewModel(context.applicationContext)
     }
     val homeViewModel: HomeViewModel = viewModel()
-    
+
     val videoPlayerViewModel: com.ivor.ivormusic.ui.video.VideoPlayerViewModel = viewModel()
     val shortsPlayerViewModel: com.ivor.ivormusic.ui.shorts.ShortsPlayerViewModel = viewModel()
+
+    // Surface music playback failures. Before this, a song that could not be
+    // resolved failed silently and the player looked stuck on loading forever.
+    val playbackError by playerViewModel.playbackError.collectAsState()
+    androidx.compose.runtime.LaunchedEffect(playbackError) {
+        playbackError?.let { message ->
+            android.widget.Toast.makeText(context, message, android.widget.Toast.LENGTH_LONG).show()
+            playerViewModel.clearPlaybackError()
+        }
+    }
 
     Box(
         modifier = Modifier

--- a/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
@@ -130,11 +130,6 @@ class YouTubeRepository(private val context: Context) {
         private const val TV_EMBED_USER_AGENT =
             "Mozilla/5.0 (PlayStation; PlayStation 4/12.00) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Safari/605.1.15"
 
-        // Anonymous visitorData (base64) — present in YouTube's public bootstrap
-        // JS. Many endpoints now require it; without it, ANDROID_VR can return
-        // empty streamingData under load.
-        private const val DEFAULT_VISITOR_DATA = "Cgt6SUNYVzB2VkJDbyjGrrSmBg=="
-
         // visitorData cache is companion-level: repositories are created per
         // ViewModel (no DI), so instance-level storage would make every VM pay
         // the youtube.com bootstrap download once. Shared storage means one
@@ -553,58 +548,11 @@ class YouTubeRepository(private val context: Context) {
     suspend fun getStreamUrl(videoId: String): Result<String> = withContext(Dispatchers.IO) {
         val startMs = System.currentTimeMillis()
 
-        // Single resolution mechanism: direct InnerTube /player calls.
-        //
-        // ANDROID_VR is the primary (and effectively only) client that yields
-        // *fully downloadable* audio URLs without a GVS PO Token: its googlevideo
-        // URLs serve the whole file, where IOS-issued URLs are throttled to the
-        // first ~1 MiB and then return HTTP 403 (GVS PO-Token enforcement).
-        //
-        // The catch is YouTube's bot check: with a stale/shared visitorData,
-        // ANDROID_VR returns playabilityStatus=LOGIN_REQUIRED ("Sign in to
-        // confirm you're not a bot"). A freshly minted, session-unique
-        // visitorData (see getVisitorData) clears that check. We refresh it once
-        // up front and reuse it for both attempts.
-        //
-        // IOS stays only as a last-ditch fallback for the rare videos ANDROID_VR
-        // can't serve (e.g. "made for kids", which ANDROID_VR omits). Its URL may
-        // be throttled, but a few seconds of audio beats a hard failure.
-        //
-        // Each call is hard-capped by streamResolveClient's callTimeout, so the
-        // worst case is bounded regardless of coroutine cancellability.
-        val visitorData = getVisitorData()
-
-        val androidVrExtras = org.json.JSONObject().apply {
-            put("androidSdkVersion", 32)
-            put("deviceMake", "Oculus")
-            put("deviceModel", "Quest 3")
-            put("osName", "Android")
-            put("osVersion", "12L")
-        }
-        val iosExtras = org.json.JSONObject().apply {
-            put("deviceMake", "Apple")
-            put("deviceModel", "iPhone16,2")
-            put("osName", "iPhone")
-            put("osVersion", "18.1.0.22B83")
-        }
-
-        val url = getStreamUrlFromInnerTube(
-            videoId = videoId,
-            clientName = "ANDROID_VR",
-            clientVersion = ANDROID_VR_VERSION,
-            clientNameId = ANDROID_VR_CLIENT_ID,
-            userAgent = ANDROID_VR_USER_AGENT,
-            visitorData = visitorData,
-            extraClientFields = androidVrExtras,
-        ) ?: getStreamUrlFromInnerTube(
-            videoId = videoId,
-            clientName = "IOS",
-            clientVersion = IOS_VERSION,
-            clientNameId = IOS_CLIENT_ID,
-            userAgent = IOS_USER_AGENT,
-            visitorData = visitorData,
-            extraClientFields = iosExtras,
-        )
+        // Single resolution mechanism: direct InnerTube /player calls
+        // (ANDROID_VR primary, IOS fallback — see runPlayerClientChain), with a
+        // one-shot visitorData remint + retry when YouTube's bot check flags
+        // the current token (see resolvePlayerStreamingData).
+        val url = resolvePlayerStreamingData(videoId)?.let { pickAudioStreamUrl(videoId, it) }
 
         val dt = System.currentTimeMillis() - startMs
         if (!url.isNullOrEmpty()) {
@@ -625,8 +573,11 @@ class YouTubeRepository(private val context: Context) {
     // --- Fresh visitorData (anti-bot) ---------------------------------------
     // YouTube's /player bot check keys off visitorData: a stale or shared value
     // gets flagged (LOGIN_REQUIRED). A visitorData freshly minted from the
-    // youtube.com bootstrap passes. We cache it (companion-level, see there)
-    // and refresh on a TTL.
+    // youtube.com bootstrap passes. We cache it (companion-level, see there),
+    // refresh on a TTL, persist the last good token per install, and remint
+    // immediately when a /player response shows the current token got flagged
+    // mid-TTL (remintVisitorData) — otherwise every resolution keeps failing
+    // for hours, which users experience as "music suddenly stops playing".
 
     /**
      * Warm the visitorData cache off the critical path. The cold fetch
@@ -652,13 +603,63 @@ class YouTubeRepository(private val context: Context) {
             if (!fresh.isNullOrEmpty()) {
                 cachedVisitorData = fresh
                 visitorDataFetchedAt = nowInner
+                persistVisitorData(fresh)
                 android.util.Log.i("YouTubeRepository", "visitorData refreshed (len=${fresh.length})")
                 fresh
             } else {
-                // Reuse a previously-good value if we have one; otherwise fall
-                // back to the baked-in constant (better than nothing).
-                cachedVisitorData ?: DEFAULT_VISITOR_DATA
+                // Reuse a previously-good value: this session's, else the last
+                // one this install successfully minted. Never a token shared
+                // across installs — the bot check flags shared visitorData,
+                // which kills all stream resolution. Empty means "send the
+                // /player call without visitorData", which mostly still works.
+                cachedVisitorData ?: loadPersistedVisitorData() ?: ""
             }
+        }
+    }
+
+    /**
+     * Drop [flagged] from the in-memory and persisted caches and mint a fresh
+     * visitorData right now. Called when a /player response shows YouTube's
+     * bot check rejected the current token (LOGIN_REQUIRED / missing
+     * streamingData). Returns null when the bootstrap fetch fails.
+     */
+    private suspend fun remintVisitorData(flagged: String): String? =
+        visitorDataMutex.withLock {
+            // A concurrent resolution may have already reminted while this one
+            // waited on the lock — reuse its token instead of re-fetching.
+            cachedVisitorData?.takeIf { it != flagged }?.let { return@withLock it }
+            cachedVisitorData = null
+            visitorDataFetchedAt = 0L
+            clearPersistedVisitorData(flagged)
+            val fresh = fetchVisitorData()
+            if (!fresh.isNullOrEmpty()) {
+                cachedVisitorData = fresh
+                visitorDataFetchedAt = System.currentTimeMillis()
+                persistVisitorData(fresh)
+                android.util.Log.i("YouTubeRepository", "visitorData reminted after bot-check flag")
+                fresh
+            } else {
+                android.util.Log.w("YouTubeRepository", "visitorData remint failed (bootstrap fetch)")
+                null
+            }
+        }
+
+    // Last successfully minted token, persisted per install so a cold start on
+    // a flaky network still has a usable, install-unique token to fall back on.
+    private val visitorDataPrefs by lazy {
+        context.getSharedPreferences("ivor_visitor_data", Context.MODE_PRIVATE)
+    }
+
+    private fun loadPersistedVisitorData(): String? =
+        visitorDataPrefs.getString("visitor_data", null)?.takeIf { it.isNotBlank() }
+
+    private fun persistVisitorData(value: String) {
+        visitorDataPrefs.edit().putString("visitor_data", value).apply()
+    }
+
+    private fun clearPersistedVisitorData(flagged: String) {
+        if (visitorDataPrefs.getString("visitor_data", null) == flagged) {
+            visitorDataPrefs.edit().remove("visitor_data").apply()
         }
     }
 
@@ -674,7 +675,10 @@ class YouTubeRepository(private val context: Context) {
                 .addHeader("User-Agent", BROWSER_USER_AGENT)
                 .addHeader("Accept-Language", "en-US,en;q=0.9")
                 .build()
-            val response = streamResolveClient.newCall(request).execute()
+            // The bootstrap page is ~1.5 MB — use the general 30s client, not
+            // streamResolveClient whose 8s callTimeout kills the download on
+            // slow connections and left those users without a usable token.
+            val response = okHttpClient.newCall(request).execute()
             val html = response.body?.string().orEmpty()
             response.close()
             Regex("\"visitorData\":\"(.*?)\"").find(html)
@@ -1253,25 +1257,105 @@ class YouTubeRepository(private val context: Context) {
     }
 
     /**
-     * Single-client InnerTube /player call. Returns the best audio URL or null on any
-     * failure. Falls back to muxed video-only formats (e.g. itag 18) when no audio-only
-     * format is available — ExoPlayer extracts the audio track from the MP4 container,
-     * which is critical because ANDROID_VR can return only format 18 since March 2026
-     * (see yt-dlp issue #16150).
+     * Outcome of one InnerTube /player call. [visitorDataSuspect] is true when
+     * the response indicates YouTube's bot check flagged our visitorData:
+     * playability LOGIN_REQUIRED ("Sign in to confirm you're not a bot"), or a
+     * 200/OK response with streamingData missing (stale/missing visitorData).
      */
-    private suspend fun getStreamUrlFromInnerTube(
-        videoId: String,
-        clientName: String,
-        clientVersion: String,
-        clientNameId: Int,
-        userAgent: String,
-        visitorData: String,
-        extraClientFields: org.json.JSONObject = org.json.JSONObject(),
-    ): String? = withContext(Dispatchers.IO) {
-        val streamingData = fetchPlayerStreamingData(
-            videoId, clientName, clientVersion, clientNameId, userAgent, visitorData, extraClientFields
-        ) ?: return@withContext null
+    private class PlayerResponse(
+        val streamingData: org.json.JSONObject?,
+        val visitorDataSuspect: Boolean,
+    )
 
+    /**
+     * Resolve /player streamingData for [videoId], reminting the visitorData
+     * and retrying once when the responses show the current token has been
+     * flagged by YouTube's bot check. Without the remint, a token flagged
+     * mid-TTL poisons every resolution until it expires — the "music played
+     * fine, then nothing plays anymore" failure mode.
+     */
+    private suspend fun resolvePlayerStreamingData(videoId: String): org.json.JSONObject? {
+        val visitorData = getVisitorData()
+        val first = runPlayerClientChain(videoId, visitorData)
+        first.streamingData?.let { return it }
+        if (!first.visitorDataSuspect) return null
+
+        android.util.Log.w(
+            "YouTubeRepository",
+            "Resolve: visitorData flagged by bot check, reminting and retrying videoId=$videoId",
+        )
+        val fresh = remintVisitorData(flagged = visitorData) ?: return null
+        if (fresh == visitorData) return null
+        return runPlayerClientChain(videoId, fresh).streamingData
+    }
+
+    /**
+     * The two-client /player chain.
+     *
+     * ANDROID_VR is the primary (and effectively only) client that yields
+     * *fully downloadable* audio URLs without a GVS PO Token: its googlevideo
+     * URLs serve the whole file, where IOS-issued URLs are throttled to the
+     * first ~1 MiB and then return HTTP 403 (GVS PO-Token enforcement).
+     *
+     * IOS stays only as a last-ditch fallback for the rare videos ANDROID_VR
+     * can't serve (e.g. "made for kids", which ANDROID_VR omits). Its URL may
+     * be throttled, but a few seconds of audio beats a hard failure.
+     *
+     * Each call is hard-capped by streamResolveClient's callTimeout, so the
+     * worst case is bounded regardless of coroutine cancellability.
+     */
+    private suspend fun runPlayerClientChain(videoId: String, visitorData: String): PlayerResponse {
+        val androidVrExtras = org.json.JSONObject().apply {
+            put("androidSdkVersion", 32)
+            put("deviceMake", "Oculus")
+            put("deviceModel", "Quest 3")
+            put("osName", "Android")
+            put("osVersion", "12L")
+        }
+        val iosExtras = org.json.JSONObject().apply {
+            put("deviceMake", "Apple")
+            put("deviceModel", "iPhone16,2")
+            put("osName", "iPhone")
+            put("osVersion", "18.1.0.22B83")
+        }
+
+        val vr = fetchPlayerResponse(
+            videoId = videoId,
+            clientName = "ANDROID_VR",
+            clientVersion = ANDROID_VR_VERSION,
+            clientNameId = ANDROID_VR_CLIENT_ID,
+            userAgent = ANDROID_VR_USER_AGENT,
+            visitorData = visitorData,
+            extraClientFields = androidVrExtras,
+        )
+        vr.streamingData?.let { return vr }
+
+        val ios = fetchPlayerResponse(
+            videoId = videoId,
+            clientName = "IOS",
+            clientVersion = IOS_VERSION,
+            clientNameId = IOS_CLIENT_ID,
+            userAgent = IOS_USER_AGENT,
+            visitorData = visitorData,
+            extraClientFields = iosExtras,
+        )
+        return PlayerResponse(
+            streamingData = ios.streamingData,
+            visitorDataSuspect = vr.visitorDataSuspect || ios.visitorDataSuspect,
+        )
+    }
+
+    /**
+     * Select the best audio URL from a /player streamingData object. Falls back
+     * to muxed video formats (e.g. itag 18) when no audio-only format is
+     * available — ExoPlayer extracts the audio track from the MP4 container,
+     * which is critical because ANDROID_VR can return only format 18 since
+     * March 2026 (see yt-dlp issue #16150).
+     */
+    private fun pickAudioStreamUrl(
+        videoId: String,
+        streamingData: org.json.JSONObject,
+    ): String? {
         val formats = mutableListOf<org.json.JSONObject>()
         streamingData.optJSONArray("adaptiveFormats")?.let { arr ->
             for (i in 0 until arr.length()) formats.add(arr.getJSONObject(i))
@@ -1287,11 +1371,11 @@ class YouTubeRepository(private val context: Context) {
         }
         android.util.Log.d(
             "YouTubeRepository",
-            "Resolve[InnerTube/$clientName] formats=${formats.size} audioOnly=${audioFormats.size} videoId=$videoId",
+            "Resolve[InnerTube] formats=${formats.size} audioOnly=${audioFormats.size} videoId=$videoId",
         )
 
         audioFormats.maxByOrNull { it.optInt("bitrate") }?.optString("url")
-            ?.takeIf { it.isNotEmpty() }?.let { return@withContext it }
+            ?.takeIf { it.isNotEmpty() }?.let { return it }
 
         // No audio-only stream available — fall back to a muxed MP4 (itag 18 etc.).
         // ExoPlayer happily plays just the audio track of these.
@@ -1302,9 +1386,9 @@ class YouTubeRepository(private val context: Context) {
             ?.takeIf { it.isNotEmpty() }?.let {
                 android.util.Log.w(
                     "YouTubeRepository",
-                    "Resolve[InnerTube/$clientName] using muxed video format videoId=$videoId (no audio-only)",
+                    "Resolve[InnerTube] using muxed video format videoId=$videoId (no audio-only)",
                 )
-                return@withContext it
+                return it
             }
 
         val cipheredCount = formats.count {
@@ -1313,17 +1397,17 @@ class YouTubeRepository(private val context: Context) {
         }
         android.util.Log.w(
             "YouTubeRepository",
-            "Resolve[InnerTube/$clientName] no usable URL videoId=$videoId ciphered=${cipheredCount}/${formats.size}",
+            "Resolve[InnerTube] no usable URL videoId=$videoId ciphered=${cipheredCount}/${formats.size}",
         )
-        null
+        return null
     }
 
     /**
      * Single-client InnerTube /player call returning the raw streamingData
-     * object, or null on any failure (HTTP error, bad playability, missing
-     * streamingData). Shared by audio resolution and video quality listing.
+     * object plus a bot-check verdict (see [PlayerResponse]). Shared by audio
+     * resolution and video quality listing.
      */
-    private suspend fun fetchPlayerStreamingData(
+    private suspend fun fetchPlayerResponse(
         videoId: String,
         clientName: String,
         clientVersion: String,
@@ -1331,7 +1415,7 @@ class YouTubeRepository(private val context: Context) {
         userAgent: String,
         visitorData: String,
         extraClientFields: org.json.JSONObject = org.json.JSONObject(),
-    ): org.json.JSONObject? = withContext(Dispatchers.IO) {
+    ): PlayerResponse = withContext(Dispatchers.IO) {
         try {
             val clientObj = org.json.JSONObject().apply {
                 put("clientName", clientName)
@@ -1339,7 +1423,7 @@ class YouTubeRepository(private val context: Context) {
                 put("hl", "en")
                 put("gl", "US")
                 put("utcOffsetMinutes", 0)
-                put("visitorData", visitorData)
+                if (visitorData.isNotBlank()) put("visitorData", visitorData)
                 val keys = extraClientFields.keys()
                 while (keys.hasNext()) {
                     val k = keys.next()
@@ -1360,17 +1444,19 @@ class YouTubeRepository(private val context: Context) {
 
             val url = "https://youtubei.googleapis.com/youtubei/v1/player?key=$INNER_TUBE_API_KEY&prettyPrint=false"
 
-            val request = okhttp3.Request.Builder()
+            val requestBuilder = okhttp3.Request.Builder()
                 .url(url)
                 .post(jsonBody.toRequestBody("application/json".toMediaType()))
                 .addHeader("User-Agent", userAgent)
                 .addHeader("X-Goog-Api-Format-Version", "2")
                 .addHeader("X-YouTube-Client-Name", clientNameId.toString())
                 .addHeader("X-YouTube-Client-Version", clientVersion)
-                .addHeader("X-Goog-Visitor-Id", visitorData)
                 .addHeader("Origin", "https://www.youtube.com")
                 .addHeader("Accept", "application/json")
-                .build()
+            if (visitorData.isNotBlank()) {
+                requestBuilder.addHeader("X-Goog-Visitor-Id", visitorData)
+            }
+            val request = requestBuilder.build()
 
             val response = streamResolveClient.newCall(request).execute()
             val code = response.code
@@ -1382,14 +1468,14 @@ class YouTubeRepository(private val context: Context) {
                     "YouTubeRepository",
                     "Resolve[InnerTube/$clientName] HTTP $code videoId=$videoId body=${json.take(160)}",
                 )
-                return@withContext null
+                return@withContext PlayerResponse(null, false)
             }
             if (json.isEmpty()) {
                 android.util.Log.w(
                     "YouTubeRepository",
                     "Resolve[InnerTube/$clientName] empty body videoId=$videoId",
                 )
-                return@withContext null
+                return@withContext PlayerResponse(null, false)
             }
 
             val root = org.json.JSONObject(json)
@@ -1401,23 +1487,29 @@ class YouTubeRepository(private val context: Context) {
                     "YouTubeRepository",
                     "Resolve[InnerTube/$clientName] playability=$status reason=${playability?.optString("reason")} videoId=$videoId",
                 )
-                return@withContext null
+                // LOGIN_REQUIRED here is the bot check rejecting our
+                // visitorData ("Sign in to confirm you're not a bot").
+                return@withContext PlayerResponse(null, status == "LOGIN_REQUIRED")
             }
 
-            root.optJSONObject("streamingData") ?: run {
+            val streamingData = root.optJSONObject("streamingData")
+            if (streamingData == null) {
                 android.util.Log.w(
                     "YouTubeRepository",
                     "Resolve[InnerTube/$clientName] no streamingData videoId=$videoId",
                 )
-                null
+                // Status OK with no streamingData is the other known signature
+                // of a stale/missing visitorData.
+                return@withContext PlayerResponse(null, true)
             }
+            PlayerResponse(streamingData, false)
         } catch (e: Exception) {
             android.util.Log.e(
                 "YouTubeRepository",
                 "Resolve[InnerTube/$clientName] exception videoId=$videoId",
                 e,
             )
-            null
+            PlayerResponse(null, false)
         }
     }
 
@@ -3325,44 +3417,12 @@ class YouTubeRepository(private val context: Context) {
 
     /**
      * Resolve the full video quality ladder via InnerTube: ANDROID_VR first
-     * (no PO token, unciphered URLs), IOS as fallback. Returns an empty list
-     * when neither client yields usable streamingData.
+     * (no PO token, unciphered URLs), IOS as fallback, with a one-shot
+     * visitorData remint when the bot check flags the current token. Returns
+     * an empty list when neither client yields usable streamingData.
      */
     private suspend fun getVideoQualitiesFromInnerTube(videoId: String): List<VideoQuality> {
-        val visitorData = getVisitorData()
-
-        val androidVrExtras = org.json.JSONObject().apply {
-            put("androidSdkVersion", 32)
-            put("deviceMake", "Oculus")
-            put("deviceModel", "Quest 3")
-            put("osName", "Android")
-            put("osVersion", "12L")
-        }
-        val iosExtras = org.json.JSONObject().apply {
-            put("deviceMake", "Apple")
-            put("deviceModel", "iPhone16,2")
-            put("osName", "iPhone")
-            put("osVersion", "18.1.0.22B83")
-        }
-
-        val streamingData = fetchPlayerStreamingData(
-            videoId = videoId,
-            clientName = "ANDROID_VR",
-            clientVersion = ANDROID_VR_VERSION,
-            clientNameId = ANDROID_VR_CLIENT_ID,
-            userAgent = ANDROID_VR_USER_AGENT,
-            visitorData = visitorData,
-            extraClientFields = androidVrExtras,
-        ) ?: fetchPlayerStreamingData(
-            videoId = videoId,
-            clientName = "IOS",
-            clientVersion = IOS_VERSION,
-            clientNameId = IOS_CLIENT_ID,
-            userAgent = IOS_USER_AGENT,
-            visitorData = visitorData,
-            extraClientFields = iosExtras,
-        ) ?: return emptyList()
-
+        val streamingData = resolvePlayerStreamingData(videoId) ?: return emptyList()
         return parseQualitiesFromStreamingData(streamingData)
     }
 

--- a/app/src/main/java/com/ivor/ivormusic/service/MusicService.kt
+++ b/app/src/main/java/com/ivor/ivormusic/service/MusicService.kt
@@ -62,11 +62,19 @@ class MusicService : MediaLibraryService() {
     private val resolveScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     // --- State & Cache ---
-    // --- State & Cache ---
     // Deduplicated active resolutions: VideoID -> Deferred result
     private val activeResolutions = ConcurrentHashMap<String, kotlinx.coroutines.Deferred<MediaItem>>()
-    // Cache for resolved URIs (VideoID -> URI)
-    private val uriCache = ConcurrentHashMap<String, String>()
+
+    // Cache for resolved stream URIs. googlevideo URLs die after ~6h (their
+    // `expire` param) and on network/IP changes, so each entry carries an
+    // expiry and is dropped instead of being replayed as a guaranteed 403.
+    private class CachedUri(val uri: String, val expiresAtMs: Long)
+    private val uriCache = ConcurrentHashMap<String, CachedUri>()
+
+    // Per-song playback error retries. Kept separate from uriCache and reset
+    // on successful playback so a song can't permanently exhaust its budget
+    // over the lifetime of the service.
+    private val retryCounts = ConcurrentHashMap<String, Int>()
     
     // --- Configuration ---
     private var isCrossfadeEnabled = true
@@ -93,6 +101,28 @@ class MusicService : MediaLibraryService() {
         private const val PLACEHOLDER_PREFIX = "https://placeholder.ivormusic/"
         private const val CACHED_PREFIX = "https://cached.ivormusic/"
         private const val ANDROID_AUTO_BROWSE_TIMEOUT_MS = 30_000L
+        // Safety margin before a googlevideo URL's `expire` timestamp, and the
+        // fallback lifetime when the URL carries no readable expire param.
+        private const val URI_EXPIRY_SAFETY_MS = 5 * 60 * 1000L
+        private const val URI_DEFAULT_TTL_MS = 4 * 60 * 60 * 1000L
+    }
+
+    /**
+     * When the cached URI for a googlevideo URL stops being usable. Prefers the
+     * URL's own `expire` query param (epoch seconds, ~6h out) minus a safety
+     * margin; falls back to a conservative fixed TTL.
+     */
+    private fun streamUrlExpiryMs(url: String): Long {
+        val expireSec = try {
+            Uri.parse(url).getQueryParameter("expire")?.toLongOrNull()
+        } catch (_: Exception) {
+            null
+        }
+        return if (expireSec != null && expireSec > 0) {
+            expireSec * 1000L - URI_EXPIRY_SAFETY_MS
+        } else {
+            System.currentTimeMillis() + URI_DEFAULT_TTL_MS
+        }
     }
 
     override fun onCreate() {
@@ -149,6 +179,7 @@ class MusicService : MediaLibraryService() {
         CacheManager.release()
         activeResolutions.clear()
         uriCache.clear()
+        retryCounts.clear()
         super.onDestroy()
     }
 
@@ -298,6 +329,10 @@ class MusicService : MediaLibraryService() {
 
             // Start prefetching as soon as we are ready
             if (playbackState == Player.STATE_READY) {
+                // The current song plays — give it back its full retry budget
+                // so one bad stretch (expired URL, network blip) months of
+                // uptime ago can't permanently blacklist it.
+                player.currentMediaItem?.mediaId?.let { retryCounts.remove(it) }
                 prefetchUpcomingSongs()
             }
 
@@ -438,10 +473,15 @@ class MusicService : MediaLibraryService() {
             return buildMediaItemWithUri(originalItem, downloaded.uri, downloaded.duration)
         }
 
-        // 2. Cache (Memory)
-        uriCache[videoId]?.let { cachedUri ->
-            Log.d(TAG, "Resolution: Found cached URI for $videoId")
-            return buildMediaItemWithUri(originalItem, Uri.parse(cachedUri))
+        // 2. Cache (Memory) — only while the underlying googlevideo URL is
+        // still valid; expired entries are re-resolved instead of replayed.
+        uriCache[videoId]?.let { cached ->
+            if (cached.expiresAtMs > System.currentTimeMillis()) {
+                Log.d(TAG, "Resolution: Found cached URI for $videoId")
+                return buildMediaItemWithUri(originalItem, Uri.parse(cached.uri))
+            }
+            Log.d(TAG, "Resolution: Cached URI expired for $videoId, re-resolving")
+            uriCache.remove(videoId)
         }
 
         // 3. Disk Cache (Fully Cached - Instant Playback)
@@ -460,7 +500,7 @@ class MusicService : MediaLibraryService() {
             
             val streamUrl = result?.getOrNull()
             if (!streamUrl.isNullOrEmpty()) {
-                uriCache[videoId] = streamUrl
+                uriCache[videoId] = CachedUri(streamUrl, streamUrlExpiryMs(streamUrl))
                 Log.d(TAG, "Resolution: Network success for $videoId")
                 buildMediaItemWithUri(originalItem, Uri.parse(streamUrl))
             } else {
@@ -531,12 +571,11 @@ class MusicService : MediaLibraryService() {
         }
 
         // 2. Retry Logic (YouTube songs only)
-        val retryCountKey = "retry_count_$videoId"
-        val retryCount = uriCache[retryCountKey]?.toIntOrNull() ?: 0
+        val retryCount = retryCounts[videoId] ?: 0
 
         if (retryCount < 2) {
             Log.w(TAG, "Error: Retrying ($retryCount/2) for $videoId...")
-            uriCache[retryCountKey] = (retryCount + 1).toString()
+            retryCounts[videoId] = retryCount + 1
             uriCache.remove(videoId) // Clear bad cache
             
             serviceScope.launch {

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.isActive
@@ -53,6 +54,16 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
 
     private val _isBuffering = MutableStateFlow(false)
     val isBuffering: StateFlow<Boolean> = _isBuffering.asStateFlow()
+
+    // One-shot user-facing playback error message. The UI shows it (toast) and
+    // calls clearPlaybackError(). Without this, resolution/network failures
+    // were completely silent and the player sat on the buffering spinner.
+    private val _playbackError = MutableStateFlow<String?>(null)
+    val playbackError: StateFlow<String?> = _playbackError.asStateFlow()
+
+    fun clearPlaybackError() {
+        _playbackError.value = null
+    }
 
     private val _shuffleModeEnabled = MutableStateFlow(false)
     val shuffleModeEnabled: StateFlow<Boolean> = _shuffleModeEnabled.asStateFlow()
@@ -148,6 +159,27 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
     init {
         initializeController()
         startProgressUpdates()
+        startBufferingWatchdog()
+    }
+
+    /**
+     * Global buffering watchdog: whenever the spinner has been showing for 30s
+     * without playback starting, clear it. Covers every path that sets
+     * _isBuffering (playQueue, skip, auto-advance) so a failed resolution can
+     * never leave the UI on an eternal loading state.
+     */
+    private fun startBufferingWatchdog() {
+        viewModelScope.launch {
+            _isBuffering.collectLatest { buffering ->
+                if (buffering) {
+                    delay(30_000)
+                    if (_isBuffering.value && !_isPlaying.value) {
+                        android.util.Log.w("PlayerViewModel", "Buffering watchdog: clearing stuck state")
+                        _isBuffering.value = false
+                    }
+                }
+            }
+        }
     }
     
     /**
@@ -259,6 +291,21 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
                             // especially for local songs that transition through IDLE->READY
                             // almost instantly.
                         }
+                    }
+                }
+
+                override fun onPlayerError(error: androidx.media3.common.PlaybackException) {
+                    android.util.Log.e("PlayerViewModel", "Playback error: ${error.errorCodeName}", error)
+                    // MusicService retries and skips on its own; if it recovers,
+                    // the player re-enters BUFFERING and the flag comes back.
+                    // Clearing here guarantees the spinner can't outlive a
+                    // playback that is never going to start.
+                    _isBuffering.value = false
+                    val title = _currentSong.value?.title
+                    _playbackError.value = if (title != null) {
+                        "Couldn't play \"$title\". Check your connection and try again."
+                    } else {
+                        "Playback failed. Check your connection and try again."
                     }
                 }
 
@@ -504,17 +551,9 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
             }
             
             // 3. NOW prepare and play - notification will see complete queue
+            // (the buffering watchdog in init covers the stuck-spinner case)
             player.prepare()
             player.play()
-            
-            // Safety timeout for buffering state - if stuck for 30 seconds, clear it
-            viewModelScope.launch {
-                delay(30_000)
-                if (_isBuffering.value && !_isPlaying.value) {
-                    android.util.Log.w("PlayerViewModel", "Buffering timeout - clearing stuck state")
-                    _isBuffering.value = false
-                }
-            }
         }
     }
     


### PR DESCRIPTION
## Summary

Fixes critical playback failures caused by YouTube's bot-check flagging stale `visitorData` tokens mid-TTL, and improves stream URL caching to handle expiry. Without these fixes, users experience "music played fine, then nothing plays anymore" after hours of uptime.

## Key Changes

**YouTubeRepository (`data/YouTubeRepository.kt`)**
- **Removed hardcoded fallback `visitorData`**: The `DEFAULT_VISITOR_DATA` constant was a shared token that YouTube's bot check explicitly rejects. Replaced with per-install persistence + empty string fallback.
- **Added `visitorData` persistence**: New `SharedPreferences`-backed `loadPersistedVisitorData()` / `persistVisitorData()` / `clearPersistedVisitorData()` methods store the last successfully minted token per install, so cold starts on flaky networks still have a usable, install-unique token.
- **Implemented mid-TTL remint on bot-check flag**: New `remintVisitorData(flagged)` method detects when YouTube rejects the current token (LOGIN_REQUIRED playability status or 200/OK with missing streamingData) and immediately mints a fresh one, then retries the resolution. Without this, a flagged token poisons all resolutions for hours until TTL expiry.
- **Refactored stream resolution flow**:
  - Extracted `resolvePlayerStreamingData()`: Wraps the two-client chain with one-shot remint + retry logic.
  - Extracted `runPlayerClientChain()`: Encapsulates ANDROID_VR → IOS fallback with a new `PlayerResponse` class that carries both streamingData and a `visitorDataSuspect` flag.
  - Renamed `fetchPlayerStreamingData()` → `fetchPlayerResponse()`: Now returns `PlayerResponse` instead of nullable streamingData, allowing callers to distinguish "no data" from "bot check flagged this token".
  - Extracted `pickAudioStreamUrl()`: Separated URL selection logic from the /player call, making the flow clearer.
- **Fixed bootstrap fetch timeout**: Changed `fetchVisitorData()` to use the general 30s `okHttpClient` instead of `streamResolveClient`'s 8s timeout, which was killing downloads on slow connections and leaving users without a usable token.
- **Allowed empty `visitorData` in requests**: Modified `/player` call construction to omit `visitorData` and `X-Goog-Visitor-Id` header when the token is blank, instead of sending an empty string (which YouTube may reject).
- **Unified quality listing**: `getVideoQualitiesFromInnerTube()` now uses `resolvePlayerStreamingData()` instead of duplicating the client chain, so quality fetches also benefit from bot-check remint.

**MusicService (`service/MusicService.kt`)**
- **Implemented stream URL expiry tracking**: Replaced simple string cache with `CachedUri(uri, expiresAtMs)` class. Googlevideo URLs carry an `expire` query param (epoch seconds, ~6h out); cache entries are dropped instead of replayed when expired, preventing 403 errors from stale URLs.
- **Separated retry tracking**: Moved per-song retry counts from the URI cache (where they were stored as `"retry_count_$videoId"` strings) to a dedicated `retryCounts` map. Retry budget is now reset when a song successfully starts playback, so one bad stretch months ago can't permanently blacklist a song.
- **Added `streamUrlExpiryMs()` helper**: Parses the `expire` param with a 5-minute safety margin; falls back to a conservative 4-hour TTL when the param is missing or unreadable.

**PlayerViewModel (`ui/player/PlayerViewModel.kt`)**
- **Added playback error surface**: New `_playbackError` StateFlow and `clearPlaybackError()` method expose resolution/network failures to the UI. Before this, failed resolutions were silent and the player sat on the buffering spinner indefinitely.
- **Moved buffering watchdog to init**: Extracted the 30-second stuck-spinner timeout into a dedicated `start

https://claude.ai/code/session_01SXimBoKVuWf7j6toxw6sSF