### PR TITLE
Player UX polish: Canvas style, sharp artwork, swipe-to-skip and haptics everywhere

### DIFF
--- a/app/src/main/java/com/ivor/ivormusic/data/Song.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/Song.kt
@@ -34,9 +34,16 @@ data class Song(
         get() = thumbnailUrl?.let { url ->
             when {
                 url.contains("googleusercontent.com") -> {
-                    // Replace size params like w120-h120 with w1080-h1080
-                    url.replace(Regex("w\\d+-h\\d+"), "w1080-h1080")
-                        .replace(Regex("s\\d+"), "s1080")
+                    // Size directives (w120-h120, s120) only live after the '='
+                    // separator; the opaque image token before it can itself
+                    // contain "s<digits>" runs, so an unanchored replace over
+                    // the whole URL corrupts it into a permanent 404.
+                    val sep = url.lastIndexOf('=')
+                    if (sep >= 0) {
+                        url.substring(0, sep) + url.substring(sep)
+                            .replace(Regex("w\\d+-h\\d+"), "w1080-h1080")
+                            .replace(Regex("s\\d+"), "s1080")
+                    } else url
                 }
                 url.contains("ytimg.com") || url.contains("youtube.com") -> {
                     // Replace low res filenames with max res

--- a/app/src/main/java/com/ivor/ivormusic/ui/components/SongArtwork.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/components/SongArtwork.kt
@@ -1,0 +1,49 @@
+package com.ivor.ivormusic.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.ivor.ivormusic.data.Song
+
+/**
+ * Album artwork that layers the high-res cover over the low-res thumbnail.
+ *
+ * The low-res thumbnail (usually already in Coil's memory cache from the
+ * list or mini player) renders immediately, and the high-res version fades
+ * in on top only once it has actually loaded. If the high-res URL fails
+ * (e.g. ytimg maxresdefault returns 404 for many tracks) the low-res image
+ * simply stays visible instead of leaving a blank frame.
+ */
+@Composable
+fun SongArtwork(
+    song: Song,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    contentScale: ContentScale = ContentScale.Crop
+) {
+    val lowRes: Any? = song.thumbnailUrl ?: song.albumArtUri
+    val highRes = song.highResThumbnailUrl?.takeIf { it != song.thumbnailUrl }
+    Box(modifier = modifier) {
+        AsyncImage(
+            model = lowRes,
+            contentDescription = contentDescription,
+            modifier = Modifier.matchParentSize(),
+            contentScale = contentScale
+        )
+        if (highRes != null) {
+            AsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(highRes)
+                    .crossfade(300)
+                    .build(),
+                contentDescription = null,
+                modifier = Modifier.matchParentSize(),
+                contentScale = contentScale
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/ArtworkColorScheme.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/ArtworkColorScheme.kt
@@ -2,8 +2,6 @@ package com.ivor.ivormusic.ui.player
 
 import android.content.Context
 import android.graphics.drawable.BitmapDrawable
-import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.tween
 import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -29,10 +27,9 @@ private data class ArtworkSeeds(val primary: Color, val secondary: Color)
  * Derives a color scheme for the expanded player from the current album
  * cover: Palette swatches become the accent roles buttons draw from
  * (primary/secondary/tertiary families), while surfaces and background
- * stay on the app theme. Seed colors crossfade between songs so the
- * controls morph instead of snapping. Returns [base] unchanged while
- * disabled, while extraction is in flight, or when the art has no
- * usable swatches.
+ * stay on the app theme. Colors switch directly to the new song's seeds,
+ * no crossfade. Returns [base] unchanged while disabled, while extraction
+ * is in flight, or when the art has no usable swatches.
  */
 @Composable
 fun rememberArtworkColorScheme(
@@ -49,27 +46,16 @@ fun rememberArtworkColorScheme(
             return@LaunchedEffect
         }
         // Keep the previous song's seeds while the new art loads so the
-        // scheme animates seed-to-seed rather than resetting to theme.
+        // scheme doesn't flash back to the theme colors between songs.
         extractArtworkSeeds(context, albumArtUri)?.let { seeds = it }
     }
 
     val current = seeds
     if (!enabled || current == null) return base
 
-    val primarySeed by animateColorAsState(
-        targetValue = current.primary,
-        animationSpec = tween(durationMillis = 600),
-        label = "artworkPrimarySeed"
-    )
-    val secondarySeed by animateColorAsState(
-        targetValue = current.secondary,
-        animationSpec = tween(durationMillis = 600),
-        label = "artworkSecondarySeed"
-    )
-
     val isDark = base.background.luminance() < 0.5f
-    return remember(base, primarySeed, secondarySeed, isDark) {
-        base.withArtworkAccents(primarySeed, secondarySeed, isDark)
+    return remember(base, current, isDark) {
+        base.withArtworkAccents(current.primary, current.secondary, isDark)
     }
 }
 

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/BentoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/BentoPlayerContent.kt
@@ -71,8 +71,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.media3.common.Player
-import coil.compose.AsyncImage
 import com.ivor.ivormusic.ui.components.LikeBurstIcon
+import com.ivor.ivormusic.ui.components.SongArtwork
 
 /**
  * Bento Player - the squish grid style.
@@ -107,6 +107,7 @@ fun BentoPlayerSheetContent(
 
     val currentSong by viewModel.currentSong.collectAsState()
     val isPlaying by viewModel.isPlaying.collectAsState()
+    val playerHaptics = rememberPlayerHaptics()
     val isBuffering by viewModel.isBuffering.collectAsState()
     val playWhenReady by viewModel.playWhenReady.collectAsState()
     val progress by viewModel.progress.collectAsState()
@@ -235,7 +236,10 @@ fun BentoPlayerSheetContent(
                             .clip(RoundedCornerShape(artCorner.dp))
                             .background(tileColor)
                             .pointerInput(Unit) {
-                                detectTapGestures(onTap = { viewModel.togglePlayPause() })
+                                detectTapGestures(onTap = {
+                                    playerHaptics.playPause(!viewModel.isPlaying.value)
+                                    viewModel.togglePlayPause()
+                                })
                             }
                             .styleWheelHold(styleWheel)
                     ) {
@@ -246,19 +250,16 @@ fun BentoPlayerSheetContent(
                                         lyricsResult = lyricsResult,
                                         currentPositionMs = progress,
                                         onSeekTo = { viewModel.seekTo(it) },
-                                        ambientBackground = false,
                                         primaryColor = MaterialTheme.colorScheme.primary,
                                         onSurfaceColor = onTile,
                                         onSurfaceVariantColor = onTileVariant
                                     )
                                 }
                             } else {
-                                val artModel = currentSong?.highResThumbnailUrl
-                                    ?: currentSong?.thumbnailUrl
-                                    ?: currentSong?.albumArtUri
-                                if (artModel != null) {
-                                    AsyncImage(
-                                        model = artModel,
+                                val artSong = currentSong?.takeIf { it.thumbnailUrl != null || it.albumArtUri != null }
+                                if (artSong != null) {
+                                    SongArtwork(
+                                        song = artSong,
                                         contentDescription = "Album Art",
                                         modifier = Modifier.fillMaxSize(),
                                         contentScale = ContentScale.Crop
@@ -332,7 +333,7 @@ fun BentoPlayerSheetContent(
                     ) {
                         BentoSquishTile(
                             baseWeight = 1f,
-                            onClick = { viewModel.skipToPrevious() },
+                            onClick = { playerHaptics.skip(); viewModel.skipToPrevious() },
                             color = MaterialTheme.colorScheme.secondaryContainer,
                             contentColor = MaterialTheme.colorScheme.onSecondaryContainer
                         ) {
@@ -343,7 +344,10 @@ fun BentoPlayerSheetContent(
                         }
                         BentoSquishTile(
                             baseWeight = 1.6f,
-                            onClick = { viewModel.togglePlayPause() },
+                            onClick = {
+                                playerHaptics.playPause(!viewModel.isPlaying.value)
+                                viewModel.togglePlayPause()
+                            },
                             color = MaterialTheme.colorScheme.primaryContainer,
                             contentColor = MaterialTheme.colorScheme.onPrimaryContainer
                         ) {
@@ -368,7 +372,7 @@ fun BentoPlayerSheetContent(
                         }
                         BentoSquishTile(
                             baseWeight = 1f,
-                            onClick = { viewModel.skipToNext() },
+                            onClick = { playerHaptics.skip(); viewModel.skipToNext() },
                             color = MaterialTheme.colorScheme.secondaryContainer,
                             contentColor = MaterialTheme.colorScheme.onSecondaryContainer
                         ) {

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/DialPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/DialPlayerContent.kt
@@ -66,9 +66,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.graphics.shapes.Morph
 import androidx.media3.common.Player
-import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.Song
 import com.ivor.ivormusic.ui.components.LikeBurstIcon
+import com.ivor.ivormusic.ui.components.SongArtwork
 import kotlin.math.abs
 import kotlin.math.atan2
 import kotlin.math.cos
@@ -103,6 +103,7 @@ fun DialPlayerSheetContent(
 
     val currentSong by viewModel.currentSong.collectAsState()
     val isPlaying by viewModel.isPlaying.collectAsState()
+    val playerHaptics = rememberPlayerHaptics()
     val isBuffering by viewModel.isBuffering.collectAsState()
     val playWhenReady by viewModel.playWhenReady.collectAsState()
     val progress by viewModel.progress.collectAsState()
@@ -210,7 +211,6 @@ fun DialPlayerSheetContent(
                                         lyricsResult = lyricsResult,
                                         currentPositionMs = progress,
                                         onSeekTo = { viewModel.seekTo(it) },
-                                        ambientBackground = false,
                                         primaryColor = accent,
                                         onSurfaceColor = ink,
                                         onSurfaceVariantColor = inkVariant
@@ -224,7 +224,10 @@ fun DialPlayerSheetContent(
                                     progress = progress,
                                     duration = duration,
                                     onSeekTo = { viewModel.seekTo(it) },
-                                    onPlayPause = { viewModel.togglePlayPause() }
+                                    onPlayPause = {
+                                        playerHaptics.playPause(!viewModel.isPlaying.value)
+                                        viewModel.togglePlayPause()
+                                    }
                                 )
                             }
                         }
@@ -284,7 +287,7 @@ fun DialPlayerSheetContent(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         EditorialCircleButton(
-                            onClick = { viewModel.skipToPrevious() },
+                            onClick = { playerHaptics.skip(); viewModel.skipToPrevious() },
                             accent = chipColor,
                             field = ink,
                             size = 56.dp
@@ -332,7 +335,7 @@ fun DialPlayerSheetContent(
                             Icon(Icons.Rounded.Lyrics, "Lyrics", modifier = Modifier.size(20.dp))
                         }
                         EditorialCircleButton(
-                            onClick = { viewModel.skipToNext() },
+                            onClick = { playerHaptics.skip(); viewModel.skipToNext() },
                             accent = chipColor,
                             field = ink,
                             size = 56.dp
@@ -533,12 +536,10 @@ private fun RotaryDial(
                 .styleWheelHold(styleWheel),
             contentAlignment = Alignment.Center
         ) {
-            val artModel = currentSong?.highResThumbnailUrl
-                ?: currentSong?.thumbnailUrl
-                ?: currentSong?.albumArtUri
-            if (artModel != null) {
-                AsyncImage(
-                    model = artModel,
+            val artSong = currentSong?.takeIf { it.thumbnailUrl != null || it.albumArtUri != null }
+            if (artSong != null) {
+                SongArtwork(
+                    song = artSong,
                     contentDescription = "Album Art",
                     modifier = Modifier.fillMaxSize(),
                     contentScale = ContentScale.Crop

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/EditorialPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/EditorialPlayerContent.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -68,6 +69,8 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -96,11 +99,12 @@ import androidx.graphics.shapes.Morph
 import androidx.graphics.shapes.RoundedPolygon
 import androidx.graphics.shapes.toPath
 import androidx.media3.common.Player
-import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.LyricsResult
 import com.ivor.ivormusic.data.Song
 import com.ivor.ivormusic.ui.components.LikeBurstIcon
+import com.ivor.ivormusic.ui.components.SongArtwork
 import kotlin.math.abs
+import kotlinx.coroutines.launch
 
 /**
  * Editorial Player - the two-tone magazine style.
@@ -133,6 +137,7 @@ fun EditorialPlayerSheetContent(
 
     val currentSong by viewModel.currentSong.collectAsState()
     val isPlaying by viewModel.isPlaying.collectAsState()
+    val playerHaptics = rememberPlayerHaptics()
     val isBuffering by viewModel.isBuffering.collectAsState()
     val playWhenReady by viewModel.playWhenReady.collectAsState()
     val progress by viewModel.progress.collectAsState()
@@ -186,9 +191,12 @@ fun EditorialPlayerSheetContent(
                     showLyrics = showLyrics,
                     lyricsResult = lyricsResult,
                     onToggleLyrics = { showLyrics = !showLyrics },
-                    onPlayPause = { viewModel.togglePlayPause() },
-                    onPrevious = { viewModel.skipToPrevious() },
-                    onNext = { viewModel.skipToNext() },
+                    onPlayPause = {
+                        playerHaptics.playPause(!viewModel.isPlaying.value)
+                        viewModel.togglePlayPause()
+                    },
+                    onPrevious = { playerHaptics.skip(); viewModel.skipToPrevious() },
+                    onNext = { playerHaptics.skip(); viewModel.skipToNext() },
                     onSeekTo = { viewModel.seekTo(it) },
                     onToggleShuffle = { viewModel.toggleShuffle() },
                     onToggleRepeat = { viewModel.toggleRepeat() },
@@ -297,10 +305,45 @@ private fun EditorialNowPlayingView(
         }
 
         // ========== DIE-CUT ART / LYRICS ==========
+        // Swipe-to-skip: the die-cut art follows the finger and springs
+        // back if the drag is abandoned; past the threshold it commits a
+        // previous/next skip. Inactive while lyrics are shown.
+        val scope = rememberCoroutineScope()
+        val swipeDragX = remember { Animatable(0f) }
+        val skipThresholdPx = with(LocalDensity.current) { 90.dp.toPx() }
+        val currentOnNext by rememberUpdatedState(onNext)
+        val currentOnPrevious by rememberUpdatedState(onPrevious)
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .weight(1f),
+                .weight(1f)
+                .pointerInput(showLyrics) {
+                    if (showLyrics) return@pointerInput
+                    detectHorizontalDragGestures(
+                        onHorizontalDrag = { change, dragAmount ->
+                            change.consume()
+                            scope.launch { swipeDragX.snapTo(swipeDragX.value + dragAmount) }
+                        },
+                        onDragEnd = {
+                            val dx = swipeDragX.value
+                            scope.launch {
+                                if (abs(dx) > skipThresholdPx) {
+                                    if (dx < 0) currentOnNext() else currentOnPrevious()
+                                }
+                                swipeDragX.animateTo(
+                                    0f,
+                                    spring(
+                                        dampingRatio = Spring.DampingRatioMediumBouncy,
+                                        stiffness = Spring.StiffnessLow
+                                    )
+                                )
+                            }
+                        },
+                        onDragCancel = {
+                            scope.launch { swipeDragX.animateTo(0f, spring()) }
+                        }
+                    )
+                },
             contentAlignment = Alignment.Center
         ) {
             Crossfade(targetState = showLyrics, label = "EditorialArtLyrics") { lyricsVisible ->
@@ -310,20 +353,26 @@ private fun EditorialNowPlayingView(
                             lyricsResult = lyricsResult,
                             currentPositionMs = progress,
                             onSeekTo = onSeekTo,
-                            ambientBackground = false,
                             primaryColor = accent,
                             onSurfaceColor = accent,
                             onSurfaceVariantColor = accent.copy(alpha = 0.6f)
                         )
                     }
                 } else {
-                    EditorialDieCutArt(
-                        currentSong = currentSong,
-                        isPlaying = isPlaying,
-                        onTap = onPlayPause,
-                        accent = accent,
-                        field = field
-                    )
+                    Box(
+                        modifier = Modifier.graphicsLayer {
+                            translationX = swipeDragX.value * 0.5f
+                            rotationZ = swipeDragX.value / 80f
+                        }
+                    ) {
+                        EditorialDieCutArt(
+                            currentSong = currentSong,
+                            isPlaying = isPlaying,
+                            onTap = onPlayPause,
+                            accent = accent,
+                            field = field
+                        )
+                    }
                 }
             }
         }
@@ -674,12 +723,10 @@ private fun EditorialDieCutArt(
                 .styleWheelHold(styleWheel),
             contentAlignment = Alignment.Center
         ) {
-            val artModel = currentSong?.highResThumbnailUrl
-                ?: currentSong?.thumbnailUrl
-                ?: currentSong?.albumArtUri
-            if (artModel != null) {
-                AsyncImage(
-                    model = artModel,
+            val artSong = currentSong?.takeIf { it.thumbnailUrl != null || it.albumArtUri != null }
+            if (artSong != null) {
+                SongArtwork(
+                    song = artSong,
                     contentDescription = "Album Art",
                     modifier = Modifier.fillMaxSize(),
                     contentScale = ContentScale.Crop

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/GesturePlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/GesturePlayerContent.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.zIndex
 import androidx.media3.common.Player
 import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.Song
+import com.ivor.ivormusic.ui.components.SongArtwork
 import com.ivor.ivormusic.data.LyricsResult
 import java.util.Locale
 import kotlin.math.absoluteValue
@@ -81,6 +82,7 @@ fun GesturePlayerSheetContent(
     
     val currentSong by viewModel.currentSong.collectAsState()
     val isPlaying by viewModel.isPlaying.collectAsState()
+    val playerHaptics = rememberPlayerHaptics()
     val isBuffering by viewModel.isBuffering.collectAsState()
     val progress by viewModel.progress.collectAsState()
     val duration by viewModel.duration.collectAsState()
@@ -167,8 +169,11 @@ fun GesturePlayerSheetContent(
                     onToggleDownload = { currentSong?.let { viewModel.toggleDownload(it) } },
                     sleepTimerActive = sleepTimerEndsAt != null,
                     onSleepTimerClick = { showSleepTimerDialog = true },
-                    onPlayPauseToggle = { viewModel.togglePlayPause() },
-                    onSongChange = { song -> viewModel.skipToSong(song) },
+                    onPlayPauseToggle = {
+                        playerHaptics.playPause(!viewModel.isPlaying.value)
+                        viewModel.togglePlayPause()
+                    },
+                    onSongChange = { song -> playerHaptics.skip(); viewModel.skipToSong(song) },
 
                     isDownloaded = currentSong?.let { viewModel.isDownloaded(it.id) } ?: false,
                     isDownloading = currentSong?.let { viewModel.isDownloading(it.id) } ?: false,
@@ -406,7 +411,6 @@ private fun GestureNowPlayingView(
                                         lyricsResult = lyricsResult,
                                         currentPositionMs = progress,
                                         onSeekTo = onSeekTo,
-                                        ambientBackground = ambientBackground,
                                         primaryColor = primaryColor,
                                         onSurfaceColor = onSurfaceColor,
                                         onSurfaceVariantColor = onSurfaceVariantColor
@@ -869,14 +873,16 @@ private fun SwipeableAlbumCarousel(
                     ) {
                         Box(modifier = Modifier.fillMaxSize()) {
                             // Album art with stable loading
-                            AsyncImage(
-                                model = imgUrl,
-                                contentDescription = song.title,
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .clip(RoundedCornerShape(currentCornerRadius)),
-                                contentScale = ContentScale.Crop
-                            )
+                            if (imgUrl != null) {
+                                SongArtwork(
+                                    song = song,
+                                    contentDescription = song.title,
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .clip(RoundedCornerShape(currentCornerRadius)),
+                                    contentScale = ContentScale.Crop
+                                )
+                            }
                             
                             // Fallback gradient if no image
                             if (imgUrl == null) {
@@ -980,12 +986,12 @@ private fun SingleAlbumArt(
             shadowElevation = 16.dp
         ) {
             Box(modifier = Modifier.fillMaxSize()) {
-                val imgUrl = song?.highResThumbnailUrl ?: song?.thumbnailUrl ?: song?.albumArtUri?.toString()
-                
-                if (imgUrl != null) {
-                    AsyncImage(
-                        model = imgUrl,
-                        contentDescription = song?.title ?: "Album Art",
+                val artSong = song?.takeIf { it.thumbnailUrl != null || it.albumArtUri != null }
+
+                if (artSong != null) {
+                    SongArtwork(
+                        song = artSong,
+                        contentDescription = artSong.title,
                         modifier = Modifier
                             .fillMaxSize()
                             .clip(RoundedCornerShape(cornerRadius)),
@@ -1183,8 +1189,8 @@ private fun GestureQueueView(
                                         .padding(bottom = 16.dp),
                                     contentAlignment = Alignment.Center
                                 ) {
-                                    val imgUrl = song.highResThumbnailUrl ?: song.thumbnailUrl ?: song.albumArtUri?.toString()
-                                    
+                                    val hasArt = song.thumbnailUrl != null || song.albumArtUri != null
+
                                     Surface(
                                         modifier = Modifier
                                             .size(140.dp)
@@ -1193,9 +1199,9 @@ private fun GestureQueueView(
                                         shadowElevation = 8.dp,
                                         color = MaterialTheme.colorScheme.surfaceContainerHigh
                                     ) {
-                                        if (imgUrl != null) {
-                                            AsyncImage(
-                                                model = imgUrl,
+                                        if (hasArt) {
+                                            SongArtwork(
+                                                song = song,
                                                 contentDescription = "Now Playing",
                                                 modifier = Modifier
                                                     .fillMaxSize()

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/MorphPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/MorphPlayerContent.kt
@@ -90,9 +90,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.graphics.shapes.Morph
 import androidx.media3.common.Player
-import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.Song
 import com.ivor.ivormusic.ui.components.LikeBurstIcon
+import com.ivor.ivormusic.ui.components.SongArtwork
 import kotlin.math.abs
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -125,6 +125,7 @@ fun MorphPlayerSheetContent(
 
     val currentSong by viewModel.currentSong.collectAsState()
     val isPlaying by viewModel.isPlaying.collectAsState()
+    val playerHaptics = rememberPlayerHaptics()
     val isBuffering by viewModel.isBuffering.collectAsState()
     val playWhenReady by viewModel.playWhenReady.collectAsState()
     val progress by viewModel.progress.collectAsState()
@@ -245,7 +246,6 @@ fun MorphPlayerSheetContent(
                                         lyricsResult = lyricsResult,
                                         currentPositionMs = progress,
                                         onSeekTo = { viewModel.seekTo(it) },
-                                        ambientBackground = ambientBackground,
                                         primaryColor = primaryColor,
                                         onSurfaceColor = onSurfaceColor,
                                         onSurfaceVariantColor = onSurfaceVariantColor
@@ -259,9 +259,12 @@ fun MorphPlayerSheetContent(
                                     progressFraction = if (duration > 0) {
                                         (progress.toFloat() / duration.toFloat()).coerceIn(0f, 1f)
                                     } else 0f,
-                                    onPlayPause = { viewModel.togglePlayPause() },
-                                    onNext = { viewModel.skipToNext() },
-                                    onPrevious = { viewModel.skipToPrevious() },
+                                    onPlayPause = {
+                                        playerHaptics.playPause(!viewModel.isPlaying.value)
+                                        viewModel.togglePlayPause()
+                                    },
+                                    onNext = { playerHaptics.skip(); viewModel.skipToNext() },
+                                    onPrevious = { playerHaptics.skip(); viewModel.skipToPrevious() },
                                     ringColor = primaryColor,
                                     ringTrackColor = onSurfaceVariantColor.copy(alpha = 0.2f)
                                 )
@@ -392,12 +395,12 @@ fun MorphPlayerSheetContent(
                                         Icon(Icons.Default.Shuffle, "Shuffle")
                                     }
                                     androidx.compose.material3.IconButton(
-                                        onClick = { viewModel.skipToPrevious() }
+                                        onClick = { playerHaptics.skip(); viewModel.skipToPrevious() }
                                     ) {
                                         Icon(Icons.Default.SkipPrevious, "Previous")
                                     }
                                     androidx.compose.material3.IconButton(
-                                        onClick = { viewModel.skipToNext() }
+                                        onClick = { playerHaptics.skip(); viewModel.skipToNext() }
                                     ) {
                                         Icon(Icons.Default.SkipNext, "Next")
                                     }
@@ -629,12 +632,10 @@ private fun MorphHero(
                 .styleWheelHold(styleWheel),
             contentAlignment = Alignment.Center
         ) {
-            val artModel = currentSong?.highResThumbnailUrl
-                ?: currentSong?.thumbnailUrl
-                ?: currentSong?.albumArtUri
-            if (artModel != null) {
-                AsyncImage(
-                    model = artModel,
+            val artSong = currentSong?.takeIf { it.thumbnailUrl != null || it.albumArtUri != null }
+            if (artSong != null) {
+                SongArtwork(
+                    song = artSong,
                     contentDescription = "Album Art",
                     modifier = Modifier.fillMaxSize(),
                     contentScale = ContentScale.Crop

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerHaptics.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerHaptics.kt
@@ -1,0 +1,31 @@
+package com.ivor.ivormusic.ui.player
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.hapticfeedback.HapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+
+/**
+ * Expressive haptics shared by every player style.
+ *
+ * Scope is deliberately narrow for now: previous/next skips and the
+ * play/pause toggle. Other player actions (like, shuffle, repeat, seek)
+ * stay silent until there is a decision to expand this.
+ */
+class PlayerHaptics(private val haptics: HapticFeedback) {
+
+    /** A previous/next skip committed (button tap or swipe gesture). */
+    fun skip() = haptics.performHapticFeedback(HapticFeedbackType.Confirm)
+
+    /** Play/pause toggled; [nowPlaying] is the state being switched to. */
+    fun playPause(nowPlaying: Boolean) = haptics.performHapticFeedback(
+        if (nowPlaying) HapticFeedbackType.ToggleOn else HapticFeedbackType.ToggleOff
+    )
+}
+
+@Composable
+fun rememberPlayerHaptics(): PlayerHaptics {
+    val haptics = LocalHapticFeedback.current
+    return remember(haptics) { PlayerHaptics(haptics) }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerScreen.kt
@@ -65,8 +65,8 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.sp
-import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.Song
+import com.ivor.ivormusic.ui.components.SongArtwork
 import com.ivor.ivormusic.ui.theme.IvorMusicTheme
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -77,6 +77,7 @@ fun PlayerScreen(
 ) {
     val currentSong by viewModel.currentSong.collectAsState()
     val isPlaying by viewModel.isPlaying.collectAsState()
+    val playerHaptics = rememberPlayerHaptics()
     val isBuffering by viewModel.isBuffering.collectAsState()
     val playWhenReady by viewModel.playWhenReady.collectAsState()
     val progress by viewModel.progress.collectAsState()
@@ -147,9 +148,10 @@ fun PlayerScreen(
                 color = MaterialTheme.colorScheme.surfaceVariant
             ) {
                 Box(contentAlignment = Alignment.Center) {
-                    if (currentSong?.albumArtUri != null || currentSong?.thumbnailUrl != null) {
-                        AsyncImage(
-                            model = currentSong?.highResThumbnailUrl ?: currentSong?.albumArtUri,
+                    val artSong = currentSong?.takeIf { it.albumArtUri != null || it.thumbnailUrl != null }
+                    if (artSong != null) {
+                        SongArtwork(
+                            song = artSong,
                             contentDescription = "Album Art",
                             modifier = Modifier.fillMaxSize(),
                             contentScale = ContentScale.Crop
@@ -281,7 +283,7 @@ fun PlayerScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 FilledIconButton(
-                    onClick = { viewModel.skipToPrevious() },
+                    onClick = { playerHaptics.skip(); viewModel.skipToPrevious() },
                     modifier = Modifier.size(64.dp),
                     shapes = IconButtonDefaults.shapes(),
                     colors = IconButtonDefaults.filledIconButtonColors(
@@ -292,7 +294,10 @@ fun PlayerScreen(
                 }
 
                 FilledIconButton(
-                    onClick = { viewModel.togglePlayPause() },
+                    onClick = {
+                        playerHaptics.playPause(!viewModel.isPlaying.value)
+                        viewModel.togglePlayPause()
+                    },
                     modifier = Modifier.size(96.dp),
                     shapes = IconButtonDefaults.shapes(
                         shape = RoundedCornerShape(32.dp)
@@ -321,7 +326,7 @@ fun PlayerScreen(
                 }
 
                 FilledIconButton(
-                    onClick = { viewModel.skipToNext() },
+                    onClick = { playerHaptics.skip(); viewModel.skipToNext() },
                     modifier = Modifier.size(64.dp),
                     shapes = IconButtonDefaults.shapes(),
                     colors = IconButtonDefaults.filledIconButtonColors(

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.zIndex
 import androidx.media3.common.Player
 import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.Song
+import com.ivor.ivormusic.ui.components.SongArtwork
 import com.ivor.ivormusic.data.LyricsResult
 
 /**
@@ -233,6 +234,7 @@ private fun ExpressiveNowPlayingView(
 ) {
     // State for toggling between album art and lyrics
     var showLyrics by remember { mutableStateOf(false) }
+    val playerHaptics = rememberPlayerHaptics()
     
     // Get album art URL for background
     val albumArtUrl = currentSong?.highResThumbnailUrl 
@@ -365,7 +367,6 @@ private fun ExpressiveNowPlayingView(
                         lyricsResult = lyricsResult,
                         currentPositionMs = progress,
                         onSeekTo = onSeekTo,
-                        ambientBackground = ambientBackground,
                         primaryColor = primaryColor,
                         onSurfaceColor = onSurfaceColor,
                         onSurfaceVariantColor = onSurfaceVariantColor
@@ -397,9 +398,10 @@ private fun ExpressiveNowPlayingView(
                             ) {
                                 Box(modifier = Modifier.fillMaxSize()) {
                                     // Album Art
-                                    if (currentSong?.albumArtUri != null || currentSong?.thumbnailUrl != null) {
-                                        AsyncImage(
-                                            model = currentSong?.highResThumbnailUrl ?: currentSong?.thumbnailUrl ?: currentSong?.albumArtUri,
+                                    val artSong = currentSong?.takeIf { it.albumArtUri != null || it.thumbnailUrl != null }
+                                    if (artSong != null) {
+                                        SongArtwork(
+                                            song = artSong,
                                             contentDescription = "Album Art",
                                             modifier = Modifier
                                                 .fillMaxSize()
@@ -577,7 +579,7 @@ private fun ExpressiveNowPlayingView(
                 // Previous Button - with animateWidth for squishy physics
                 val prevInteraction = remember { MutableInteractionSource() }
                 FilledTonalIconButton(
-                    onClick = { viewModel.skipToPrevious() },
+                    onClick = { playerHaptics.skip(); viewModel.skipToPrevious() },
                     shapes = stableShapes,
                     interactionSource = prevInteraction,
                     modifier = Modifier
@@ -595,7 +597,10 @@ private fun ExpressiveNowPlayingView(
                 // 🌟 Play/Pause Button (center, larger weight for emphasis)
                 val playInteraction = remember { MutableInteractionSource() }
                 FilledIconButton(
-                    onClick = { viewModel.togglePlayPause() },
+                    onClick = {
+                        playerHaptics.playPause(!viewModel.isPlaying.value)
+                        viewModel.togglePlayPause()
+                    },
                     shapes = stableShapes,
                     interactionSource = playInteraction,
                     colors = IconButtonDefaults.filledIconButtonColors(
@@ -632,7 +637,7 @@ private fun ExpressiveNowPlayingView(
                 // Next Button - with animateWidth for squishy physics
                 val nextInteraction = remember { MutableInteractionSource() }
                 FilledTonalIconButton(
-                    onClick = { viewModel.skipToNext() },
+                    onClick = { playerHaptics.skip(); viewModel.skipToNext() },
                     shapes = stableShapes,
                     interactionSource = nextInteraction,
                     modifier = Modifier
@@ -923,8 +928,8 @@ private fun ExpressiveQueueView(
                                     ) {
                                         Box(modifier = Modifier.fillMaxSize()) {
                                             if (song.albumArtUri != null || song.thumbnailUrl != null) {
-                                                AsyncImage(
-                                                    model = song.highResThumbnailUrl ?: song.thumbnailUrl ?: song.albumArtUri,
+                                                SongArtwork(
+                                                    song = song,
                                                     contentDescription = "Now Playing",
                                                     modifier = Modifier
                                                         .fillMaxSize()

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerStyleWheel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerStyleWheel.kt
@@ -26,7 +26,7 @@ import androidx.compose.material.icons.rounded.Newspaper
 import androidx.compose.material.icons.rounded.PlayCircle
 import androidx.compose.material.icons.rounded.RadioButtonChecked
 import androidx.compose.material.icons.rounded.SwipeRight
-import androidx.compose.material.icons.rounded.TextFields
+import androidx.compose.material.icons.rounded.Wallpaper
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialShapes
@@ -189,7 +189,7 @@ internal fun rememberPlayerStyleWheelEntries(): List<PlayerStyleWheelEntry> = re
         PlayerStyleWheelEntry(PlayerStyle.CLASSIC, "Classic", Icons.Rounded.PlayCircle, MaterialShapes.Circle),
         PlayerStyleWheelEntry(PlayerStyle.GESTURE, "Gesture", Icons.Rounded.SwipeRight, MaterialShapes.Pill),
         PlayerStyleWheelEntry(PlayerStyle.EDITORIAL, "Editorial", Icons.Rounded.Newspaper, MaterialShapes.Flower),
-        PlayerStyleWheelEntry(PlayerStyle.POSTER, "Poster", Icons.Rounded.TextFields, MaterialShapes.Gem),
+        PlayerStyleWheelEntry(PlayerStyle.POSTER, "Canvas", Icons.Rounded.Wallpaper, MaterialShapes.Gem),
         PlayerStyleWheelEntry(PlayerStyle.BENTO, "Bento", Icons.Rounded.GridView, MaterialShapes.Cookie4Sided),
         PlayerStyleWheelEntry(PlayerStyle.STICKER, "Sticker", Icons.Rounded.Interests, MaterialShapes.Clover4Leaf),
         PlayerStyleWheelEntry(PlayerStyle.MORPH, "Morph", Icons.Rounded.Animation, MaterialShapes.SoftBurst),

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PosterPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PosterPlayerContent.kt
@@ -1,21 +1,20 @@
 package com.ivor.ivormusic.ui.player
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.spring
-import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
@@ -32,7 +31,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.QueueMusic
@@ -43,58 +42,63 @@ import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material.icons.rounded.Lyrics
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.PlaylistAdd
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialShapes
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.graphics.shapes.Morph
 import androidx.media3.common.Player
 import com.ivor.ivormusic.ui.components.LikeBurstIcon
+import com.ivor.ivormusic.ui.components.SongArtwork
+import kotlin.math.abs
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 /**
- * Poster Player - the kinetic type style.
+ * Canvas Player - the full-bleed artwork style (replaces the old kinetic
+ * type poster; the style key stays "poster").
  *
- * The song title IS the screen: a stack of display-scale words on a flat
- * field, like a letterpress gig poster. Pure-flat contract: no gradients,
- * no shadows, no scrims.
+ * The album art IS the screen: edge-to-edge artwork with a quiet monochrome
+ * UI floating over a bottom scrim. Nothing depends on how long the song
+ * title is.
  *
  * Signature moves:
- * - Progress is a hard-edged highlighter fill sweeping through the title
- *   glyphs themselves (played characters in primary, ahead in onSurface).
- * - Play state is an oversized punctuation mark: a MaterialShapes burst
- *   that slowly spins while playing and morphs to a full stop on pause.
- * - Dragging horizontally across the words scrubs; a single seek fires on
- *   release.
- * - Controls are summoned by tapping the field and hide themselves again;
- *   the resting screen is pure typography.
- *
- * See docs/PLAYER_STYLES_PURE_EXPRESSIVE_CONCEPTS.md section 1.
+ * - The resting screen is pure artwork: while music plays the chrome slips
+ *   away after a few seconds and a tap anywhere summons it back.
+ * - Swiping the artwork horizontally skips; the art follows the finger,
+ *   springs back if abandoned, and the next cover slides in from the swipe
+ *   direction.
+ * - All controls are white-on-scrim, so they read over any cover.
  */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -126,15 +130,19 @@ fun PosterPlayerSheetContent(
     var showAddToPlaylist by remember { mutableStateOf(false) }
     var controlsVisible by remember { mutableStateOf(true) }
 
-    // Poster palette: quiet field, ink for unplayed type, primary for the
-    // sweep and every control. Roles only.
-    val field = MaterialTheme.colorScheme.surfaceContainerLowest
-    val ink = MaterialTheme.colorScheme.onSurface
-    val accent = MaterialTheme.colorScheme.primary
-    val onAccent = MaterialTheme.colorScheme.onPrimary
+    val playerHaptics = rememberPlayerHaptics()
+    val styleWheel = LocalPlayerStyleWheelController.current
 
-    // Summoned controls: any tap on the field brings them back; they slip
-    // away on their own while music plays.
+    // Swipe-to-skip: the artwork follows the finger, springs back if the
+    // drag is abandoned, and the incoming cover slides in from the swipe
+    // direction.
+    val scope = rememberCoroutineScope()
+    val swipeDragX = remember { Animatable(0f) }
+    var skipDirection by remember { mutableIntStateOf(1) }
+    val skipThresholdPx = with(LocalDensity.current) { 90.dp.toPx() }
+
+    // The chrome slips away on its own while music plays; any tap on the
+    // canvas summons it back.
     LaunchedEffect(controlsVisible, isPlaying) {
         if (controlsVisible && isPlaying) {
             delay(5000)
@@ -142,16 +150,17 @@ fun PosterPlayerSheetContent(
         }
     }
 
+    // Monochrome UI over the art: white glyphs, black scrims. Reads over
+    // any cover without fighting the artwork's own palette.
+    val glyph = Color.White
+    val scrim = Color.Black
+
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(field)
-            .clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null
-            ) { controlsVisible = true }
+            .background(MaterialTheme.colorScheme.surfaceContainerLowest)
     ) {
-        Crossfade(targetState = showQueue, label = "PosterQueueTransition") { queueVisible ->
+        Crossfade(targetState = showQueue, label = "CanvasQueueTransition") { queueVisible ->
             if (queueVisible) {
                 EditorialQueueView(
                     queue = currentQueue,
@@ -162,218 +171,400 @@ fun PosterPlayerSheetContent(
                     isLoadingMore = isLoadingMore,
                     onCollapse = onCollapse,
                     onBackToPlayer = { showQueue = false },
-                    field = field,
-                    accent = ink
+                    field = MaterialTheme.colorScheme.surfaceContainerLowest,
+                    accent = MaterialTheme.colorScheme.onSurface
                 )
             } else {
-                Column(modifier = Modifier.fillMaxSize()) {
-
-                    // ========== TOP BAR ==========
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .statusBarsPadding()
-                            .padding(horizontal = 20.dp, vertical = 12.dp),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        EditorialCircleButton(
-                            onClick = onCollapse,
-                            accent = accent,
-                            field = onAccent,
-                            size = 44.dp
-                        ) {
-                            Icon(
-                                Icons.Default.KeyboardArrowDown, "Collapse",
-                                modifier = Modifier.size(26.dp)
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null
+                        ) { controlsVisible = true }
+                        .pointerInput(showLyrics) {
+                            if (showLyrics) return@pointerInput
+                            detectHorizontalDragGestures(
+                                onHorizontalDrag = { change, dragAmount ->
+                                    change.consume()
+                                    scope.launch { swipeDragX.snapTo(swipeDragX.value + dragAmount) }
+                                },
+                                onDragEnd = {
+                                    val dx = swipeDragX.value
+                                    scope.launch {
+                                        if (abs(dx) > skipThresholdPx) {
+                                            skipDirection = if (dx < 0) 1 else -1
+                                            playerHaptics.skip()
+                                            if (dx < 0) viewModel.skipToNext()
+                                            else viewModel.skipToPrevious()
+                                        }
+                                        swipeDragX.animateTo(
+                                            0f,
+                                            spring(
+                                                dampingRatio = Spring.DampingRatioMediumBouncy,
+                                                stiffness = Spring.StiffnessLow
+                                            )
+                                        )
+                                    }
+                                },
+                                onDragCancel = {
+                                    scope.launch { swipeDragX.animateTo(0f, spring()) }
+                                }
                             )
                         }
-                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                            EditorialCircleButton(
-                                onClick = { showAddToPlaylist = true },
-                                accent = accent,
-                                field = onAccent,
-                                size = 44.dp
-                            ) {
-                                Icon(
-                                    Icons.Rounded.PlaylistAdd, "Add to Playlist",
-                                    modifier = Modifier.size(22.dp)
+                        // Last in the chain: consumes the post-long-press
+                        // hold stream before the tap and swipe detectors.
+                        .styleWheelHold(styleWheel)
+                ) {
+                    // ========== THE CANVAS: full-bleed artwork ==========
+                    AnimatedContent(
+                        targetState = currentSong,
+                        transitionSpec = {
+                            val dir = skipDirection
+                            (slideInHorizontally(
+                                animationSpec = spring(
+                                    dampingRatio = Spring.DampingRatioNoBouncy,
+                                    stiffness = Spring.StiffnessLow
                                 )
-                            }
-                            EditorialCircleButton(
-                                onClick = { showQueue = true },
-                                accent = accent,
-                                field = onAccent,
-                                size = 44.dp
+                            ) { (it / 3) * dir } + fadeIn()) togetherWith
+                                (slideOutHorizontally(
+                                    animationSpec = spring(
+                                        dampingRatio = Spring.DampingRatioNoBouncy,
+                                        stiffness = Spring.StiffnessLow
+                                    )
+                                ) { (-it / 3) * dir } + fadeOut())
+                        },
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .graphicsLayer { translationX = swipeDragX.value * 0.35f },
+                        label = "CanvasSongSwitch"
+                    ) { song ->
+                        if (song != null && (song.thumbnailUrl != null || song.albumArtUri != null)) {
+                            SongArtwork(
+                                song = song,
+                                contentDescription = "Album Art",
+                                modifier = Modifier.fillMaxSize(),
+                                contentScale = ContentScale.Crop
+                            )
+                        } else {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+                                contentAlignment = Alignment.Center
                             ) {
                                 Icon(
-                                    Icons.AutoMirrored.Filled.QueueMusic, "Queue",
-                                    modifier = Modifier.size(22.dp)
+                                    imageVector = Icons.Rounded.MusicNote,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                                    modifier = Modifier.size(120.dp)
                                 )
                             }
                         }
                     }
 
-                    // ========== THE POSTER (title stack or lyrics) ==========
+                    // Scrims fade with the chrome so the resting screen is
+                    // pure artwork.
+                    val scrimAlpha by animateFloatAsState(
+                        targetValue = if (controlsVisible || showLyrics) 1f else 0f,
+                        animationSpec = spring(stiffness = Spring.StiffnessLow),
+                        label = "CanvasScrimAlpha"
+                    )
                     Box(
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .weight(1f)
-                    ) {
-                        Crossfade(targetState = showLyrics, label = "PosterLyrics") { lyricsVisible ->
-                            if (lyricsVisible) {
-                                Box(
-                                    modifier = Modifier
-                                        .fillMaxSize()
-                                        .padding(horizontal = 24.dp)
-                                ) {
-                                    SyncedLyricsView(
-                                        lyricsResult = lyricsResult,
-                                        currentPositionMs = progress,
-                                        onSeekTo = { viewModel.seekTo(it) },
-                                        ambientBackground = false,
-                                        primaryColor = accent,
-                                        onSurfaceColor = ink,
-                                        onSurfaceVariantColor = ink.copy(alpha = 0.6f)
-                                    )
-                                }
-                            } else {
-                                PosterTitleStack(
-                                    title = currentSong?.title
-                                        ?.takeIf { !it.startsWith("Unknown") } ?: "Untitled",
-                                    progress = progress,
-                                    duration = duration,
-                                    onSeekTo = { viewModel.seekTo(it) },
-                                    ink = ink,
-                                    accent = accent
+                            .fillMaxSize()
+                            .alpha(scrimAlpha)
+                            .background(
+                                Brush.verticalGradient(
+                                    0f to scrim.copy(alpha = 0.35f),
+                                    0.25f to Color.Transparent,
+                                    0.55f to Color.Transparent,
+                                    1f to scrim.copy(alpha = 0.75f)
                                 )
-                            }
-                        }
-                    }
+                            )
+                    )
 
-                    // ========== SIGNATURE ROW: glyph + artist + times ==========
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 24.dp, vertical = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically
+                    // ========== LYRICS OVERLAY ==========
+                    AnimatedVisibility(
+                        visible = showLyrics,
+                        enter = fadeIn(),
+                        exit = fadeOut(),
+                        modifier = Modifier.fillMaxSize()
                     ) {
-                        PosterPunctuationGlyph(
-                            isPlaying = isPlaying,
-                            isBuffering = isBuffering && playWhenReady && !isPlaying,
-                            onTap = { viewModel.togglePlayPause() },
-                            accent = accent,
-                            onAccent = onAccent
-                        )
-                        Spacer(modifier = Modifier.width(16.dp))
-                        Column(modifier = Modifier.weight(1f)) {
-                            val artistName = currentSong?.artist
-                                ?.takeIf { !it.startsWith("Unknown") } ?: "Unknown Artist"
-                            Text(
-                                text = artistName.uppercase(),
-                                style = MaterialTheme.typography.labelLarge.copy(letterSpacing = 2.sp),
-                                color = ink.copy(alpha = 0.8f),
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier
-                                    .clip(RoundedCornerShape(8.dp))
-                                    .clickable(enabled = artistName != "Unknown Artist") {
-                                        onArtistClick(artistName)
-                                    }
-                                    .padding(vertical = 2.dp)
-                            )
-                            Text(
-                                text = "${formatEditorialTime(progress)} of ${formatEditorialTime(duration)}",
-                                style = MaterialTheme.typography.labelMedium,
-                                color = ink.copy(alpha = 0.55f)
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(scrim.copy(alpha = 0.6f))
+                                .padding(horizontal = 16.dp)
+                        ) {
+                            SyncedLyricsView(
+                                lyricsResult = lyricsResult,
+                                currentPositionMs = progress,
+                                onSeekTo = { viewModel.seekTo(it) },
+                                primaryColor = glyph,
+                                onSurfaceColor = glyph.copy(alpha = 0.9f),
+                                onSurfaceVariantColor = glyph.copy(alpha = 0.6f)
                             )
                         }
                     }
 
-                    // ========== SUMMONED CONTROL DECK ==========
+                    // ========== TOP BAR ==========
                     AnimatedVisibility(
                         visible = controlsVisible,
-                        enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
-                        exit = slideOutVertically(targetOffsetY = { it }) + fadeOut()
+                        enter = slideInVertically(initialOffsetY = { -it }) + fadeIn(),
+                        exit = slideOutVertically(targetOffsetY = { -it }) + fadeOut(),
+                        modifier = Modifier.align(Alignment.TopCenter)
                     ) {
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(horizontal = 24.dp)
-                                .padding(top = 8.dp, bottom = 12.dp),
-                            horizontalArrangement = Arrangement.spacedBy(
-                                10.dp,
-                                Alignment.CenterHorizontally
-                            ),
+                                .statusBarsPadding()
+                                .padding(horizontal = 20.dp, vertical = 12.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             EditorialCircleButton(
-                                onClick = { viewModel.skipToPrevious() },
-                                accent = accent,
-                                field = onAccent,
-                                size = 56.dp
+                                onClick = onCollapse,
+                                accent = scrim.copy(alpha = 0.35f),
+                                field = glyph,
+                                size = 44.dp
                             ) {
                                 Icon(
-                                    Icons.Default.SkipPrevious, "Previous",
-                                    modifier = Modifier.size(28.dp)
+                                    Icons.Default.KeyboardArrowDown, "Collapse",
+                                    modifier = Modifier.size(26.dp)
                                 )
                             }
-                            EditorialCircleButton(
-                                onClick = { viewModel.skipToNext() },
-                                accent = accent,
-                                field = onAccent,
-                                size = 56.dp
-                            ) {
-                                Icon(
-                                    Icons.Default.SkipNext, "Next",
-                                    modifier = Modifier.size(28.dp)
-                                )
-                            }
-                            EditorialChip(
-                                checked = isFavorite,
-                                onClick = { viewModel.toggleCurrentSongLike() },
-                                accent = accent,
-                                field = onAccent
-                            ) {
-                                LikeBurstIcon(isFavorite = isFavorite, iconSize = 20.dp)
-                            }
-                            EditorialChip(
-                                checked = shuffleModeEnabled,
-                                onClick = { viewModel.toggleShuffle() },
-                                accent = accent,
-                                field = onAccent
-                            ) {
-                                Icon(Icons.Default.Shuffle, "Shuffle", modifier = Modifier.size(20.dp))
-                            }
-                            EditorialChip(
-                                checked = repeatMode != Player.REPEAT_MODE_OFF,
-                                onClick = { viewModel.toggleRepeat() },
-                                accent = accent,
-                                field = onAccent
-                            ) {
-                                Icon(
-                                    if (repeatMode == Player.REPEAT_MODE_ONE) Icons.Default.RepeatOne
-                                    else Icons.Default.Repeat,
-                                    "Repeat",
-                                    modifier = Modifier.size(20.dp)
-                                )
-                            }
-                            EditorialChip(
-                                checked = showLyrics,
-                                onClick = { showLyrics = !showLyrics },
-                                accent = accent,
-                                field = onAccent
-                            ) {
-                                Icon(Icons.Rounded.Lyrics, "Lyrics", modifier = Modifier.size(20.dp))
+                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                EditorialCircleButton(
+                                    onClick = { showAddToPlaylist = true },
+                                    accent = scrim.copy(alpha = 0.35f),
+                                    field = glyph,
+                                    size = 44.dp
+                                ) {
+                                    Icon(
+                                        Icons.Rounded.PlaylistAdd, "Add to Playlist",
+                                        modifier = Modifier.size(22.dp)
+                                    )
+                                }
+                                EditorialCircleButton(
+                                    onClick = { showQueue = true },
+                                    accent = scrim.copy(alpha = 0.35f),
+                                    field = glyph,
+                                    size = 44.dp
+                                ) {
+                                    Icon(
+                                        Icons.AutoMirrored.Filled.QueueMusic, "Queue",
+                                        modifier = Modifier.size(22.dp)
+                                    )
+                                }
                             }
                         }
                     }
 
-                    Spacer(
-                        modifier = Modifier
-                            .navigationBarsPadding()
-                            .height(8.dp)
-                    )
+                    // ========== BOTTOM CLUSTER ==========
+                    AnimatedVisibility(
+                        visible = controlsVisible,
+                        enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
+                        exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
+                        modifier = Modifier.align(Alignment.BottomCenter)
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 24.dp)
+                                .navigationBarsPadding()
+                                .padding(bottom = 16.dp)
+                        ) {
+                            // Title + like/lyrics chips
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(
+                                        text = currentSong?.title
+                                            ?.takeIf { !it.startsWith("Unknown") } ?: "Untitled",
+                                        style = MaterialTheme.typography.headlineMedium.copy(
+                                            fontWeight = FontWeight.Black
+                                        ),
+                                        color = glyph,
+                                        maxLines = 2,
+                                        overflow = TextOverflow.Ellipsis
+                                    )
+                                    val artistName = currentSong?.artist
+                                        ?.takeIf { !it.startsWith("Unknown") } ?: "Unknown Artist"
+                                    Text(
+                                        text = artistName,
+                                        style = MaterialTheme.typography.titleSmall,
+                                        color = glyph.copy(alpha = 0.75f),
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                        modifier = Modifier
+                                            .clip(RoundedCornerShape(8.dp))
+                                            .clickable(enabled = artistName != "Unknown Artist") {
+                                                onArtistClick(artistName)
+                                            }
+                                            .padding(vertical = 2.dp)
+                                    )
+                                }
+                                EditorialChip(
+                                    checked = isFavorite,
+                                    onClick = { viewModel.toggleCurrentSongLike() },
+                                    accent = glyph,
+                                    field = scrim
+                                ) {
+                                    LikeBurstIcon(isFavorite = isFavorite, iconSize = 20.dp)
+                                }
+                                EditorialChip(
+                                    checked = showLyrics,
+                                    onClick = { showLyrics = !showLyrics },
+                                    accent = glyph,
+                                    field = scrim
+                                ) {
+                                    Icon(Icons.Rounded.Lyrics, "Lyrics", modifier = Modifier.size(20.dp))
+                                }
+                            }
+
+                            Spacer(modifier = Modifier.height(4.dp))
+
+                            // Seek bar + times
+                            var scrubFraction by remember { mutableStateOf<Float?>(null) }
+                            Slider(
+                                value = scrubFraction
+                                    ?: if (duration > 0) {
+                                        (progress.toFloat() / duration.toFloat()).coerceIn(0f, 1f)
+                                    } else 0f,
+                                onValueChange = { scrubFraction = it },
+                                onValueChangeFinished = {
+                                    scrubFraction?.let {
+                                        if (duration > 0) viewModel.seekTo((it * duration).toLong())
+                                    }
+                                    scrubFraction = null
+                                },
+                                colors = SliderDefaults.colors(
+                                    thumbColor = glyph,
+                                    activeTrackColor = glyph,
+                                    inactiveTrackColor = glyph.copy(alpha = 0.3f)
+                                ),
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                Text(
+                                    text = formatEditorialTime(progress),
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = glyph.copy(alpha = 0.7f)
+                                )
+                                Text(
+                                    text = formatEditorialTime(duration),
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = glyph.copy(alpha = 0.7f)
+                                )
+                            }
+
+                            Spacer(modifier = Modifier.height(8.dp))
+
+                            // Floating pill toolbar
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.Center
+                            ) {
+                                Surface(
+                                    shape = CircleShape,
+                                    color = scrim.copy(alpha = 0.45f)
+                                ) {
+                                    Row(
+                                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        EditorialChip(
+                                            checked = shuffleModeEnabled,
+                                            onClick = { viewModel.toggleShuffle() },
+                                            accent = glyph,
+                                            field = scrim
+                                        ) {
+                                            Icon(
+                                                Icons.Default.Shuffle, "Shuffle",
+                                                modifier = Modifier.size(20.dp)
+                                            )
+                                        }
+                                        EditorialCircleButton(
+                                            onClick = {
+                                                skipDirection = -1
+                                                playerHaptics.skip()
+                                                viewModel.skipToPrevious()
+                                            },
+                                            accent = Color.Transparent,
+                                            field = glyph,
+                                            size = 52.dp
+                                        ) {
+                                            Icon(
+                                                Icons.Default.SkipPrevious, "Previous",
+                                                modifier = Modifier.size(30.dp)
+                                            )
+                                        }
+                                        EditorialCircleButton(
+                                            onClick = {
+                                                playerHaptics.playPause(!viewModel.isPlaying.value)
+                                                viewModel.togglePlayPause()
+                                            },
+                                            accent = glyph,
+                                            field = scrim,
+                                            size = 64.dp
+                                        ) {
+                                            if (isBuffering && playWhenReady && !isPlaying) {
+                                                LoadingIndicator(
+                                                    modifier = Modifier.size(28.dp),
+                                                    color = scrim,
+                                                    polygons = listOf(
+                                                        MaterialShapes.SoftBurst,
+                                                        MaterialShapes.Cookie9Sided,
+                                                        MaterialShapes.Pill,
+                                                        MaterialShapes.Sunny
+                                                    )
+                                                )
+                                            } else {
+                                                Icon(
+                                                    if (isPlaying) Icons.Rounded.Pause
+                                                    else Icons.Rounded.PlayArrow,
+                                                    if (isPlaying) "Pause" else "Play",
+                                                    modifier = Modifier.size(34.dp)
+                                                )
+                                            }
+                                        }
+                                        EditorialCircleButton(
+                                            onClick = {
+                                                skipDirection = 1
+                                                playerHaptics.skip()
+                                                viewModel.skipToNext()
+                                            },
+                                            accent = Color.Transparent,
+                                            field = glyph,
+                                            size = 52.dp
+                                        ) {
+                                            Icon(
+                                                Icons.Default.SkipNext, "Next",
+                                                modifier = Modifier.size(30.dp)
+                                            )
+                                        }
+                                        EditorialChip(
+                                            checked = repeatMode != Player.REPEAT_MODE_OFF,
+                                            onClick = { viewModel.toggleRepeat() },
+                                            accent = glyph,
+                                            field = scrim
+                                        ) {
+                                            Icon(
+                                                if (repeatMode == Player.REPEAT_MODE_ONE) Icons.Default.RepeatOne
+                                                else Icons.Default.Repeat,
+                                                "Repeat",
+                                                modifier = Modifier.size(20.dp)
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -392,184 +583,5 @@ fun PosterPlayerSheetContent(
             },
             onDismissRequest = { showAddToPlaylist = false }
         )
-    }
-}
-
-/**
- * The word stack: each word of the title on its own display-scale line.
- * Playback progress sweeps a hard-edged accent fill through the glyphs,
- * character-weighted across the words. Dragging horizontally anywhere on
- * the stack scrubs; one seek fires on release.
- */
-@Composable
-private fun PosterTitleStack(
-    title: String,
-    progress: Long,
-    duration: Long,
-    onSeekTo: (Long) -> Unit,
-    ink: Color,
-    accent: Color
-) {
-    val styleWheel = LocalPlayerStyleWheelController.current
-    val allWords = remember(title) { title.trim().split(Regex("\\s+")).filter { it.isNotBlank() } }
-    val words = remember(allWords) {
-        if (allWords.size > 5) allWords.take(4) + "…" else allWords.ifEmpty { listOf("Untitled") }
-    }
-    val charTotals = remember(words) {
-        val counts = words.map { it.length.coerceAtLeast(1) }
-        val total = counts.sum().toFloat()
-        var running = 0
-        counts.map { count ->
-            val start = running / total
-            running += count
-            start to running / total
-        }
-    }
-
-    var scrubFraction by remember { mutableStateOf<Float?>(null) }
-    var stackWidthPx by remember { mutableFloatStateOf(1f) }
-    // pointerInput captures its lambda once per key; read the live values
-    // through rememberUpdatedState so a drag starts from the real position.
-    val liveProgress by rememberUpdatedState(progress)
-    val liveDuration by rememberUpdatedState(duration)
-    val playedFraction = scrubFraction
-        ?: if (duration > 0) (progress.toFloat() / duration.toFloat()).coerceIn(0f, 1f) else 0f
-
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = 24.dp)
-            .onSizeChanged { stackWidthPx = it.width.toFloat().coerceAtLeast(1f) }
-            .pointerInput(Unit) {
-                detectHorizontalDragGestures(
-                    onDragStart = {
-                        scrubFraction = if (liveDuration > 0) {
-                            (liveProgress.toFloat() / liveDuration.toFloat()).coerceIn(0f, 1f)
-                        } else 0f
-                    },
-                    onDragEnd = {
-                        scrubFraction?.let { onSeekTo((it * liveDuration).toLong()) }
-                        scrubFraction = null
-                    },
-                    onDragCancel = { scrubFraction = null },
-                    onHorizontalDrag = { change, dragAmount ->
-                        change.consume()
-                        scrubFraction = ((scrubFraction ?: 0f) + dragAmount / stackWidthPx)
-                            .coerceIn(0f, 1f)
-                    }
-                )
-            }
-            // Last in the chain: processes the pointer stream first, so the
-            // post-long-press hold-drag is consumed before the scrub
-            // detector can see it.
-            .styleWheelHold(styleWheel),
-        verticalArrangement = Arrangement.Center
-    ) {
-        val wordStyle = when {
-            words.maxOf { it.length } <= 8 -> MaterialTheme.typography.displayLarge
-            words.maxOf { it.length } <= 13 -> MaterialTheme.typography.displayMedium
-            else -> MaterialTheme.typography.displaySmall
-        }.copy(fontWeight = FontWeight.Black)
-
-        words.forEachIndexed { index, word ->
-            val (start, end) = charTotals[index]
-            val wordFraction = when {
-                playedFraction <= start -> 0f
-                playedFraction >= end -> 1f
-                else -> (playedFraction - start) / (end - start)
-            }
-            // Base ink word with a hard-clipped accent overlay: the
-            // highlighter sweep. Animate only the smoothly-progressing
-            // fraction, no crossfade.
-            val animatedWordFraction by animateFloatAsState(
-                targetValue = wordFraction,
-                animationSpec = spring(
-                    dampingRatio = Spring.DampingRatioNoBouncy,
-                    stiffness = Spring.StiffnessLow
-                ),
-                label = "PosterWordFill$index"
-            )
-            Box {
-                Text(
-                    text = word,
-                    style = wordStyle,
-                    color = ink,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-                Text(
-                    text = word,
-                    style = wordStyle,
-                    color = accent,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.drawWithContent {
-                        clipRect(right = size.width * animatedWordFraction) {
-                            this@drawWithContent.drawContent()
-                        }
-                    }
-                )
-            }
-        }
-    }
-}
-
-/**
- * The oversized punctuation mark: a burst that slowly spins while music
- * plays and morphs into a full stop when paused. Tapping it toggles
- * playback - the shape is the play/pause control and its own feedback.
- */
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
-@Composable
-private fun PosterPunctuationGlyph(
-    isPlaying: Boolean,
-    isBuffering: Boolean,
-    onTap: () -> Unit,
-    accent: Color,
-    onAccent: Color
-) {
-    val burstToDot = remember { Morph(MaterialShapes.SoftBurst, MaterialShapes.Circle) }
-    val morphProgress by animateFloatAsState(
-        targetValue = if (isPlaying) 0f else 1f,
-        animationSpec = spring(
-            dampingRatio = Spring.DampingRatioMediumBouncy,
-            stiffness = Spring.StiffnessLow
-        ),
-        label = "PosterGlyphMorph"
-    )
-    val glyphShape = remember(morphProgress) { EditorialMorphShape(burstToDot, morphProgress) }
-
-    val spin = rememberInfiniteTransition(label = "PosterGlyphSpin")
-    val spinAngle by spin.animateFloat(
-        initialValue = 0f,
-        targetValue = 360f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 12000, easing = LinearEasing),
-            repeatMode = RepeatMode.Restart
-        ),
-        label = "PosterGlyphAngle"
-    )
-
-    Box(
-        modifier = Modifier
-            .size(64.dp)
-            .graphicsLayer { rotationZ = if (isPlaying) spinAngle else 0f }
-            .clip(glyphShape)
-            .background(accent)
-            .clickable { onTap() },
-        contentAlignment = Alignment.Center
-    ) {
-        if (isBuffering) {
-            LoadingIndicator(
-                modifier = Modifier.size(28.dp),
-                color = onAccent,
-                polygons = listOf(
-                    MaterialShapes.SoftBurst,
-                    MaterialShapes.Cookie9Sided,
-                    MaterialShapes.Pill,
-                    MaterialShapes.Sunny
-                )
-            )
-        }
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/StickerPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/StickerPlayerContent.kt
@@ -79,9 +79,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.media3.common.Player
-import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.Song
 import com.ivor.ivormusic.ui.components.LikeBurstIcon
+import com.ivor.ivormusic.ui.components.SongArtwork
 import kotlin.math.abs
 import kotlinx.coroutines.launch
 
@@ -119,6 +119,7 @@ fun StickerPlayerSheetContent(
 
     val currentSong by viewModel.currentSong.collectAsState()
     val isPlaying by viewModel.isPlaying.collectAsState()
+    val playerHaptics = rememberPlayerHaptics()
     val isBuffering by viewModel.isBuffering.collectAsState()
     val playWhenReady by viewModel.playWhenReady.collectAsState()
     val progress by viewModel.progress.collectAsState()
@@ -241,7 +242,6 @@ fun StickerPlayerSheetContent(
                                         lyricsResult = lyricsResult,
                                         currentPositionMs = progress,
                                         onSeekTo = { viewModel.seekTo(it) },
-                                        ambientBackground = false,
                                         primaryColor = accent,
                                         onSurfaceColor = ink,
                                         onSurfaceVariantColor = inkVariant
@@ -252,10 +252,13 @@ fun StickerPlayerSheetContent(
                                     currentSong = currentSong,
                                     isPlaying = isPlaying,
                                     isBuffering = isBuffering && playWhenReady && !isPlaying,
-                                    onPlayPause = { viewModel.togglePlayPause() },
+                                    onPlayPause = {
+                                        playerHaptics.playPause(!viewModel.isPlaying.value)
+                                        viewModel.togglePlayPause()
+                                    },
                                     onLike = { viewModel.toggleCurrentSongLike() },
-                                    onNext = { viewModel.skipToNext() },
-                                    onPrevious = { viewModel.skipToPrevious() },
+                                    onNext = { playerHaptics.skip(); viewModel.skipToNext() },
+                                    onPrevious = { playerHaptics.skip(); viewModel.skipToPrevious() },
                                     ringColor = chipColor,
                                     placeholderColor = chipColor,
                                     placeholderIconColor = onChip
@@ -371,7 +374,7 @@ fun StickerPlayerSheetContent(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         EditorialCircleButton(
-                            onClick = { viewModel.skipToPrevious() },
+                            onClick = { playerHaptics.skip(); viewModel.skipToPrevious() },
                             accent = chipColor,
                             field = onChip,
                             size = 56.dp
@@ -382,7 +385,7 @@ fun StickerPlayerSheetContent(
                             )
                         }
                         EditorialCircleButton(
-                            onClick = { viewModel.skipToNext() },
+                            onClick = { playerHaptics.skip(); viewModel.skipToNext() },
                             accent = chipColor,
                             field = onChip,
                             size = 56.dp
@@ -658,12 +661,10 @@ private fun DraggableSticker(
                 .styleWheelHold(styleWheel),
             contentAlignment = Alignment.Center
         ) {
-            val artModel = currentSong?.highResThumbnailUrl
-                ?: currentSong?.thumbnailUrl
-                ?: currentSong?.albumArtUri
-            if (artModel != null) {
-                AsyncImage(
-                    model = artModel,
+            val artSong = currentSong?.takeIf { it.thumbnailUrl != null || it.albumArtUri != null }
+            if (artSong != null) {
+                SongArtwork(
+                    song = artSong,
                     contentDescription = "Album Art",
                     modifier = Modifier.fillMaxSize(),
                     contentScale = ContentScale.Crop

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/SyncedLyricsView.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/SyncedLyricsView.kt
@@ -4,13 +4,11 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material.icons.rounded.MusicOff
@@ -20,9 +18,13 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.text.SpanStyle
@@ -41,7 +43,9 @@ import kotlinx.coroutines.launch
  * - Highlighted current line with distinct styling
  * - Spring animations for smooth transitions
  * - Tap to seek functionality
- * - Beautiful gradient fade at top/bottom
+ * - Lines fade out toward the top/bottom edges via an alpha mask, so the
+ *   effect works over any background (flat field or ambient mist) without
+ *   painting assumed background colors on top of it
  */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -49,7 +53,6 @@ fun SyncedLyricsView(
     lyricsResult: LyricsResult,
     currentPositionMs: Long,
     onSeekTo: (Long) -> Unit,
-    ambientBackground: Boolean = false,
     modifier: Modifier = Modifier,
     primaryColor: Color = MaterialTheme.colorScheme.primary,
     onSurfaceColor: Color = MaterialTheme.colorScheme.onSurface,
@@ -74,7 +77,6 @@ fun SyncedLyricsView(
                     lines = lyricsResult.lines,
                     currentPositionMs = currentPositionMs,
                     onSeekTo = onSeekTo,
-                    ambientBackground = ambientBackground,
                     primaryColor = primaryColor,
                     onSurfaceColor = onSurfaceColor,
                     onSurfaceVariantColor = onSurfaceVariantColor
@@ -89,7 +91,6 @@ private fun LyricsContent(
     lines: List<LrcLine>,
     currentPositionMs: Long,
     onSeekTo: (Long) -> Unit,
-    ambientBackground: Boolean,
     primaryColor: Color,
     onSurfaceColor: Color,
     onSurfaceVariantColor: Color
@@ -125,7 +126,23 @@ private fun LyricsContent(
         
         LazyColumn(
             state = listState,
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                // Fade the lyrics themselves out toward the edges instead of
+                // painting background-colored scrims over whatever is behind.
+                .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
+                .drawWithContent {
+                    drawContent()
+                    drawRect(
+                        brush = Brush.verticalGradient(
+                            0f to Color.Transparent,
+                            0.18f to Color.Black,
+                            0.82f to Color.Black,
+                            1f to Color.Transparent
+                        ),
+                        blendMode = BlendMode.DstIn
+                    )
+                },
             contentPadding = PaddingValues(
                 top = centerPadding,
                 bottom = centerPadding,
@@ -146,39 +163,6 @@ private fun LyricsContent(
                     currentPositionMs = currentPositionMs
                 )
             }
-        }
-        
-        // Premium gradient fade at top and bottom
-        if (!ambientBackground) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(centerPadding * 0.6f)
-                    .align(Alignment.TopCenter)
-                    .background(
-                        Brush.verticalGradient(
-                            colors = listOf(
-                                MaterialTheme.colorScheme.background,
-                                MaterialTheme.colorScheme.background.copy(alpha = 0f)
-                            )
-                        )
-                    )
-            )
-            
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(centerPadding * 0.6f)
-                    .align(Alignment.BottomCenter)
-                    .background(
-                        Brush.verticalGradient(
-                            colors = listOf(
-                                MaterialTheme.colorScheme.background.copy(alpha = 0f),
-                                MaterialTheme.colorScheme.background
-                            )
-                        )
-                    )
-            )
         }
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
@@ -71,7 +71,7 @@ import androidx.compose.material.icons.rounded.Security
 import androidx.compose.material.icons.rounded.FlashOn
 import androidx.compose.material.icons.rounded.HighQuality
 import androidx.compose.material.icons.rounded.SwipeRight
-import androidx.compose.material.icons.rounded.TextFields
+import androidx.compose.material.icons.rounded.Wallpaper
 import androidx.compose.material.icons.rounded.ThumbDown
 import androidx.compose.material.icons.rounded.ThumbUp
 import androidx.compose.material.icons.rounded.ToggleOn
@@ -1876,7 +1876,7 @@ private val playerStyleOptions = listOf(
     PlayerStyleOption(PlayerStyle.CLASSIC, "Classic", "Button controls for playback", Icons.Rounded.PlayCircle),
     PlayerStyleOption(PlayerStyle.GESTURE, "Gesture", "Swipe album art to navigate", Icons.Rounded.SwipeRight),
     PlayerStyleOption(PlayerStyle.EDITORIAL, "Editorial", "Two-tone magazine layout", Icons.Rounded.Newspaper),
-    PlayerStyleOption(PlayerStyle.POSTER, "Poster", "Kinetic type, title as progress", Icons.Rounded.TextFields),
+    PlayerStyleOption(PlayerStyle.POSTER, "Canvas", "Full-bleed album art", Icons.Rounded.Wallpaper),
     PlayerStyleOption(PlayerStyle.BENTO, "Bento", "Squishy grid of flat tiles", Icons.Rounded.GridView),
     PlayerStyleOption(PlayerStyle.STICKER, "Sticker", "Die-cut art with toy physics", Icons.Rounded.Interests),
     PlayerStyleOption(PlayerStyle.MORPH, "Morph", "Living shape that breathes", Icons.Rounded.Animation),


### PR DESCRIPTION
## Now Playing artwork is sharp, instantly

- New `SongArtwork` composable layers the high-res cover over the low-res thumbnail: the small thumbnail (already in Coil's memory cache from the lists) renders immediately, and the 1080px version crossfades in on top once it actually loads. If the high-res URL 404s (common for `maxresdefault.jpg`), the low-res just stays - no more blank or blurry frames on the expanded player.
- Fixed a URL-corruption bug in `Song.highResThumbnailUrl`: the `s<digits>` size rewrite ran over the whole googleusercontent URL and could mangle the opaque image token, producing a permanent 404 so the high-quality cover never loaded. Size directives are now only rewritten after the `=` separator.
- All nine player surfaces (every style + queue headers) use `SongArtwork` for their main artwork.

## Lyrics view

- Removed the top/bottom gradient bands. They painted `colorScheme.background` over whatever was behind, which produced dark smears over the ambient mist backdrop. The lyrics text itself now fades out toward the edges with an alpha mask (`BlendMode.DstIn`), which works over any background. The now-meaningless `ambientBackground` flag is gone from `SyncedLyricsView` and its 8 callers.

## Poster style is now Canvas

Complete rewrite of `PosterPlayerContent.kt` (style key stays `POSTER`, so saved settings carry over):

- Full-bleed album art fills the screen; UI is monochrome white over a bottom scrim so it reads on any cover.
- Chrome auto-hides after 5s while playing - the resting screen is pure artwork; tap to summon it back.
- Swipe anywhere to skip: the art follows the finger, springs back if abandoned, and the next cover slides in from the swipe direction.
- Title/artist with like + lyrics chips, a seek slider with elapsed/total times, and a floating pill toolbar (shuffle / prev / play / next / repeat). Lyrics open as an overlay on the dimmed art.
- Picker and style wheel labels updated to "Canvas" with a wallpaper icon.

## Swipe-to-skip in Editorial

Editorial had no swipe gesture at all (buttons only). The die-cut art now follows the finger with a slight tilt, springs back on abandoned drags, and commits previous/next past a 90dp threshold. Disabled while lyrics are open so scrolling lyrics can't change tracks.

## Expressive haptics on transport controls

New shared `PlayerHaptics` helper wired into every player style: `Confirm` on previous/next (buttons and swipe commits alike), `ToggleOn`/`ToggleOff` on play/pause. Deliberately scoped to those three actions - like, shuffle, repeat and seek stay silent.

## Player palette changes are instant again

Removed the 600ms color tween in `rememberArtworkColorScheme`; the accent roles now snap directly to the new song's extracted palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H43LrvL6ULGwR9pSQKAAnN