### PR TITLE
Polish overlay layout, exclusive playback, miniplayer shape and rotation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,8 +32,10 @@
             android:exported="true"
             android:label="@string/app_name"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|smallestScreenSize"
+            android:screenOrientation="portrait"
             android:supportsPictureInPicture="true"
-            android:theme="@style/Theme.App.Starting">
+            android:theme="@style/Theme.App.Starting"
+            tools:ignore="LockedOrientationActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -41,9 +41,15 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
-        
+
         // Remove splash instantly when ready — the AVD entrance animation is the show
         splashScreen.setOnExitAnimationListener { it.remove() }
+
+        // The app is portrait-only, like YouTube: rotating the device must not
+        // rotate the app UI. The only exception is fullscreen video playback,
+        // which temporarily requests landscape from VideoPlayerContent and
+        // restores portrait when it exits.
+        requestedOrientation = android.content.pm.ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
 
         enableEdgeToEdge()
 
@@ -224,6 +230,40 @@ fun MusicApp(
         }
     }
 
+    // Music, video and Shorts are mutually exclusive: whichever pipeline
+    // starts playing pauses the other two. System audio focus alone is not
+    // reliable between players inside the same app, so this is enforced
+    // explicitly. Each effect only fires on a transition to playing, so
+    // pausing one player never re-triggers the others.
+    val isMusicPlaying by playerViewModel.isPlaying.collectAsState()
+    val isVideoPlaying by videoPlayerViewModel.isPlaying.collectAsState()
+    val isShortsPlaying by shortsPlayerViewModel.isPlaying.collectAsState()
+    androidx.compose.runtime.LaunchedEffect(isMusicPlaying) {
+        if (isMusicPlaying) {
+            videoPlayerViewModel.pause()
+            shortsPlayerViewModel.pause()
+        }
+    }
+    androidx.compose.runtime.LaunchedEffect(isVideoPlaying) {
+        if (isVideoPlaying) {
+            playerViewModel.pause()
+            shortsPlayerViewModel.pause()
+        }
+    }
+    androidx.compose.runtime.LaunchedEffect(isShortsPlaying) {
+        if (isShortsPlaying) {
+            playerViewModel.pause()
+            videoPlayerViewModel.pause()
+        }
+    }
+
+    // Video overlay state, needed by HomeScreen so bottom-anchored UI (FABs)
+    // and the music mini player can stay clear of the video mini player.
+    val overlayVideo by videoPlayerViewModel.currentVideo.collectAsState()
+    val isVideoOverlayExpanded by videoPlayerViewModel.isExpanded.collectAsState()
+    val hasVideoMiniPlayer = overlayVideo != null && !isVideoOverlayExpanded
+    val musicPillVisible = playerViewModel.currentSong.collectAsState().value != null
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -295,7 +335,8 @@ fun MusicApp(
                     showModeToggle = homeModeToggleEnabled,
                     playerStyle = playerStyle,
                     onPlayerStyleChange = onPlayerStyleChange,
-                    manualScan = manualScanEnabled
+                    manualScan = manualScanEnabled,
+                    hasVideoMiniPlayer = hasVideoMiniPlayer
                 )
             }
             composable(
@@ -454,7 +495,10 @@ fun MusicApp(
         
         com.ivor.ivormusic.ui.video.VideoPlayerOverlay(
             viewModel = videoPlayerViewModel,
-            timedCommentsEnabled = timedCommentsEnabled
+            timedCommentsEnabled = timedCommentsEnabled,
+            // Stack the minimized video player above the music pill instead of
+            // on top of it when both are alive at once
+            miniPlayerExtraBottomPadding = if (musicPillVisible) 88.dp else 0.dp
         )
 
         // Shorts sit above everything, including the video player overlay

--- a/app/src/main/java/com/ivor/ivormusic/ui/components/BottomOverlayInset.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/components/BottomOverlayInset.kt
@@ -1,0 +1,17 @@
+package com.ivor.ivormusic.ui.components
+
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Clearance, measured from the top of the navigation bar inset, that
+ * bottom-anchored UI (FABs, split buttons) needs to stay clear of the
+ * floating overlays HomeScreen stacks above every tab: the pill nav bar,
+ * plus the music and/or video mini players when something is loaded.
+ *
+ * Provided (animated) by HomeScreen so deep screens like the playlist detail
+ * page don't need the player state threaded through every call site. Screens
+ * hosted outside HomeScreen fall back to 0.
+ */
+val LocalBottomOverlayInset = compositionLocalOf { 0.dp }

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeScreen.kt
@@ -47,6 +47,8 @@ import androidx.compose.material.icons.rounded.SystemUpdate
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.BottomSheetDefaults
@@ -155,7 +157,8 @@ fun HomeScreen(
     showModeToggle: Boolean = true,
     playerStyle: PlayerStyle = PlayerStyle.CLASSIC,
     onPlayerStyleChange: (PlayerStyle) -> Unit = {},
-    manualScan: Boolean = false
+    manualScan: Boolean = false,
+    hasVideoMiniPlayer: Boolean = false
 ) {
     val context = androidx.compose.ui.platform.LocalContext.current
     val localSongs by viewModel.songs.collectAsState()
@@ -276,7 +279,30 @@ fun HomeScreen(
         }
     }
 
+    // How much clearance bottom-anchored UI needs above the nav bar inset to
+    // stay clear of the floating overlays: the nav pill always, the music
+    // pill (top edge at 180dp) and/or the video mini player (top edge at
+    // 188dp, stacked to 284dp when the music pill is also alive). Animated so
+    // FABs glide instead of jumping when a mini player appears.
+    val musicPillVisible = currentSong != null
+    val bottomOverlayInset by androidx.compose.animation.core.animateDpAsState(
+        targetValue = when {
+            musicPillVisible && hasVideoMiniPlayer -> 284.dp
+            hasVideoMiniPlayer -> 196.dp
+            musicPillVisible -> 188.dp
+            else -> 88.dp
+        },
+        animationSpec = MaterialTheme.motionScheme.defaultSpatialSpec(),
+        label = "bottomOverlayInset"
+    )
+    val navBarInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    // Scroll clearance for the tab lists (they don't apply insets themselves)
+    val listBottomPadding = PaddingValues(bottom = bottomOverlayInset + navBarInset + 16.dp)
+
     // Use Box overlay instead of Scaffold for truly floating navbar
+    androidx.compose.runtime.CompositionLocalProvider(
+        com.ivor.ivormusic.ui.components.LocalBottomOverlayInset provides bottomOverlayInset
+    ) {
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -343,7 +369,7 @@ fun HomeScreen(
                                     onDownloadsClick = onNavigateToDownloads,
                                     onRefresh = { viewModel.refreshVideos() },
                                     isDarkMode = isDarkMode,
-                                    contentPadding = PaddingValues(bottom = 160.dp),
+                                    contentPadding = listBottomPadding,
                                     viewModel = viewModel,
                                     videoMode = videoMode,
                                     onVideoModeToggle = onVideoModeToggle,
@@ -376,7 +402,7 @@ fun HomeScreen(
                                     onSettingsClick = onNavigateToSettings,
                                     onDownloadsClick = onNavigateToDownloads,
                                     isDarkMode = isDarkMode,
-                                    contentPadding = PaddingValues(bottom = 160.dp), // Space for navbar + miniplayer
+                                    contentPadding = listBottomPadding,
                                     viewModel = viewModel,
                                     excludedFolders = excludedFolders,
                                     manualScan = manualScan,
@@ -404,7 +430,7 @@ fun HomeScreen(
                             // Navigate to video player screen
                             onNavigateToVideoPlayer(video)
                         },
-                        contentPadding = PaddingValues(bottom = 160.dp),
+                        contentPadding = listBottomPadding,
                         viewModel = viewModel,
                         isDarkMode = isDarkMode,
                         videoMode = videoMode
@@ -417,7 +443,7 @@ fun HomeScreen(
                                     onNavigateToVideoPlayer(video)
                                 },
                                 onLoginClick = { showAuthDialog = true },
-                                contentPadding = PaddingValues(bottom = 160.dp)
+                                contentPadding = listBottomPadding
                             )
                         } else {
                             LibraryContent(
@@ -436,7 +462,7 @@ fun HomeScreen(
                                     playerViewModel.playQueue(songs, selectedSong)
                                     showPlayerSheet = true
                                 },
-                                contentPadding = PaddingValues(bottom = 160.dp),
+                                contentPadding = listBottomPadding,
                                 viewModel = viewModel,
                                 isDarkMode = isDarkMode,
                                 initialArtist = viewedArtistFromPlayer,
@@ -455,7 +481,7 @@ fun HomeScreen(
                                     onNavigateToVideoPlayer(video)
                                 },
                                 onLoginClick = { showAuthDialog = true },
-                                contentPadding = PaddingValues(bottom = 160.dp)
+                                contentPadding = listBottomPadding
                             )
                         }
                     }
@@ -644,7 +670,8 @@ fun HomeScreen(
             }
         }
     }
-    
+    }
+
     // Auth Dialog
     if (showAuthDialog) {
         com.ivor.ivormusic.ui.auth.YouTubeAuthDialog(

--- a/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
@@ -1039,13 +1039,14 @@ fun ExpressivePlaylistCard(
         label = "playlistCardScale"
     )
 
+    // No clip on the column: the artwork Surface rounds itself, and clipping
+    // here used to shave the corners off the title/subtitle text below it
     Column(
         modifier = Modifier
             .graphicsLayer {
                 scaleX = pressScale
                 scaleY = pressScale
             }
-            .clip(RoundedCornerShape(24.dp))
             .clickable(interactionSource = interactionSource, indication = null) { onClick() }
     ) {
         Box(

--- a/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
@@ -3,18 +3,22 @@ package com.ivor.ivormusic.ui.library
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.*
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
@@ -759,27 +763,46 @@ fun PlaylistsGrid(
     contentPadding: PaddingValues
 ) {
     LazyVerticalGrid(
-        columns = GridCells.Adaptive(minSize = 160.dp),
+        columns = GridCells.Fixed(2),
         contentPadding = PaddingValues(
             top = 8.dp,
             bottom = contentPadding.calculateBottomPadding() + 80.dp,
             start = 16.dp,
             end = 16.dp
         ),
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp),
         modifier = Modifier.fillMaxSize()
     ) {
-        item {
-            // Liked songs as a square card in grid
-            ExpressivePlaylistCard(
-                name = "Liked Songs",
+        // Liked songs as a full-width hero banner, same card the Songs tab
+        // uses, instead of an odd square tile among the playlists
+        item(key = "liked_hero", span = { GridItemSpan(maxLineSpan) }) {
+            ExpressiveLikedSongsCard(
                 count = likedSongs.size,
-                thumbnailUrl = null,
-                isLiked = true,
                 onClick = onLikedSongsClick
             )
         }
+
+        if (playlists.isNotEmpty()) {
+            item(key = "playlists_header", span = { GridItemSpan(maxLineSpan) }) {
+                Text(
+                    text = "Your playlists • ${playlists.size}",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+            }
+        } else {
+            item(key = "playlists_empty", span = { GridItemSpan(maxLineSpan) }) {
+                EmptyLibraryState(
+                    icon = Icons.AutoMirrored.Rounded.PlaylistAdd,
+                    title = "No playlists yet",
+                    subtitle = "Create one with the + button below"
+                )
+            }
+        }
+
         items(playlists) { playlist ->
             val isLocalPlaylist = localPlaylistIds.contains(playlist.id)
             // YouTube playlists are editable through InnerTube; the synthesized
@@ -922,25 +945,47 @@ fun AlbumsGrid(
 
 // ============ UI COMPONENTS ============
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ExpressiveLikedSongsCard(count: Int, onClick: () -> Unit) {
+    // Flat expressive hero: gradient wash, heart seated in a SoftBurst
+    // material shape, press-scale spring instead of a shadow
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val pressScale by animateFloatAsState(
+        targetValue = if (isPressed) 0.97f else 1f,
+        animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+        label = "likedCardScale"
+    )
     Surface(
         onClick = onClick,
+        interactionSource = interactionSource,
         shape = RoundedCornerShape(28.dp),
         modifier = Modifier
             .fillMaxWidth()
-            .height(120.dp),
-        color = MaterialTheme.colorScheme.primaryContainer,
-        shadowElevation = 8.dp
+            .height(120.dp)
+            .graphicsLayer {
+                scaleX = pressScale
+                scaleY = pressScale
+            },
+        color = Color.Transparent
     ) {
         Row(
             modifier = Modifier
                 .fillMaxSize()
+                .background(
+                    Brush.horizontalGradient(
+                        colors = listOf(
+                            MaterialTheme.colorScheme.primaryContainer,
+                            MaterialTheme.colorScheme.tertiaryContainer
+                        )
+                    )
+                )
                 .padding(24.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Surface(
-                shape = CircleShape,
+                shape = MaterialShapes.SoftBurst.toShape(),
                 color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.size(56.dp)
             ) {
@@ -949,14 +994,24 @@ fun ExpressiveLikedSongsCard(count: Int, onClick: () -> Unit) {
                 }
             }
             Spacer(Modifier.width(24.dp))
-            Column {
+            Column(modifier = Modifier.weight(1f)) {
                 Text("Liked Songs", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onPrimaryContainer)
-                Text("$count tracks • Auto-playlist", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f))
+                Text(
+                    if (count == 1) "1 track • Auto-playlist" else "$count tracks • Auto-playlist",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                )
             }
+            Icon(
+                Icons.Rounded.ChevronRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimaryContainer
+            )
         }
     }
 }
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ExpressivePlaylistCard(
     name: String,
@@ -974,36 +1029,103 @@ fun ExpressivePlaylistCard(
     var showEditDialog by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf(false) }
 
-    Column(modifier = Modifier.clickable { onClick() }) {
-        Surface(
-            shape = RoundedCornerShape(20.dp),
+    // Flat expressive tile: no shadow — depth comes from tonal layering and
+    // a press-scale spring, matching the settings rows and the liked hero
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val pressScale by animateFloatAsState(
+        targetValue = if (isPressed) 0.95f else 1f,
+        animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+        label = "playlistCardScale"
+    )
+
+    Column(
+        modifier = Modifier
+            .graphicsLayer {
+                scaleX = pressScale
+                scaleY = pressScale
+            }
+            .clip(RoundedCornerShape(24.dp))
+            .clickable(interactionSource = interactionSource, indication = null) { onClick() }
+    ) {
+        Box(
             modifier = Modifier
                 .aspectRatio(1f)
-                .fillMaxWidth(),
-            color = if (isLiked) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surfaceContainerHigh,
-            shadowElevation = 4.dp
+                .fillMaxWidth()
         ) {
-            if (thumbnailUrl != null && thumbnailUrl != "null") {
-                AsyncImage(model = thumbnailUrl, contentDescription = null, contentScale = ContentScale.Crop)
-            } else {
-                Box(contentAlignment = Alignment.Center) {
-                    Icon(
-                        if (isLiked) Icons.Rounded.Favorite else Icons.AutoMirrored.Rounded.PlaylistPlay,
-                        null,
-                        modifier = Modifier.size(48.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+            Surface(
+                shape = RoundedCornerShape(24.dp),
+                modifier = Modifier.fillMaxSize(),
+                color = if (isLiked) MaterialTheme.colorScheme.secondaryContainer
+                    else MaterialTheme.colorScheme.surfaceContainerHigh
+            ) {
+                if (thumbnailUrl != null && thumbnailUrl != "null") {
+                    AsyncImage(model = thumbnailUrl, contentDescription = null, contentScale = ContentScale.Crop)
+                } else {
+                    // Placeholder art: icon seated in a morphing material shape
+                    Box(contentAlignment = Alignment.Center) {
+                        Surface(
+                            shape = MaterialShapes.Cookie9Sided.toShape(),
+                            color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                            modifier = Modifier.size(72.dp)
+                        ) {
+                            Box(contentAlignment = Alignment.Center) {
+                                Icon(
+                                    if (isLiked) Icons.Rounded.Favorite else Icons.AutoMirrored.Rounded.PlaylistPlay,
+                                    null,
+                                    modifier = Modifier.size(32.dp),
+                                    tint = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+            // Track-count chip floating on the artwork
+            if (count > 0) {
+                Surface(
+                    color = Color.Black.copy(alpha = 0.65f),
+                    shape = RoundedCornerShape(50),
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(10.dp)
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Rounded.PlaylistPlay,
+                            contentDescription = null,
+                            modifier = Modifier.size(14.dp),
+                            tint = Color.White
+                        )
+                        Text(
+                            text = "$count",
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Bold,
+                            color = Color.White
+                        )
+                    }
                 }
             }
         }
-        Spacer(Modifier.height(12.dp))
+        Spacer(Modifier.height(10.dp))
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 4.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Column(modifier = Modifier.weight(1f)) {
                 Text(name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onBackground, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                Text(subtitle ?: "$count songs", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1)
+                Text(
+                    subtitle ?: if (count == 1) "1 song" else "$count songs",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1
+                )
             }
             if (isEditable) {
                 Box {

--- a/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
@@ -432,12 +432,17 @@ fun LibraryMainScreen(
     }
 
     // --- M3E FAB menu: quick library actions ---
+    // Lifted above the floating nav pill and the mini player(s) via the
+    // overlay inset HomeScreen provides, so the button is never covered.
     FloatingActionButtonMenu(
         expanded = fabMenuExpanded,
         modifier = Modifier
             .align(Alignment.BottomEnd)
             .navigationBarsPadding()
-            .padding(end = 4.dp, bottom = 8.dp),
+            .padding(
+                end = 4.dp,
+                bottom = com.ivor.ivormusic.ui.components.LocalBottomOverlayInset.current + 8.dp
+            ),
         button = {
             ToggleFloatingActionButton(
                 checked = fabMenuExpanded,
@@ -1470,14 +1475,22 @@ fun PlaylistDetailScreen(
                                 }
                             }
                         }
-                    } else null
+                    } else null,
+                    // Clear the floating nav pill and mini player(s)
+                    modifier = Modifier.padding(
+                        bottom = com.ivor.ivormusic.ui.components.LocalBottomOverlayInset.current
+                    )
                 )
             }
         }
     ) { padding ->
         LazyColumn(
             state = listState,
-            contentPadding = PaddingValues(bottom = 100.dp),
+            // Enough scroll clearance for the floating overlays plus the FAB
+            contentPadding = PaddingValues(
+                bottom = com.ivor.ivormusic.ui.components.LocalBottomOverlayInset.current +
+                    WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + 88.dp
+            ),
             modifier = Modifier
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.background)

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/ExpandablePlayer.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/ExpandablePlayer.kt
@@ -93,19 +93,26 @@ fun ExpandablePlayer(
     val collapsedHeight = 80.dp
     val collapsedWidthPadding = 16.dp
     val collapsedBottomPadding = 100.dp + bottomInset
-    val collapsedCornerRadius = 50.dp
-    
+    // Exactly half the collapsed height: a radius larger than that (the old
+    // 50.dp) is illegal for the shape and rendered visibly distorted corners.
+    // It also now matches MiniPlayerContent's inner 50% pill, so the ripple
+    // and the container clip along the same outline.
+    val collapsedCornerRadius = collapsedHeight / 2
+
     val expandedHeight = screenHeight
     val expandedWidthPadding = 0.dp
     val expandedBottomPadding = 0.dp
     val expandedCornerRadius = 0.dp
-    
+
     // Interpolated values based on progress
     val height = lerp(collapsedHeight, expandedHeight, expandProgress)
     val widthPadding = lerp(collapsedWidthPadding, expandedWidthPadding, expandProgress)
     val bottomPadding = lerp(collapsedBottomPadding, expandedBottomPadding, expandProgress)
     val cornerRadius = lerp(collapsedCornerRadius, expandedCornerRadius, expandProgress)
-    
+        .coerceAtMost(height / 2)
+    // Soft floating-pill depth while collapsed, gone once fullscreen
+    val pillShadowElevation = lerp(8.dp, 0.dp, expandProgress)
+
     // Color interpolation - collapsed shows surface, expanded shows transparent
     val containerColor = MaterialTheme.colorScheme.surfaceContainerHigh.copy(
         alpha = 1f - expandProgress
@@ -213,8 +220,8 @@ fun ExpandablePlayer(
                 }
                 .clickable(enabled = !isExpanded) { onExpandChange(true) },
             shape = RoundedCornerShape(cornerRadius.coerceAtLeast(0.dp)),
-            color = containerColor
-            // No shadow/elevation for cleaner look
+            color = containerColor,
+            shadowElevation = pillShadowElevation.coerceAtLeast(0.dp)
         ) {
             // Both layers are positioned in a Box sized to the current (animating)
             // Surface height, which the Surface shape clips. The expanded content

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
@@ -715,6 +715,15 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
         }
     }
 
+    /**
+     * Pause music playback without touching the queue. Also cancels a pending
+     * playWhenReady while a track is still buffering, so a song that finishes
+     * resolving after a video started does not begin playing over it.
+     */
+    fun pause() {
+        controller?.pause()
+    }
+
     fun toggleShuffle() {
         controller?.let {
             it.shuffleModeEnabled = !it.shuffleModeEnabled

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/ChannelSheet.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/ChannelSheet.kt
@@ -1,0 +1,245 @@
+package com.ivor.ivormusic.ui.video
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.VideoLibrary
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ContainedLoadingIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.ivor.ivormusic.data.VideoItem
+
+/**
+ * Channel page opened from the channel row in the video player: avatar,
+ * name, subscriber count and a Subscribe button on top, latest uploads
+ * below. Tapping an upload plays it (the caller dismisses the sheet).
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun ChannelSheet(
+    channelName: String,
+    channelIconUrl: String?,
+    subscriberCountText: String?,
+    isSubscribed: Boolean,
+    canSubscribe: Boolean,
+    videos: List<VideoItem>,
+    isLoading: Boolean,
+    onSubscribeClick: () -> Unit,
+    onVideoClick: (VideoItem) -> Unit,
+    onDismiss: () -> Unit
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        contentColor = MaterialTheme.colorScheme.onSurface
+    ) {
+        LazyColumn(
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(bottom = 32.dp)
+        ) {
+            item(key = "channel_header") {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp)
+                        .padding(bottom = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    if (!channelIconUrl.isNullOrBlank()) {
+                        AsyncImage(
+                            model = channelIconUrl,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .size(64.dp)
+                                .clip(CircleShape),
+                            contentScale = ContentScale.Crop
+                        )
+                    } else {
+                        Box(
+                            modifier = Modifier
+                                .size(64.dp)
+                                .clip(CircleShape)
+                                .background(MaterialTheme.colorScheme.primaryContainer),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = channelName.take(1).uppercase(),
+                                style = MaterialTheme.typography.headlineSmall,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                    }
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = channelName,
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.Bold,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        if (!subscriberCountText.isNullOrBlank()) {
+                            Text(
+                                text = subscriberCountText,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                    Button(
+                        onClick = onSubscribeClick,
+                        enabled = canSubscribe,
+                        colors = if (isSubscribed) {
+                            ButtonDefaults.filledTonalButtonColors()
+                        } else {
+                            ButtonDefaults.buttonColors()
+                        }
+                    ) {
+                        Text(if (isSubscribed) "Subscribed" else "Subscribe")
+                    }
+                }
+            }
+
+            item(key = "uploads_header") {
+                Text(
+                    text = "Latest videos",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
+                )
+            }
+
+            if (isLoading && videos.isEmpty()) {
+                item(key = "loading") {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 40.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        ContainedLoadingIndicator()
+                    }
+                }
+            } else if (videos.isEmpty()) {
+                item(key = "empty") {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 32.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Icon(
+                            Icons.Rounded.VideoLibrary,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Text(
+                            text = "Couldn't load this channel's videos",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            } else {
+                items(videos) { video ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onVideoClick(video) }
+                            .padding(horizontal = 24.dp, vertical = 8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .width(140.dp)
+                                .aspectRatio(16f / 9f)
+                                .clip(RoundedCornerShape(12.dp))
+                                .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                        ) {
+                            if (video.thumbnailUrl != null) {
+                                AsyncImage(
+                                    model = video.thumbnailUrl,
+                                    contentDescription = null,
+                                    modifier = Modifier.matchParentSize(),
+                                    contentScale = ContentScale.Crop
+                                )
+                            }
+                            if (video.duration > 0) {
+                                Surface(
+                                    color = Color.Black.copy(alpha = 0.7f),
+                                    shape = RoundedCornerShape(4.dp),
+                                    modifier = Modifier
+                                        .align(Alignment.BottomEnd)
+                                        .padding(4.dp)
+                                ) {
+                                    Text(
+                                        text = video.formattedDuration,
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = Color.White,
+                                        modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp)
+                                    )
+                                }
+                            }
+                        }
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.Center
+                        ) {
+                            Text(
+                                text = video.title,
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            Spacer(Modifier.height(4.dp))
+                            Text(
+                                text = listOfNotNull(
+                                    video.viewCount.takeIf { it.isNotBlank() },
+                                    video.uploadedDate?.takeIf { it.isNotBlank() }
+                                ).joinToString(" • "),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/CommentsSheet.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/CommentsSheet.kt
@@ -83,8 +83,9 @@ fun CommentsSheet(
     onDeleteComment: (CommentItem) -> Unit,
     onDismiss: () -> Unit
 ) {
-    // Opens fully expanded
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    // Opens half-expanded like a standard sheet; drag up for the full list
+    // and the comment box
+    val sheetState = rememberModalBottomSheetState()
     val listState = rememberLazyListState()
 
     // Trigger pagination when the user nears the end of the list

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
@@ -146,7 +146,10 @@ fun VideoPlayerContent(
         }
     }
     
-    // Fullscreen / Immersive
+    // Fullscreen / Immersive. The app is portrait-locked (MainActivity), so
+    // fullscreen temporarily requests sensor landscape and every exit path
+    // restores PORTRAIT — never UNSPECIFIED, which used to leave the whole
+    // app free-rotating in broken half-landscape states.
     DisposableEffect(isFullscreen) {
         val window = activity?.window
         val insetsController = window?.let { WindowCompat.getInsetsController(it, it.decorView) }
@@ -163,24 +166,64 @@ fun VideoPlayerContent(
             // Draw into the camera cutout area too, otherwise the system
             // letterboxes the window and background shows around the notch
             setCutoutMode(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES)
-            activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+            // Sensor landscape: both landscape directions work, like YouTube
+            activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
             insetsController?.apply {
                 hide(WindowInsetsCompat.Type.systemBars())
                 systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
             }
         } else {
-            activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+            activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
             insetsController?.show(WindowInsetsCompat.Type.systemBars())
             setCutoutMode(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT)
         }
 
         onDispose {
-            activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+            activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
             insetsController?.show(WindowInsetsCompat.Type.systemBars())
             setCutoutMode(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT)
-            // Restore normal window behavior
-            window?.let { WindowCompat.setDecorFitsSystemWindows(it, true) }
+            // The app is edge-to-edge (enableEdgeToEdge in MainActivity), so
+            // keep decorFits false — restoring true here used to break the
+            // edge-to-edge layout for the rest of the session
+            window?.let { WindowCompat.setDecorFitsSystemWindows(it, false) }
         }
+    }
+
+    // YouTube-style rotation while the player is open: physically turning the
+    // device to landscape enters fullscreen, turning it upright again exits.
+    // Only orientation *transitions* act — so fullscreen entered with the
+    // button while holding the phone upright is not immediately exited — and
+    // the system auto-rotate lock is respected.
+    DisposableEffect(activity) {
+        var lastDeviceOrientation = -1 // 0 = portrait, 1 = landscape
+        val listener = object : android.view.OrientationEventListener(context) {
+            override fun onOrientationChanged(degrees: Int) {
+                if (degrees == android.view.OrientationEventListener.ORIENTATION_UNKNOWN) return
+                val autoRotateOn = android.provider.Settings.System.getInt(
+                    context.contentResolver,
+                    android.provider.Settings.System.ACCELEROMETER_ROTATION, 0
+                ) == 1
+                if (!autoRotateOn) return
+                // Only classify when clearly near an axis (30-degree window)
+                // so jitter around the diagonals cannot flip the state
+                val orientation = when {
+                    degrees <= 30 || degrees >= 330 || degrees in 150..210 -> 0
+                    degrees in 60..120 || degrees in 240..300 -> 1
+                    else -> return
+                }
+                if (orientation == lastDeviceOrientation) return
+                val isFirstReading = lastDeviceOrientation == -1
+                lastDeviceOrientation = orientation
+                if (isFirstReading) return
+                if (orientation == 1 && !isFullscreen) {
+                    isFullscreen = true
+                } else if (orientation == 0 && isFullscreen) {
+                    isFullscreen = false
+                }
+            }
+        }
+        if (listener.canDetectOrientation()) listener.enable()
+        onDispose { listener.disable() }
     }
     
     // Quality Sheet State

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
@@ -88,6 +88,10 @@ fun VideoPlayerContent(
     val timedComments by viewModel.timedComments.collectAsState()
     val canComment by viewModel.canComment.collectAsState()
     val isPostingComment by viewModel.isPostingComment.collectAsState()
+    val videoPlaylists by viewModel.videoPlaylists.collectAsState()
+    val isVideoPlaylistsLoading by viewModel.isVideoPlaylistsLoading.collectAsState()
+    val channelVideos by viewModel.channelVideos.collectAsState()
+    val isChannelVideosLoading by viewModel.isChannelVideosLoading.collectAsState()
 
     // Local UI State
     var showControls by remember { mutableStateOf(false) }
@@ -233,6 +237,11 @@ fun VideoPlayerContent(
     // Comments Sheet + Sign-in Dialog State
     var showCommentsSheet by remember { mutableStateOf(false) }
     var showSignInDialog by remember { mutableStateOf(false) }
+
+    // Save-to-playlist sheet (Save button or long-press on an Up Next video)
+    // and the channel page sheet (tap on the channel row)
+    var saveTargetVideo by remember { mutableStateOf<VideoItem?>(null) }
+    var showChannelSheet by remember { mutableStateOf(false) }
 
     // Gate authenticated actions behind login
     fun requireLogin(action: () -> Unit) {
@@ -382,6 +391,22 @@ fun VideoPlayerContent(
                     onCommentsClick = {
                         viewModel.ensureCommentsLoaded()
                         showCommentsSheet = true
+                    },
+                    onSaveClick = {
+                        requireLogin {
+                            viewModel.loadVideoPlaylists()
+                            saveTargetVideo = currentVideo
+                        }
+                    },
+                    onChannelClick = {
+                        viewModel.loadChannelVideos()
+                        showChannelSheet = true
+                    },
+                    onRelatedLongPress = { related ->
+                        requireLogin {
+                            viewModel.loadVideoPlaylists()
+                            saveTargetVideo = related
+                        }
                     }
                 )
             }
@@ -408,6 +433,38 @@ fun VideoPlayerContent(
             onLikeComment = { comment -> requireLogin { viewModel.toggleCommentLike(comment) } },
             onDeleteComment = { comment -> viewModel.deleteComment(comment) },
             onDismiss = { showCommentsSheet = false }
+        )
+    }
+
+    // Save to Watch Later / playlist sheet
+    saveTargetVideo?.let { target ->
+        SaveToPlaylistSheet(
+            video = target,
+            playlists = videoPlaylists,
+            isLoading = isVideoPlaylistsLoading,
+            onSave = { playlistId, onResult ->
+                viewModel.addVideoToPlaylist(playlistId, target, onResult)
+            },
+            onDismiss = { saveTargetVideo = null }
+        )
+    }
+
+    // Channel page sheet (latest uploads + subscribe)
+    if (showChannelSheet) {
+        ChannelSheet(
+            channelName = currentVideo.channelName,
+            channelIconUrl = currentVideo.channelIconUrl,
+            subscriberCountText = engagement?.subscriberCountText ?: currentVideo.subscriberCount,
+            isSubscribed = engagement?.isSubscribed == true,
+            canSubscribe = engagement?.channelId != null,
+            videos = channelVideos,
+            isLoading = isChannelVideosLoading,
+            onSubscribeClick = { requireLogin { viewModel.toggleSubscribe() } },
+            onVideoClick = { video ->
+                showChannelSheet = false
+                viewModel.playVideo(video)
+            },
+            onDismiss = { showChannelSheet = false }
         )
     }
 

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerOverlay.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerOverlay.kt
@@ -35,7 +35,8 @@ import com.ivor.ivormusic.R
 @Composable
 fun VideoPlayerOverlay(
     viewModel: VideoPlayerViewModel,
-    timedCommentsEnabled: Boolean = false
+    timedCommentsEnabled: Boolean = false,
+    miniPlayerExtraBottomPadding: androidx.compose.ui.unit.Dp = 0.dp
 ) {
     val isExpanded by viewModel.isExpanded.collectAsState()
     val currentVideo by viewModel.currentVideo.collectAsState()
@@ -210,12 +211,22 @@ fun VideoPlayerOverlay(
             if (expanded) 0.dp else 16.dp
         }
 
-        // Position above nav bar when minimized
+        // Position above nav bar when minimized, and above the music mini
+        // player too when both players are alive at the same time
         val bottomPadding by transition.animateDp(
             transitionSpec = { spring(stiffness = 300f, dampingRatio = 0.8f) },
             label = "bottomPadding"
         ) { expanded ->
-            if (expanded) 0.dp else (100.dp + bottomInset)
+            if (expanded) 0.dp else (100.dp + bottomInset + miniPlayerExtraBottomPadding)
+        }
+
+        // Animated so the pill corners melt away as the player grows to
+        // fullscreen instead of popping square on the first frame
+        val cornerRadius by transition.animateDp(
+            transitionSpec = { spring(stiffness = 300f, dampingRatio = 0.8f) },
+            label = "cornerRadius"
+        ) { expanded ->
+            if (expanded) 0.dp else 28.dp
         }
 
         Surface(
@@ -225,7 +236,7 @@ fun VideoPlayerOverlay(
                 .fillMaxWidth()
                 .height(height.coerceAtLeast(0.dp))
                 .clickable(enabled = !isExpanded) { viewModel.setExpanded(true) },
-            shape = RoundedCornerShape(if (isExpanded) 0.dp else 28.dp), // Expressive Large Shape
+            shape = RoundedCornerShape(cornerRadius.coerceAtLeast(0.dp)), // Expressive Large Shape
             color = MaterialTheme.colorScheme.surfaceContainerHigh,
             tonalElevation = if (isExpanded) 0.dp else 4.dp,
             shadowElevation = if (isExpanded) 0.dp else 12.dp

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -16,6 +16,8 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.calculateZoom
@@ -67,6 +69,7 @@ import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.Share
 import androidx.compose.material.icons.rounded.ThumbDown
 import androidx.compose.material.icons.rounded.ThumbUp
+import androidx.compose.material.icons.rounded.WatchLater
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -1072,6 +1075,7 @@ private fun SeekFeedbackBadge(
     }
 }
 
+@OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
 @Composable
 fun VideoInfoSection(
     video: VideoItem,
@@ -1082,7 +1086,10 @@ fun VideoInfoSection(
     onLikeClick: () -> Unit = {},
     onDislikeClick: () -> Unit = {},
     onSubscribeClick: () -> Unit = {},
-    onCommentsClick: () -> Unit = {}
+    onCommentsClick: () -> Unit = {},
+    onSaveClick: () -> Unit = {},
+    onChannelClick: () -> Unit = {},
+    onRelatedLongPress: ((VideoItem) -> Unit)? = null
 ) {
     Column(
         modifier = modifier
@@ -1111,24 +1118,28 @@ fun VideoInfoSection(
             )
         }
 
-        // Like / Dislike + Share Actions
+        // Like / Dislike + Save + Share Actions (scrolls like YouTube's chip
+        // row so the pills never squash on narrow screens)
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.horizontalScroll(rememberScrollState())
         ) {
             LikeDislikeBar(
                 engagement = engagement,
                 onLikeClick = onLikeClick,
                 onDislikeClick = onDislikeClick
             )
+            SaveVideoButton(onClick = onSaveClick)
             ShareVideoButton(video = video)
         }
 
-        // Channel Info Surface
+        // Channel Info Surface (tap navigates to the channel)
         Surface(
             shape = RoundedCornerShape(16.dp),
             color = MaterialTheme.colorScheme.surfaceContainer,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
+            onClick = onChannelClick
         ) {
             ListItem(
                 headlineContent = {
@@ -1297,7 +1308,14 @@ fun VideoInfoSection(
                         modifier = Modifier
                             .fillMaxWidth()
                             .clip(RoundedCornerShape(12.dp))
-                            .clickable { onVideoSelect(relatedVideo) }
+                            // Long-press saves to Watch Later / a playlist,
+                            // same gesture as the home feed cards
+                            .combinedClickable(
+                                onClick = { onVideoSelect(relatedVideo) },
+                                onLongClick = onRelatedLongPress?.let { longPress ->
+                                    { longPress(relatedVideo) }
+                                }
+                            )
                             .padding(vertical = 8.dp),
                         horizontalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
@@ -1366,6 +1384,38 @@ fun VideoInfoSection(
                     }
                 }
             }
+        }
+    }
+}
+
+/**
+ * Save pill beside Share: opens the save-to-playlist sheet with Watch Later
+ * pinned on top. Matches the pill shape of the like/dislike bar.
+ */
+@Composable
+private fun SaveVideoButton(onClick: () -> Unit) {
+    Surface(
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        onClick = onClick
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 12.dp, bottom = 12.dp)
+        ) {
+            Icon(
+                Icons.Rounded.WatchLater,
+                contentDescription = "Save to Watch Later",
+                modifier = Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = "Save",
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
         }
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -730,6 +730,8 @@ private const val PINCH_ZOOM_OUT_THRESHOLD = 0.87f
  * - vertical drag on the left half = screen brightness (window-level override,
  *   restored when the surface leaves composition);
  * - vertical drag on the right half = media volume;
+ * - both only arm when the drag STARTS below the top 30% of the surface, so
+ *   pulling down the notification shade never yanks brightness or volume;
  * - pinch open/closed = zoom the video to fill the screen / fit inside it,
  *   reported through [onZoomedToFillChange].
  */
@@ -827,6 +829,13 @@ private fun PlayerGestureSurface(
                     awaitEachGesture {
                         val down = awaitFirstDown(requireUnconsumed = false)
                         val leftSide = down.position.x < size.width / 2f
+                        // Level drags only arm in the bottom 70% of the
+                        // surface: a swipe from the top area is almost always
+                        // the user reaching for the notification shade, and
+                        // grabbing it as a brightness/volume drag was a
+                        // constant misfire. Pinch-to-zoom stays available
+                        // everywhere.
+                        val inLevelDragZone = down.position.y >= size.height * 0.3f
                         // 0 = undecided, 1 = vertical level drag, 2 = pinch
                         var mode = 0
                         var accumulatedZoom = 1f
@@ -852,7 +861,8 @@ private fun PlayerGestureSurface(
                                 if (mode == 0) {
                                     val totalDx = change.position.x - down.position.x
                                     val totalDy = change.position.y - down.position.y
-                                    if (abs(totalDy) > viewConfiguration.touchSlop &&
+                                    if (inLevelDragZone &&
+                                        abs(totalDy) > viewConfiguration.touchSlop &&
                                         abs(totalDy) > abs(totalDx)
                                     ) {
                                         mode = 1

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
@@ -154,6 +154,24 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
     private val _isPostingComment = MutableStateFlow(false)
     val isPostingComment: StateFlow<Boolean> = _isPostingComment.asStateFlow()
 
+    // ---------------- Save to playlist (Watch Later) ----------------
+
+    private val _videoPlaylists = MutableStateFlow<List<com.ivor.ivormusic.data.VideoPlaylist>>(emptyList())
+    val videoPlaylists: StateFlow<List<com.ivor.ivormusic.data.VideoPlaylist>> = _videoPlaylists.asStateFlow()
+
+    private val _isVideoPlaylistsLoading = MutableStateFlow(false)
+    val isVideoPlaylistsLoading: StateFlow<Boolean> = _isVideoPlaylistsLoading.asStateFlow()
+
+    // ---------------- Channel page (latest uploads) ----------------
+
+    private val _channelVideos = MutableStateFlow<List<VideoItem>>(emptyList())
+    val channelVideos: StateFlow<List<VideoItem>> = _channelVideos.asStateFlow()
+
+    private val _isChannelVideosLoading = MutableStateFlow(false)
+    val isChannelVideosLoading: StateFlow<Boolean> = _isChannelVideosLoading.asStateFlow()
+
+    private var channelVideosLoadedForChannelId: String? = null
+
     init {
         // Near-instant first frame (~1s buffered) plus an aggressive
         // read-ahead: up to 5 minutes (min == max: continuous top-up),
@@ -304,6 +322,12 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         commentsLoadedForVideoId = null
         _createCommentParams.value = null
         _isLoggedIn.value = youtubeRepository.isLoggedIn()
+
+        // Channel sheet content is per-channel; the next video may belong to
+        // a different one, so force a re-fetch on the next open
+        _channelVideos.value = emptyList()
+        _isChannelVideosLoading.value = false
+        channelVideosLoadedForChannelId = null
 
         // Speed is per-video, like YouTube
         _playbackSpeed.value = 1f
@@ -607,6 +631,64 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
     /** Pause without closing the player (music or Shorts playback started). */
     fun pause() {
         _exoPlayer?.pause()
+    }
+
+    // ---------------- Save to playlist / Watch Later ----------------
+
+    /** Load the user's YouTube playlists for the save sheet. Requires login. */
+    fun loadVideoPlaylists(force: Boolean = false) {
+        if (_isVideoPlaylistsLoading.value) return
+        if (_videoPlaylists.value.isNotEmpty() && !force) return
+        viewModelScope.launch {
+            _isVideoPlaylistsLoading.value = true
+            try {
+                _videoPlaylists.value = youtubeRepository.getVideoPlaylists()
+            } finally {
+                _isVideoPlaylistsLoading.value = false
+            }
+        }
+    }
+
+    /**
+     * Add a video to a YouTube playlist ("WL" = Watch Later). Reports the
+     * outcome on the main thread so the save sheet can show inline feedback.
+     * Requires login.
+     */
+    fun addVideoToPlaylist(playlistId: String, video: VideoItem, onResult: (Boolean) -> Unit) {
+        viewModelScope.launch {
+            onResult(youtubeRepository.addToYouTubePlaylist(playlistId, video.videoId, music = false))
+        }
+    }
+
+    // ---------------- Channel page ----------------
+
+    /**
+     * Load the current video's channel uploads for the channel sheet, once
+     * per channel. Uses the canonical UC... id from engagement (falls back to
+     * the id parsed with the video item).
+     */
+    fun loadChannelVideos() {
+        val video = _currentVideo.value ?: return
+        val channelId = _engagement.value?.channelId ?: video.channelId ?: return
+        if (channelVideosLoadedForChannelId == channelId) return
+        channelVideosLoadedForChannelId = channelId
+        _channelVideos.value = emptyList()
+        _isChannelVideosLoading.value = true
+        viewModelScope.launch {
+            try {
+                val channel = com.ivor.ivormusic.data.SubscribedChannel(
+                    channelId = channelId,
+                    name = video.channelName,
+                    avatarUrl = video.channelIconUrl,
+                    subscriberCountText = _engagement.value?.subscriberCountText
+                )
+                _channelVideos.value = youtubeRepository.getChannelVideos(channel)
+            } catch (e: Exception) {
+                android.util.Log.w("VideoPlayerVM", "Failed to load channel videos", e)
+            } finally {
+                _isChannelVideosLoading.value = false
+            }
+        }
     }
 
     // ---------------- Engagement actions ----------------

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
@@ -604,6 +604,11 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         }
     }
 
+    /** Pause without closing the player (music or Shorts playback started). */
+    fun pause() {
+        _exoPlayer?.pause()
+    }
+
     // ---------------- Engagement actions ----------------
 
     /** Re-check login state and refresh engagement (call after a successful sign-in). */


### PR DESCRIPTION
- Bottom-anchored UI (Library FAB menu, playlist Play split button) now
  clears the floating nav pill and mini players via a new animated
  LocalBottomOverlayInset provided by HomeScreen; tab list scroll padding
  is derived from the same value instead of a fixed 160dp, so content no
  longer hides behind the mini player.
- The minimized video player stacks above the music pill when both are
  alive instead of rendering on top of it.
- Music, video and Shorts playback are now mutually exclusive: starting
  one explicitly pauses the other two (audio focus alone was unreliable
  between players in the same app).
- Music mini player: corner radius clamped to half the pill height (the
  50dp radius on an 80dp pill distorted the corners) and given a soft
  floating shadow; video mini player corners now animate on expand
  instead of popping square.
- App is locked to portrait like YouTube. Fullscreen video requests
  sensor landscape and every exit restores portrait (previously
  UNSPECIFIED left the whole app free-rotating). While the video player
  is open, physically rotating to landscape enters fullscreen and
  rotating upright exits, honoring the system auto-rotate lock.
  Exiting fullscreen also no longer breaks edge-to-edge by re-enabling
  decorFitsSystemWindows.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y12S7hpMv5cGgYFxTM372r