### PR TITLE
Rework downloads: shared storage, foreground service, video support

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,13 @@ Plus an **ambient artwork background**, an optional **chromatic-mist** effect, a
 
 ### Downloads
 
-- Download individual songs for offline listening.
-- A download manager to track progress, cancel, delete, and clear failed downloads, with progress notifications.
+- **Download songs and videos** for offline playback. Video is stitched back together from YouTube's separate high-quality video and audio streams into a single MP4, so downloads are not stuck at the 360p that comes as a ready-made file.
+- **Download a whole album or playlist** in one tap. Anything you already have is skipped, so re-running it only fetches what is missing.
+- **Files go where you can find them** — `Downloads/Koda/Music` and `Downloads/Koda/Video` — named after the track, not the video id. They show up in the Files app and play in anything else on your device.
+- **Downloads survive leaving the screen.** They run in the background through a foreground service instead of dying when you navigate away.
+- **A download manager** with separate Music and Video tabs, a live queue, progress, cancel, delete, and one-tap retry on anything that failed.
+- **Progress notifications with album art**, and on Android 16 an optional **Live Update** that puts download progress in the status bar as a chip with a progress bar. On by default there, switchable off in Settings.
+- Failures retry automatically with a freshly resolved stream URL, and a partial download is never left behind as a broken file.
 
 ### Interface and theming
 
@@ -121,6 +126,7 @@ Koda's interface is the product, not a wrapper around one. The whole app is cons
 ### Authentication
 
 - Sign in through an embedded WebView. No password ever leaves the browser.
+- **Or paste a session cookie** from a desktop browser, for when the in-app sign-in fails or a session has gone stale. The sheet walks through getting it and checks what you paste before saving.
 - Cookies are stored with EncryptedSharedPreferences and signed per-origin (SAPISIDHASH).
 - Everything except personalized feeds, watch history, comments, and engagement works fully signed out.
 
@@ -151,7 +157,10 @@ Koda's interface is the product, not a wrapper around one. The whole app is cons
 app/src/main/java/com/ivor/ivormusic/
 ├── data/                    # Data layer
 │   ├── YouTubeRepository    # YouTube Music and video via NewPipe and InnerTube
-│   ├── DownloadRepository   # Download management
+│   ├── DownloadRepository   # Download queue, state, and progress
+│   ├── DownloadStorage      # Writes downloads into Downloads/Koda via MediaStore
+│   ├── DownloadMuxer        # Joins separate video and audio tracks into one MP4
+│   ├── DownloadMigration    # One-time move of older downloads to shared storage
 │   ├── PlaylistRepository   # Local user playlists
 │   ├── LikedSongsRepository # Local liked songs
 │   ├── RecommendationEngine # Local taste profile and queue continuation
@@ -162,7 +171,8 @@ app/src/main/java/com/ivor/ivormusic/
 │   ├── ThemePreferences     # All app settings
 │   └── Models               # Song, Playlist, VideoItem, SubscriptionItem, ...
 ├── service/                 # Background services
-│   └── MusicService         # MediaLibraryService with live-progress notification
+│   ├── MusicService         # MediaLibraryService with live-progress notification
+│   └── DownloadService      # Keeps downloads running in the background
 └── ui/                      # Presentation layer
     ├── home/                # Home with recommendations and video feed
     ├── library/             # Playlists, liked songs, statistics
@@ -237,6 +247,7 @@ For a deeper dive into the architecture, data flows, and the InnerTube layer, se
 - [x] In-app video with a personalized feed, chapters, and captions
 - [x] Multiple player styles and a full color-palette system
 - [x] Listening statistics
+- [x] Offline downloads for music and video, saved to your Downloads folder
 - [ ] Advanced audio: equalizer and gapless playback
 - [ ] Home screen widget for playback controls
 - [ ] Kotlin Multiplatform for desktop and iOS

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -55,6 +55,16 @@
                 <action android:name="android.media.browse.MediaBrowserService"/>
             </intent-filter>
         </service>
+
+        <!--
+            Keeps the process alive while downloads run. dataSync is the correct
+            type for user-initiated file transfers; the matching
+            FOREGROUND_SERVICE_DATA_SYNC permission is declared above.
+        -->
+        <service
+            android:name=".service.DownloadService"
+            android:foregroundServiceType="dataSync"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -439,27 +440,45 @@ fun MusicApp(
                 popExitTransition = { slideOutHorizontally(targetOffsetX = { it }) + fadeOut() }
             ) {
                 val downloadedSongs by playerViewModel.downloadedSongs.collectAsState()
+                val downloadedVideos by playerViewModel.downloadedVideos.collectAsState()
                 val downloadProgress by playerViewModel.downloadProgress.collectAsState()
-                
+                val downloadsContext = LocalContext.current
+
                 com.ivor.ivormusic.ui.downloads.DownloadsScreen(
                     downloadedSongs = downloadedSongs,
+                    downloadedVideos = downloadedVideos,
                     activeDownloads = downloadProgress,
                     onBack = { navController.popBackStack() },
-                    onPlaySong = { song -> 
+                    onPlaySong = { song ->
                         playerViewModel.playSong(song)
                     },
                     onPlayQueue = { songs, song ->
                         playerViewModel.playQueue(songs, song)
                     },
-                    onDeleteDownload = { songId -> 
+                    onPlayVideo = { video ->
+                        // Handed to the system player rather than the in-app one:
+                        // VideoPlayerViewModel.playVideo drives the two-phase
+                        // InnerTube resolution, and a downloaded file has no
+                        // stream to resolve. Local playback in the app player is
+                        // a separate piece of work.
+                        val intent = android.content.Intent(android.content.Intent.ACTION_VIEW)
+                            .setDataAndType(video.uri, "video/*")
+                            .addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        runCatching { downloadsContext.startActivity(intent) }
+                    },
+                    onDeleteDownload = { songId ->
                         playerViewModel.deleteDownload(songId)
                     },
-                    onCancelDownload = { songId -> 
+                    onDeleteVideo = { videoId ->
+                        playerViewModel.deleteVideoDownload(videoId)
+                    },
+                    onCancelDownload = { songId ->
                         playerViewModel.cancelDownload(songId)
                     },
-                    onRetryDownload = { song -> 
-                        playerViewModel.toggleDownload(song)
-                    }
+                    onRetryDownload = { request ->
+                        playerViewModel.retryDownload(request)
+                    },
+                    onCancelAll = { playerViewModel.cancelAllDownloads() }
                 )
             }
             composable(

--- a/app/src/main/java/com/ivor/ivormusic/data/DownloadMigration.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/DownloadMigration.kt
@@ -1,0 +1,151 @@
+package com.ivor.ivormusic.data
+
+import android.content.Context
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import java.io.File
+
+/**
+ * One-time move of downloads out of the app's private `filesDir/music` and into
+ * shared storage under Downloads/Koda, so they are reachable from the Files app.
+ *
+ * Two properties matter more than speed here:
+ *
+ *  - **Resumable.** Files are migrated one at a time and the metadata is
+ *    rewritten after each, so a kill mid-migration loses at most the file in
+ *    flight. Entries already carrying a `mediaUri` are skipped on the next run.
+ *  - **Single-flight.** The mutex and process-wide flag mean concurrent callers
+ *    collapse into one migration rather than racing over the same files.
+ *    DownloadRepository is a singleton so in practice this runs once anyway,
+ *    but the guard is what makes that a property of this object rather than an
+ *    assumption about its caller.
+ *
+ * Copy-then-delete per file means peak extra disk usage is one file, not a
+ * duplicate of the whole library.
+ */
+object DownloadMigration {
+
+    private const val TAG = "DownloadMigration"
+    private const val PREFS_NAME = "koda_download_migration"
+    private const val KEY_MIGRATED = "downloads_migrated_to_mediastore"
+
+    private val mutex = Mutex()
+
+    @Volatile
+    private var completedThisProcess = false
+
+    /**
+     * Move any legacy downloads into MediaStore. Safe to call repeatedly and
+     * from multiple repository instances; only the first does work.
+     *
+     * @return true when anything was actually migrated, so the caller knows to
+     *         reload its metadata.
+     */
+    suspend fun migrateIfNeeded(context: Context): Boolean = withContext(Dispatchers.IO) {
+        if (completedThisProcess) return@withContext false
+
+        mutex.withLock {
+            if (completedThisProcess) return@withLock false
+
+            val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            if (prefs.getBoolean(KEY_MIGRATED, false)) {
+                completedThisProcess = true
+                return@withLock false
+            }
+
+            val metadataFile = File(context.filesDir, "downloaded_songs_metadata.json")
+            val legacyDir = File(context.filesDir, "music")
+
+            if (!metadataFile.exists()) {
+                // Nothing to move; mark done so we never look again.
+                prefs.edit().putBoolean(KEY_MIGRATED, true).apply()
+                completedThisProcess = true
+                return@withLock false
+            }
+
+            val storage = DownloadStorage(context)
+            var migratedAny = false
+
+            try {
+                val entries = JSONArray(metadataFile.readText())
+
+                for (i in 0 until entries.length()) {
+                    val entry = entries.optJSONObject(i) ?: continue
+
+                    // Already migrated on a previous (interrupted) run.
+                    if (entry.has("mediaUri")) continue
+
+                    val legacyPath = entry.optString("localPath").takeIf { it.isNotBlank() }
+                        ?: continue
+                    val legacyFile = File(legacyPath)
+                    if (!legacyFile.exists()) {
+                        // File vanished; drop the stale path so it is not retried.
+                        entry.remove("localPath")
+                        continue
+                    }
+
+                    val fileName = storage.buildFileName(
+                        title = entry.optString("title", "Koda download"),
+                        artist = entry.optString("artist", ""),
+                        type = DownloadMediaType.MUSIC
+                    )
+
+                    val target = storage.createPending(fileName, DownloadMediaType.MUSIC)
+                    if (target == null) {
+                        Log.e(TAG, "Could not create MediaStore entry for $fileName")
+                        continue
+                    }
+
+                    val copied = runCatching {
+                        storage.openOutput(target)?.use { output ->
+                            legacyFile.inputStream().use { input -> input.copyTo(output) }
+                        } != null
+                    }.getOrElse { e ->
+                        Log.e(TAG, "Copy failed for $fileName", e)
+                        false
+                    }
+
+                    if (!copied) {
+                        // Roll back the pending row so no empty file is left behind.
+                        storage.delete(target)
+                        continue
+                    }
+
+                    storage.publish(target)
+                    legacyFile.delete()
+
+                    entry.put("mediaUri", target.toString())
+                    entry.remove("localPath")
+                    migratedAny = true
+
+                    // Persist after every file so an interrupted migration
+                    // resumes rather than restarting.
+                    metadataFile.writeText(entries.toString())
+                }
+
+                metadataFile.writeText(entries.toString())
+
+                // Only clear the legacy directory once nothing is left in it, so
+                // a partially failed migration keeps its remaining source files.
+                if (legacyDir.exists() && legacyDir.listFiles()?.isEmpty() != false) {
+                    legacyDir.delete()
+                }
+
+                prefs.edit().putBoolean(KEY_MIGRATED, true).apply()
+                completedThisProcess = true
+                Log.i(TAG, "Download migration finished (migratedAny=$migratedAny)")
+            } catch (e: Exception) {
+                // Leave the flag unset so the next launch retries. The metadata
+                // file is still valid: migrated entries carry mediaUri, the rest
+                // still carry localPath, and both are readable.
+                Log.e(TAG, "Download migration failed, will retry next launch", e)
+            }
+
+            migratedAny
+        }
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/data/DownloadMuxer.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/DownloadMuxer.kt
@@ -1,0 +1,135 @@
+package com.ivor.ivormusic.data
+
+import android.media.MediaCodec
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import android.media.MediaMuxer
+import android.util.Log
+import java.io.File
+import java.io.FileDescriptor
+import java.nio.ByteBuffer
+
+/**
+ * Joins a separate video track and audio track into one MP4.
+ *
+ * YouTube only serves a single ready-made file at 360p; every higher quality
+ * arrives as video-only plus a separate audio stream (see
+ * `YouTubeRepository.parseQualitiesFromStreamingData`). Downloading anything
+ * watchable therefore means remuxing.
+ *
+ * This is a **container copy, not a transcode** - samples are read from each
+ * input and written straight into the output, so it costs IO and almost no CPU,
+ * and quality is untouched.
+ *
+ * The MP4 muxer is picky about codecs: H.264/H.265 video with AAC audio is
+ * reliable, VP9/Opus in MP4 is not. Rather than guess, [mux] reports failure
+ * when the muxer rejects a track so the caller can fall back to the progressive
+ * stream.
+ */
+object DownloadMuxer {
+
+    private const val TAG = "DownloadMuxer"
+
+    /** Fallback sample buffer when the format does not declare a max size. */
+    private const val DEFAULT_SAMPLE_SIZE = 1 shl 20 // 1 MB
+
+    /**
+     * Remux [videoFile] and, when present, [audioFile] into [output].
+     *
+     * @return true when the output holds at least a video track.
+     */
+    fun mux(videoFile: File, audioFile: File?, output: FileDescriptor): Boolean {
+        var muxer: MediaMuxer? = null
+        var videoExtractor: MediaExtractor? = null
+        var audioExtractor: MediaExtractor? = null
+
+        return try {
+            muxer = MediaMuxer(output, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
+
+            videoExtractor = MediaExtractor().apply { setDataSource(videoFile.absolutePath) }
+            val videoTrack = selectTrack(videoExtractor, "video/")
+                ?: run {
+                    Log.e(TAG, "No video track in ${videoFile.name}")
+                    return false
+                }
+            val videoFormat = videoExtractor.getTrackFormat(videoTrack)
+            val outputVideoTrack = muxer.addTrack(videoFormat)
+
+            var outputAudioTrack = -1
+            var audioFormat: MediaFormat? = null
+            if (audioFile != null && audioFile.length() > 0) {
+                audioExtractor = MediaExtractor().apply { setDataSource(audioFile.absolutePath) }
+                val audioTrack = selectTrack(audioExtractor, "audio/")
+                if (audioTrack != null) {
+                    audioFormat = audioExtractor.getTrackFormat(audioTrack)
+                    outputAudioTrack = muxer.addTrack(audioFormat)
+                } else {
+                    Log.w(TAG, "No audio track in ${audioFile.name}, writing video only")
+                    audioExtractor.release()
+                    audioExtractor = null
+                }
+            }
+
+            muxer.start()
+
+            copyTrack(videoExtractor, muxer, outputVideoTrack, videoFormat)
+            if (audioExtractor != null && audioFormat != null && outputAudioTrack >= 0) {
+                copyTrack(audioExtractor, muxer, outputAudioTrack, audioFormat)
+            }
+
+            muxer.stop()
+            true
+        } catch (e: Exception) {
+            // Most often IllegalArgumentException from addTrack for a codec the
+            // MP4 muxer will not accept (VP9, Opus, sometimes AV1).
+            Log.e(TAG, "Muxing failed: ${e.message}", e)
+            false
+        } finally {
+            runCatching { muxer?.release() }
+            runCatching { videoExtractor?.release() }
+            runCatching { audioExtractor?.release() }
+        }
+    }
+
+    private fun selectTrack(extractor: MediaExtractor, mimePrefix: String): Int? {
+        for (i in 0 until extractor.trackCount) {
+            val mime = extractor.getTrackFormat(i).getString(MediaFormat.KEY_MIME) ?: continue
+            if (mime.startsWith(mimePrefix)) {
+                extractor.selectTrack(i)
+                return i
+            }
+        }
+        return null
+    }
+
+    private fun copyTrack(
+        extractor: MediaExtractor,
+        muxer: MediaMuxer,
+        outputTrack: Int,
+        format: MediaFormat
+    ) {
+        val bufferSize = if (format.containsKey(MediaFormat.KEY_MAX_INPUT_SIZE)) {
+            format.getInteger(MediaFormat.KEY_MAX_INPUT_SIZE).coerceAtLeast(DEFAULT_SAMPLE_SIZE)
+        } else {
+            DEFAULT_SAMPLE_SIZE
+        }
+
+        val buffer = ByteBuffer.allocate(bufferSize)
+        val info = MediaCodec.BufferInfo()
+
+        while (true) {
+            val size = extractor.readSampleData(buffer, 0)
+            if (size < 0) break
+
+            info.offset = 0
+            info.size = size
+            info.presentationTimeUs = extractor.sampleTime
+            // MediaExtractor.SAMPLE_FLAG_SYNC and BUFFER_FLAG_KEY_FRAME share a
+            // value, so the extractor's flags carry over directly.
+            info.flags = extractor.sampleFlags
+
+            muxer.writeSampleData(outputTrack, buffer, info)
+            extractor.advance()
+        }
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/data/DownloadNotificationHelper.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/DownloadNotificationHelper.kt
@@ -132,7 +132,11 @@ class DownloadNotificationHelper(private val context: Context) {
         queuedCount: Int = 0,
         // Picks the tracker icon. A plain flag for now; this becomes part of the
         // download model proper once video downloads land.
-        isVideo: Boolean = false
+        isVideo: Boolean = false,
+        // Album art / video thumbnail. Null until it has been fetched, so the
+        // notification shows immediately and gains the artwork on the next
+        // update rather than waiting on the network.
+        artwork: android.graphics.Bitmap? = null
     ): android.app.Notification {
         val percent = (progress * 100).toInt().coerceIn(0, 100)
 
@@ -191,6 +195,9 @@ class DownloadNotificationHelper(private val context: Context) {
             // has it switched off; the compat layer drops it.
             .setRequestPromotedOngoing(canPostLiveUpdates())
             .setShortCriticalText("$percent%")
+            // Album art in place of the app icon. Null is fine - the system
+            // simply falls back to the small icon.
+            .setLargeIcon(artwork)
 
         // Byte counts only once the transfer is actually underway, otherwise
         // the subtext reads "0.0 / 0.0 MB" during URL resolution. The queue
@@ -215,7 +222,8 @@ class DownloadNotificationHelper(private val context: Context) {
     fun showDownloadComplete(
         songId: String,
         songTitle: String,
-        artistName: String
+        artistName: String,
+        artwork: android.graphics.Bitmap? = null
     ) {
         if (!hasNotificationPermission()) return
 
@@ -228,8 +236,10 @@ class DownloadNotificationHelper(private val context: Context) {
 
         val builder = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_download_notification)
-            .setContentTitle("Downloaded")
-            .setContentText("$songTitle - $artistName")
+            .setContentTitle(songTitle)
+            .setContentText(artistName)
+            .setSubText("Downloaded")
+            .setLargeIcon(artwork)
             .setAutoCancel(true)
             .setContentIntent(contentIntent)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)

--- a/app/src/main/java/com/ivor/ivormusic/data/DownloadNotificationHelper.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/DownloadNotificationHelper.kt
@@ -15,7 +15,6 @@ import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.IconCompat
 import com.ivor.ivormusic.MainActivity
 import com.ivor.ivormusic.R
-import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Download notifications, including Android 16 Live Updates.
@@ -45,12 +44,11 @@ class DownloadNotificationHelper(private val context: Context) {
         private const val CHANNEL_DESCRIPTION = "Song and video download progress"
 
         /**
-         * Floor on how often a single download may repost. The transfer loop
-         * reports every 8KB buffer, which for a normal track is hundreds of
-         * updates per second - posting them all is what made these
-         * notifications flicker and hammer SystemUI.
+         * Fixed id for the foreground service notification. Downloads run one
+         * at a time behind a single service, so progress is one notification
+         * that retitles itself rather than one per song.
          */
-        private const val MIN_UPDATE_INTERVAL_MS = 500L
+        const val FOREGROUND_NOTIFICATION_ID = 0xD0AD
 
         /**
          * Share of the bar given to stream resolution, matching the 0.1f the
@@ -67,10 +65,6 @@ class DownloadNotificationHelper(private val context: Context) {
     }
 
     private val notificationManager = NotificationManagerCompat.from(context)
-
-    /** Last posted percent + timestamp per download, for throttling. */
-    private data class PostState(val atMs: Long, val percent: Int)
-    private val lastPost = ConcurrentHashMap<String, PostState>()
 
     init {
         createNotificationChannel()
@@ -119,27 +113,28 @@ class DownloadNotificationHelper(private val context: Context) {
     }
 
     /**
-     * Show or update download progress.
+     * Build the download progress notification.
      *
-     * Reposts are throttled: an update is skipped unless the whole-percent value
-     * changed and [MIN_UPDATE_INTERVAL_MS] has elapsed. The 0% and 100% edges
-     * always post so the notification appears and completes promptly.
+     * This returns rather than posts, because the notification belongs to the
+     * foreground service: the same object has to be handed to startForeground
+     * on the first call and to notify() on every update, and a service that
+     * cannot produce its notification synchronously cannot start.
+     *
+     * Update rate is governed upstream - the repository only emits on
+     * whole-percent changes - so there is no throttle here.
      */
-    fun showDownloadProgress(
-        songId: String,
+    fun buildProgressNotification(
         songTitle: String,
         artistName: String,
         progress: Float, // 0.0 to 1.0
         bytesDownloaded: Long,
         totalBytes: Long,
+        queuedCount: Int = 0,
         // Picks the tracker icon. A plain flag for now; this becomes part of the
         // download model proper once video downloads land.
         isVideo: Boolean = false
-    ) {
-        if (!hasNotificationPermission()) return
-
+    ): android.app.Notification {
         val percent = (progress * 100).toInt().coerceIn(0, 100)
-        if (!shouldPost(songId, percent)) return
 
         val contentIntent = PendingIntent.getActivity(
             context,
@@ -198,16 +193,20 @@ class DownloadNotificationHelper(private val context: Context) {
             .setShortCriticalText("$percent%")
 
         // Byte counts only once the transfer is actually underway, otherwise
-        // the subtext reads "0.0 / 0.0 MB" during URL resolution.
-        if (totalBytes > 0) {
-            val downloadedMb = bytesDownloaded / (1024 * 1024f)
-            val totalMb = totalBytes / (1024 * 1024f)
-            builder.setSubText("%.1f / %.1f MB".format(downloadedMb, totalMb))
-        } else {
-            builder.setSubText("Preparing")
-        }
+        // the subtext reads "0.0 / 0.0 MB" during URL resolution. The queue
+        // depth matters more than bytes when there is one, so it wins.
+        builder.setSubText(
+            when {
+                queuedCount > 0 -> "$queuedCount more in queue"
+                totalBytes > 0 -> "%.1f / %.1f MB".format(
+                    bytesDownloaded / (1024 * 1024f),
+                    totalBytes / (1024 * 1024f)
+                )
+                else -> "Preparing"
+            }
+        )
 
-        notificationManager.notify(getNotificationId(songId), builder.build())
+        return builder.build()
     }
 
     /**
@@ -218,7 +217,6 @@ class DownloadNotificationHelper(private val context: Context) {
         songTitle: String,
         artistName: String
     ) {
-        lastPost.remove(songId)
         if (!hasNotificationPermission()) return
 
         val contentIntent = PendingIntent.getActivity(
@@ -247,7 +245,6 @@ class DownloadNotificationHelper(private val context: Context) {
         songId: String,
         songTitle: String
     ) {
-        lastPost.remove(songId)
         if (!hasNotificationPermission()) return
 
         val builder = NotificationCompat.Builder(context, CHANNEL_ID)
@@ -264,28 +261,7 @@ class DownloadNotificationHelper(private val context: Context) {
      * Dismiss a download notification.
      */
     fun dismissNotification(songId: String) {
-        lastPost.remove(songId)
         notificationManager.cancel(getNotificationId(songId))
-    }
-
-    /**
-     * Throttle gate. Posts on the first update, on every whole-percent change
-     * that is at least [MIN_UPDATE_INTERVAL_MS] after the last one, and always
-     * on the 0/100 edges.
-     */
-    private fun shouldPost(songId: String, percent: Int): Boolean {
-        val now = System.currentTimeMillis()
-        val previous = lastPost[songId]
-
-        val allow = when {
-            previous == null -> true
-            percent >= 100 || percent == 0 -> true
-            percent == previous.percent -> false
-            else -> now - previous.atMs >= MIN_UPDATE_INTERVAL_MS
-        }
-
-        if (allow) lastPost[songId] = PostState(now, percent)
-        return allow
     }
 
     /**

--- a/app/src/main/java/com/ivor/ivormusic/data/DownloadRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/DownloadRepository.kt
@@ -7,35 +7,109 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import com.ivor.ivormusic.service.DownloadService
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
-import java.io.FileOutputStream
 import java.util.concurrent.TimeUnit
 
 enum class DownloadStatus {
     NOT_DOWNLOADED,
+
+    /** Accepted and waiting for the worker; downloads run one at a time. */
+    QUEUED,
     DOWNLOADING,
     DOWNLOADED,
     FAILED,
     LOCAL_ORIGINAL
 }
 
+/**
+ * One queued or in-flight download, of either media type.
+ *
+ * Music carries its originating [Song] so completion can reuse it verbatim;
+ * video has no equivalent domain object to preserve, so the display fields on
+ * the request itself are the whole story.
+ */
+data class DownloadRequest(
+    val id: String,
+    val title: String,
+    val subtitle: String,
+    val type: DownloadMediaType,
+    val thumbnailUrl: String? = null,
+    val durationMs: Long = 0,
+    val song: Song? = null
+) {
+    val isVideo: Boolean get() = type == DownloadMediaType.VIDEO
+}
+
 data class DownloadProgress(
     val songId: String,
-    val song: Song,
+    val request: DownloadRequest,
     val progress: Float, // 0.0 to 1.0
     val status: DownloadStatus,
     val bytesDownloaded: Long = 0,
     val totalBytes: Long = 0
 )
 
-class DownloadRepository(private val context: Context) {
+/** A completed video download. */
+data class DownloadedVideo(
+    val id: String,
+    val title: String,
+    val channelName: String,
+    val uri: Uri,
+    val thumbnailUrl: String? = null,
+    val durationMs: Long = 0,
+    val quality: String? = null
+)
+
+/**
+ * Owns download state for the whole process.
+ *
+ * This is a singleton on purpose. Every consumer used to construct its own
+ * instance, and since all download state lives in per-instance StateFlows, the
+ * instances never agreed: starting a download from the home screen updated the
+ * home ViewModel's copy while the Downloads screen watched the player
+ * ViewModel's, so the transfer was invisible there and the finished song only
+ * turned up after an app restart. One instance means one set of flows and one
+ * source of truth.
+ *
+ * The constructor is private so that failure mode cannot be reintroduced by
+ * calling `DownloadRepository(context)` again.
+ */
+class DownloadRepository private constructor(private val context: Context) {
     companion object {
         private const val TAG = "DownloadRepository"
+
+        /**
+         * Attempts per download. Each one re-resolves the stream URL, which is
+         * what actually rescues an expired googlevideo link.
+         */
+        private const val MAX_ATTEMPTS = 3
+        private const val RETRY_BACKOFF_MS = 2_000L
+        private const val BUFFER_SIZE = 8192
+
+        /** How long a finished download stays visible in the progress list. */
+        private const val COMPLETION_LINGER_MS = 1_500L
+
+        @Volatile
+        private var INSTANCE: DownloadRepository? = null
+
+        /**
+         * The process-wide instance. Always built against the application
+         * context so holding it from a Service or ViewModel cannot leak an
+         * Activity.
+         */
+        fun getInstance(context: Context): DownloadRepository =
+            INSTANCE ?: synchronized(this) {
+                INSTANCE ?: DownloadRepository(context.applicationContext).also { INSTANCE = it }
+            }
     }
 
     private val client = OkHttpClient.Builder()
@@ -52,9 +126,18 @@ class DownloadRepository(private val context: Context) {
 
     private val youtubeRepository = YouTubeRepository(context)
     private val notificationHelper = DownloadNotificationHelper(context)
+    private val storage = DownloadStorage(context)
 
     private val downloadsFile = File(context.filesDir, "downloaded_songs_metadata.json")
-    private val musicDir = File(context.filesDir, "music")
+    private val videosFile = File(context.filesDir, "downloaded_videos_metadata.json")
+
+    /**
+     * Scope for work that outlives a single call, currently only the one-time
+     * storage migration. Repository instances are never explicitly disposed, so
+     * this deliberately has no cancellation hook.
+     */
+    private val repositoryScope =
+        kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.SupervisorJob() + Dispatchers.IO)
 
     private val _downloadedSongs = MutableStateFlow<List<Song>>(emptyList())
     val downloadedSongs: StateFlow<List<Song>> = _downloadedSongs.asStateFlow()
@@ -66,19 +149,73 @@ class DownloadRepository(private val context: Context) {
     private val _downloadProgress = MutableStateFlow<Map<String, DownloadProgress>>(emptyMap())
     val downloadProgress: StateFlow<Map<String, DownloadProgress>> = _downloadProgress.asStateFlow()
 
-    // Download queue for batch downloads
-    private val _downloadQueue = MutableStateFlow<List<Song>>(emptyList())
-    val downloadQueue: StateFlow<List<Song>> = _downloadQueue.asStateFlow()
+    private val _downloadedVideos = MutableStateFlow<List<DownloadedVideo>>(emptyList())
+    val downloadedVideos: StateFlow<List<DownloadedVideo>> = _downloadedVideos.asStateFlow()
 
-    // Track active download calls for cancellation
-    private val activeDownloadCalls = mutableMapOf<String, okhttp3.Call>()
-    private val downloadJobs = mutableMapOf<String, kotlinx.coroutines.Job>()
+    // Requests accepted but not yet started. Downloads run serially, so this is
+    // the real backlog rather than a snapshot of a batch.
+    private val _downloadQueue = MutableStateFlow<List<DownloadRequest>>(emptyList())
+    val downloadQueue: StateFlow<List<DownloadRequest>> = _downloadQueue.asStateFlow()
+
+    /** Guards queue mutations and [activeId] so enqueue and drain agree. */
+    private val queueMutex = kotlinx.coroutines.sync.Mutex()
+
+    private val workerLock = Any()
+
+    @Volatile
+    private var workerRunning = false
+
+    /** The job running the current transfer, cancelled per-download. */
+    @Volatile
+    private var activeJob: kotlinx.coroutines.Job? = null
+
+    @Volatile
+    private var activeId: String? = null
+
+    // Track active download calls for cancellation. Concurrent because
+    // downloads run on Dispatchers.IO while cancellation arrives from the main
+    // thread; a plain LinkedHashMap here was a data race.
+    private val activeDownloadCalls = java.util.concurrent.ConcurrentHashMap<String, okhttp3.Call>()
 
     init {
-        if (!musicDir.exists()) musicDir.mkdirs()
+        // Read whatever is on disk right away so consumers that touch
+        // downloadedSongs.value immediately (MusicService does) are not racing
+        // an empty list, then migrate in the background and reload.
         loadDownloadedSongs()
+        loadDownloadedVideos()
+        repositoryScope.launch {
+            if (DownloadMigration.migrateIfNeeded(context)) {
+                loadDownloadedSongs()
+            }
+        }
     }
 
+    /**
+     * Whether this exact media type is already downloaded.
+     *
+     * Music and video share an id namespace (both are YouTube video ids), so
+     * the check has to be per-type: having the audio does not mean the user
+     * already has the video. The queue's own id check still prevents the two
+     * running at once, so they simply happen in sequence.
+     */
+    private fun isDownloadedOfType(id: String, type: DownloadMediaType): Boolean =
+        when (type) {
+            DownloadMediaType.MUSIC -> _downloadedSongs.value.any { it.id == id }
+            DownloadMediaType.VIDEO -> _downloadedVideos.value.any { it.id == id }
+        }
+
+    /**
+     * Hydrate from the metadata sidecar, dropping anything whose file is gone.
+     *
+     * Two entry shapes are accepted on purpose: `mediaUri` for downloads in
+     * shared storage, and the legacy `localPath` for entries that have not been
+     * migrated yet. Keeping both readable means the list works before, during
+     * and after [DownloadMigration] runs.
+     *
+     * Existence is reconciled against MediaStore in a single query rather than
+     * trusted, because these files are now user-visible and can be deleted from
+     * the Files app behind our back.
+     */
     private fun loadDownloadedSongs() {
         if (!downloadsFile.exists()) {
             _downloadedSongs.value = emptyList()
@@ -86,29 +223,50 @@ class DownloadRepository(private val context: Context) {
         }
 
         try {
-            val jsonStr = downloadsFile.readText()
-            val jsonArray = JSONArray(jsonStr)
+            val jsonArray = JSONArray(downloadsFile.readText())
+            val liveUris = storage.listExisting(DownloadMediaType.MUSIC).keys
             val songs = mutableListOf<Song>()
+            var prunedAny = false
 
             for (i in 0 until jsonArray.length()) {
-                val obj = jsonArray.getJSONObject(i)
-                val filePath = obj.getString("localPath")
-                val file = File(filePath)
-                if (file.exists()) {
-                    songs.add(Song(
-                        id = obj.getString("id"),
-                        title = obj.getString("title"),
-                        artist = obj.getString("artist"),
-                        album = obj.optString("album", ""),
-                        duration = obj.getLong("duration"),
-                        uri = Uri.fromFile(file),
-                        albumArtUri = if (obj.has("albumArtUrl")) Uri.parse(obj.getString("albumArtUrl")) else null,
-                        thumbnailUrl = if (obj.has("albumArtUrl") && !obj.isNull("albumArtUrl")) obj.getString("albumArtUrl") else null,
-                        source = SongSource.LOCAL
-                    ))
+                val obj = jsonArray.optJSONObject(i) ?: continue
+
+                val mediaUri = obj.optString("mediaUri").takeIf { it.isNotBlank() }
+                val legacyPath = obj.optString("localPath").takeIf { it.isNotBlank() }
+
+                val uri: Uri? = when {
+                    mediaUri != null -> Uri.parse(mediaUri).takeIf { it in liveUris }
+                    legacyPath != null -> File(legacyPath).takeIf { it.exists() }?.let(Uri::fromFile)
+                    else -> null
                 }
+
+                if (uri == null) {
+                    prunedAny = true
+                    continue
+                }
+
+                val artUrl = obj.optString("albumArtUrl").takeIf {
+                    it.isNotBlank() && !obj.isNull("albumArtUrl")
+                }
+                songs.add(
+                    Song(
+                        id = obj.optString("id"),
+                        title = obj.optString("title"),
+                        artist = obj.optString("artist"),
+                        album = obj.optString("album", ""),
+                        duration = obj.optLong("duration"),
+                        uri = uri,
+                        albumArtUri = artUrl?.let(Uri::parse),
+                        thumbnailUrl = artUrl,
+                        source = SongSource.LOCAL
+                    )
+                )
             }
+
             _downloadedSongs.value = songs
+            // Persist the pruned list so externally deleted files do not get
+            // re-checked on every launch.
+            if (prunedAny) saveMetadata()
         } catch (e: Exception) {
             Log.e(TAG, "Error loading downloads", e)
             _downloadedSongs.value = emptyList()
@@ -119,18 +277,23 @@ class DownloadRepository(private val context: Context) {
         try {
             val jsonArray = JSONArray()
             _downloadedSongs.value.forEach { song ->
-                if (song.source == SongSource.LOCAL && song.uri?.path?.startsWith(context.filesDir.path) == true) {
-                    val obj = JSONObject().apply {
-                        put("id", song.id)
-                        put("title", song.title)
-                        put("artist", song.artist)
-                        put("album", song.album)
-                        put("duration", song.duration)
-                        put("localPath", song.uri.path)
-                        put("albumArtUrl", song.thumbnailUrl ?: song.albumArtUri?.toString())
+                val uri = song.uri ?: return@forEach
+                val obj = JSONObject().apply {
+                    put("id", song.id)
+                    put("title", song.title)
+                    put("artist", song.artist)
+                    put("album", song.album)
+                    put("duration", song.duration)
+                    // Downloads live in MediaStore now; a file:// uri here only
+                    // happens for entries awaiting migration.
+                    if (uri.scheme == "file") {
+                        put("localPath", uri.path)
+                    } else {
+                        put("mediaUri", uri.toString())
                     }
-                    jsonArray.put(obj)
+                    put("albumArtUrl", song.thumbnailUrl ?: song.albumArtUri?.toString())
                 }
+                jsonArray.put(obj)
             }
             downloadsFile.writeText(jsonArray.toString())
         } catch (e: Exception) {
@@ -138,36 +301,116 @@ class DownloadRepository(private val context: Context) {
         }
     }
 
-    private fun updateProgress(songId: String, song: Song, progress: Float, status: DownloadStatus, bytesDownloaded: Long = 0, totalBytes: Long = 0) {
+    /** Load completed video downloads, reconciled against MediaStore. */
+    private fun loadDownloadedVideos() {
+        if (!videosFile.exists()) {
+            _downloadedVideos.value = emptyList()
+            return
+        }
+
+        try {
+            val jsonArray = JSONArray(videosFile.readText())
+            val liveUris = storage.listExisting(DownloadMediaType.VIDEO).keys
+            val videos = mutableListOf<DownloadedVideo>()
+            var prunedAny = false
+
+            for (i in 0 until jsonArray.length()) {
+                val obj = jsonArray.optJSONObject(i) ?: continue
+                val uri = obj.optString("mediaUri").takeIf { it.isNotBlank() }
+                    ?.let(Uri::parse)
+                    ?.takeIf { it in liveUris }
+
+                if (uri == null) {
+                    prunedAny = true
+                    continue
+                }
+
+                videos.add(
+                    DownloadedVideo(
+                        id = obj.optString("id"),
+                        title = obj.optString("title"),
+                        channelName = obj.optString("channelName"),
+                        uri = uri,
+                        thumbnailUrl = obj.optString("thumbnailUrl").takeIf { it.isNotBlank() },
+                        durationMs = obj.optLong("durationMs"),
+                        quality = obj.optString("quality").takeIf { it.isNotBlank() }
+                    )
+                )
+            }
+
+            _downloadedVideos.value = videos
+            if (prunedAny) saveVideoMetadata()
+        } catch (e: Exception) {
+            Log.e(TAG, "Error loading video downloads", e)
+            _downloadedVideos.value = emptyList()
+        }
+    }
+
+    private fun saveVideoMetadata() {
+        try {
+            val jsonArray = JSONArray()
+            _downloadedVideos.value.forEach { video ->
+                jsonArray.put(
+                    JSONObject().apply {
+                        put("id", video.id)
+                        put("title", video.title)
+                        put("channelName", video.channelName)
+                        put("mediaUri", video.uri.toString())
+                        put("thumbnailUrl", video.thumbnailUrl)
+                        put("durationMs", video.durationMs)
+                        put("quality", video.quality)
+                    }
+                )
+            }
+            videosFile.writeText(jsonArray.toString())
+        } catch (e: Exception) {
+            Log.e(TAG, "Error saving video metadata", e)
+        }
+    }
+
+    /**
+     * Publish progress for one download.
+     *
+     * The transfer loop calls this on every 8KB buffer, which is hundreds of
+     * times a second. Emitting all of them would recompose the Downloads screen
+     * just as often for changes too small to see, so an update is dropped
+     * unless the whole-percent value or the status actually changed. That takes
+     * a download from thousands of emissions to about a hundred, and the
+     * terminal states always get through because their status differs.
+     */
+    private fun updateProgress(
+        request: DownloadRequest,
+        progress: Float,
+        status: DownloadStatus,
+        bytesDownloaded: Long = 0,
+        totalBytes: Long = 0
+    ) {
+        val previous = _downloadProgress.value[request.id]
+        if (previous != null &&
+            previous.status == status &&
+            (previous.progress * 100).toInt() == (progress * 100).toInt()
+        ) {
+            return
+        }
+
         val current = _downloadProgress.value.toMutableMap()
-        current[songId] = DownloadProgress(songId, song, progress, status, bytesDownloaded, totalBytes)
+        current[request.id] =
+            DownloadProgress(request.id, request, progress, status, bytesDownloaded, totalBytes)
         _downloadProgress.value = current
-        
-        // Update notification
+
+        // Terminal states get their own one-shot notification. Progress itself
+        // is not posted here: it belongs to DownloadService, which owns the
+        // foreground notification and observes these flows.
         when (status) {
-            DownloadStatus.DOWNLOADING -> {
-                notificationHelper.showDownloadProgress(
-                    songId = songId,
-                    songTitle = song.title,
-                    artistName = song.artist,
-                    progress = progress,
-                    bytesDownloaded = bytesDownloaded,
-                    totalBytes = totalBytes
-                )
-            }
-            DownloadStatus.DOWNLOADED -> {
-                notificationHelper.showDownloadComplete(
-                    songId = songId,
-                    songTitle = song.title,
-                    artistName = song.artist
-                )
-            }
-            DownloadStatus.FAILED -> {
-                notificationHelper.showDownloadFailed(
-                    songId = songId,
-                    songTitle = song.title
-                )
-            }
+            DownloadStatus.DOWNLOADED -> notificationHelper.showDownloadComplete(
+                songId = request.id,
+                songTitle = request.title,
+                artistName = request.subtitle
+            )
+            DownloadStatus.FAILED -> notificationHelper.showDownloadFailed(
+                songId = request.id,
+                songTitle = request.title
+            )
             else -> { /* No notification for other statuses */ }
         }
     }
@@ -176,167 +419,505 @@ class DownloadRepository(private val context: Context) {
         val current = _downloadProgress.value.toMutableMap()
         current.remove(songId)
         _downloadProgress.value = current
-        
+
         // Dismiss notification when progress is removed
         notificationHelper.dismissNotification(songId)
     }
 
-    suspend fun downloadSong(song: Song) = withContext(Dispatchers.IO) {
-        if (isDownloaded(song.id) || _downloadingIds.value.contains(song.id)) return@withContext
+    // --- Queue and worker ---------------------------------------------------
 
-        _downloadingIds.value = _downloadingIds.value + song.id
-        updateProgress(song.id, song, 0f, DownloadStatus.DOWNLOADING)
+    /**
+     * Queue a song. Kept `suspend` so existing call sites are unchanged, but it
+     * no longer performs the transfer: it enqueues and returns. Previously the
+     * transfer ran in the caller's scope, so a download started from a screen
+     * died when that screen's ViewModel was cleared, leaving a half-written
+     * file behind.
+     */
+    suspend fun downloadSong(song: Song) {
+        enqueue(listOf(song.toRequest()))
+    }
 
+    /**
+     * Queue a whole playlist. Songs already downloaded or already queued are
+     * skipped, so re-running this over a partially downloaded playlist only
+     * fetches what is missing.
+     */
+    suspend fun downloadPlaylist(songs: List<Song>) {
+        enqueue(songs.map { it.toRequest() })
+    }
+
+    /** Queue a video download. */
+    suspend fun downloadVideo(video: VideoItem) {
+        enqueue(listOf(video.toRequest()))
+    }
+
+    /** Queue several videos at once. */
+    suspend fun downloadVideos(videos: List<VideoItem>) {
+        enqueue(videos.map { it.toRequest() })
+    }
+
+    private fun Song.toRequest() = DownloadRequest(
+        id = id,
+        title = title,
+        subtitle = artist,
+        type = DownloadMediaType.MUSIC,
+        thumbnailUrl = thumbnailUrl ?: albumArtUri?.toString(),
+        durationMs = duration,
+        song = this
+    )
+
+    private fun VideoItem.toRequest() = DownloadRequest(
+        id = videoId,
+        title = title,
+        subtitle = channelName,
+        type = DownloadMediaType.VIDEO,
+        thumbnailUrl = thumbnailUrl,
+        // VideoItem.duration is seconds; everything downstream works in millis.
+        durationMs = duration * 1000
+    )
+
+    private suspend fun enqueue(requests: List<DownloadRequest>) {
+        val accepted = queueMutex.withLock {
+            val existing = _downloadQueue.value.map { it.id }.toSet()
+            val additions = requests.filter { request ->
+                request.id.isNotBlank() &&
+                    !isDownloadedOfType(request.id, request.type) &&
+                    request.id !in existing &&
+                    request.id != activeId
+            }.distinctBy { it.id }
+
+            if (additions.isNotEmpty()) {
+                _downloadQueue.value = _downloadQueue.value + additions
+                _downloadingIds.value = _downloadingIds.value + additions.map { it.id }
+                additions.forEach { updateProgress(it, 0f, DownloadStatus.QUEUED) }
+            }
+            additions
+        }
+
+        if (accepted.isNotEmpty()) ensureWorker()
+    }
+
+    /**
+     * Start the drain loop if it is not already running.
+     *
+     * The re-check in the `finally` closes the race where a request is enqueued
+     * just as the loop decides the queue is empty: rather than locking around
+     * the whole drain, the loop re-arms itself if anything arrived on the way
+     * out.
+     */
+    private fun ensureWorker() {
+        synchronized(workerLock) {
+            if (workerRunning) return
+            workerRunning = true
+        }
+
+        repositoryScope.launch {
+            try {
+                drainQueue()
+            } finally {
+                synchronized(workerLock) { workerRunning = false }
+                if (_downloadQueue.value.isNotEmpty()) ensureWorker()
+            }
+        }
+    }
+
+    private suspend fun drainQueue() {
+        DownloadService.start(context)
         try {
-            Log.d(TAG, "Starting download for: ${song.title}")
-            
-            // Get stream URL
-            updateProgress(song.id, song, 0.05f, DownloadStatus.DOWNLOADING)
-            val result = youtubeRepository.getStreamUrl(song.id)
-            val streamUrl = result.getOrNull()
-            
-            if (streamUrl == null) {
-                val error = result.exceptionOrNull()
-                Log.e(TAG, "Could not get stream URL for ${song.title}", error)
-                updateProgress(song.id, song, 0f, DownloadStatus.FAILED)
-                return@withContext
+            while (true) {
+                val next = queueMutex.withLock {
+                    _downloadQueue.value.firstOrNull()?.also {
+                        _downloadQueue.value = _downloadQueue.value.drop(1)
+                        activeId = it.id
+                    }
+                } ?: break
+
+                // Each task is its own child job so cancelling one download
+                // does not tear down the queue. join() returns normally when
+                // the child is cancelled, so the loop simply moves on.
+                val job = repositoryScope.launch { runTask(next) }
+                activeJob = job
+                job.join()
+
+                activeJob = null
+                queueMutex.withLock { activeId = null }
+            }
+        } finally {
+            DownloadService.stop(context)
+        }
+    }
+
+    /**
+     * Run one download, retrying transient failures.
+     *
+     * Each attempt re-resolves the stream URL rather than reusing the previous
+     * one. googlevideo URLs expire, so a retry against a stale URL would fail
+     * exactly like the attempt before it.
+     */
+    private suspend fun runTask(request: DownloadRequest) {
+        var lastError: Throwable? = null
+
+        for (attempt in 1..MAX_ATTEMPTS) {
+            try {
+                val ok = if (request.isVideo) {
+                    attemptVideoDownload(request)
+                } else {
+                    attemptMusicDownload(request)
+                }
+                if (ok) return
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                lastError = e
+                Log.w(TAG, "Attempt $attempt/$MAX_ATTEMPTS failed for ${request.title}: ${e.message}")
             }
 
-            // Check if cancelled during URL fetch
-            if (!_downloadingIds.value.contains(song.id)) {
-                Log.d(TAG, "Download cancelled for ${song.title}")
-                removeProgress(song.id)
-                return@withContext
+            if (attempt < MAX_ATTEMPTS) {
+                kotlinx.coroutines.delay(RETRY_BACKOFF_MS * attempt)
             }
+        }
 
-            updateProgress(song.id, song, 0.1f, DownloadStatus.DOWNLOADING)
-            Log.d(TAG, "Got stream URL, starting download...")
+        Log.e(TAG, "Giving up on ${request.title}", lastError)
+        updateProgress(request, 0f, DownloadStatus.FAILED)
+        _downloadingIds.value = _downloadingIds.value - request.id
+    }
 
-            val request = Request.Builder().url(streamUrl).build()
-            val call = client.newCall(request)
-            activeDownloadCalls[song.id] = call
-            
-            val response = call.execute()
-            
-            if (!response.isSuccessful) {
-                Log.e(TAG, "Download failed with code: ${response.code}")
-                updateProgress(song.id, song, 0f, DownloadStatus.FAILED)
-                return@withContext
+    /**
+     * One music download attempt. Returns true on success.
+     *
+     * Cancellation is cooperative through the coroutine's own job rather than
+     * through membership of a state set: the previous design used
+     * `_downloadingIds` as both the "is downloading" state and the stop signal,
+     * which meant any code touching that set could halt a transfer.
+     */
+    private suspend fun attemptMusicDownload(request: DownloadRequest): Boolean =
+        withContext(Dispatchers.IO) {
+            val song = request.song ?: return@withContext false
+            var pendingTarget: Uri? = null
+            updateProgress(request, 0.02f, DownloadStatus.DOWNLOADING)
+
+            try {
+                val streamUrl = youtubeRepository.getStreamUrl(request.id).getOrNull()
+                    ?: throw java.io.IOException("No stream URL for ${request.id}")
+
+                ensureActive()
+                updateProgress(request, 0.1f, DownloadStatus.DOWNLOADING)
+
+                val fileName =
+                    storage.buildFileName(request.title, request.subtitle, DownloadMediaType.MUSIC)
+                val target = storage.createPending(fileName, DownloadMediaType.MUSIC)
+                    ?: throw java.io.IOException("Could not create storage entry")
+                pendingTarget = target
+
+                val output = storage.openOutput(target)
+                    ?: throw java.io.IOException("Could not open output")
+
+                output.use { out ->
+                    downloadStream(request, streamUrl, out, 0.1f, 1f)
+                }
+
+                storage.publish(target)
+                pendingTarget = null
+
+                val downloaded = song.copy(uri = target, source = SongSource.LOCAL)
+                _downloadedSongs.value = _downloadedSongs.value + downloaded
+                saveMetadata()
+
+                finishSuccess(request)
+                true
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                cleanUpCancelled(request, pendingTarget)
+                throw e
+            } catch (e: Exception) {
+                pendingTarget?.let { storage.delete(it) }
+                throw e
+            } finally {
+                activeDownloadCalls.remove(request.id)
             }
+        }
 
-            val body = response.body
-            if (body == null) {
-                Log.e(TAG, "Response body is null")
-                updateProgress(song.id, song, 0f, DownloadStatus.FAILED)
-                return@withContext
-            }
+    /**
+     * One video download attempt.
+     *
+     * YouTube serves a single ready-made file only at 360p; everything better
+     * is video-only plus a separate audio stream, so the good path downloads
+     * both to the cache and remuxes them into the final MP4 (see
+     * [DownloadMuxer]). If no adaptive pair is usable - or the MP4 muxer
+     * rejects the codec - it falls back to whatever progressive stream exists
+     * so the user gets a file rather than an error.
+     */
+    private suspend fun attemptVideoDownload(request: DownloadRequest): Boolean =
+        withContext(Dispatchers.IO) {
+            var pendingTarget: Uri? = null
+            var videoTemp: File? = null
+            var audioTemp: File? = null
+            updateProgress(request, 0.02f, DownloadStatus.DOWNLOADING)
 
-            val totalBytes = body.contentLength()
-            val file = File(musicDir, "${song.id}.m4a")
-            
-            Log.d(TAG, "Downloading ${totalBytes} bytes to ${file.absolutePath}")
+            try {
+                val qualities = youtubeRepository.getVideoStreamQualities(request.id)
+                if (qualities.isEmpty()) throw java.io.IOException("No streams for ${request.id}")
 
-            var bytesDownloaded = 0L
-            val buffer = ByteArray(8192)
+                ensureActive()
 
-            body.byteStream().use { input ->
-                FileOutputStream(file).use { output ->
-                    var bytesRead: Int
-                    while (input.read(buffer).also { bytesRead = it } != -1) {
-                        // Check for cancellation
-                        if (!_downloadingIds.value.contains(song.id)) {
-                            Log.d(TAG, "Download cancelled during transfer for ${song.title}")
-                            file.delete()
-                            removeProgress(song.id)
-                            return@withContext
-                        }
-                        
-                        output.write(buffer, 0, bytesRead)
-                        bytesDownloaded += bytesRead
-                        
-                        // Update progress (10% is fetching URL, 90% is actual download)
-                        val downloadProgress = if (totalBytes > 0) {
-                            0.1f + (bytesDownloaded.toFloat() / totalBytes.toFloat() * 0.9f)
-                        } else {
-                            0.5f // Indeterminate
-                        }
-                        updateProgress(song.id, song, downloadProgress, DownloadStatus.DOWNLOADING, bytesDownloaded, totalBytes)
+                // MP4-container entries only: the muxer will not accept VP9 or
+                // Opus, which is what the webm ladder carries.
+                val adaptive = qualities.firstOrNull {
+                    !it.isDASH && it.audioUrl != null && it.format?.contains("mp4") == true
+                }
+                val progressive = qualities.firstOrNull { !it.isDASH && it.audioUrl == null }
+
+                val chosen = adaptive ?: progressive
+                    ?: throw java.io.IOException("No downloadable stream for ${request.id}")
+
+                val fileName =
+                    storage.buildFileName(request.title, request.subtitle, DownloadMediaType.VIDEO)
+                val target = storage.createPending(fileName, DownloadMediaType.VIDEO)
+                    ?: throw java.io.IOException("Could not create storage entry")
+                pendingTarget = target
+
+                var muxed = false
+
+                if (chosen.audioUrl != null) {
+                    // Two transfers, then a remux. Progress is split so the bar
+                    // reflects real work: video is the bulk, audio a slice, and
+                    // the tail is the mux.
+                    videoTemp = File.createTempFile("koda_v_", ".mp4", context.cacheDir)
+                    audioTemp = File.createTempFile("koda_a_", ".m4a", context.cacheDir)
+
+                    videoTemp.outputStream().use { out ->
+                        downloadStream(request, chosen.url, out, 0.05f, 0.70f)
+                    }
+                    ensureActive()
+                    audioTemp.outputStream().use { out ->
+                        downloadStream(request, chosen.audioUrl, out, 0.70f, 0.88f)
+                    }
+                    ensureActive()
+
+                    updateProgress(request, 0.9f, DownloadStatus.DOWNLOADING)
+
+                    muxed = context.contentResolver.openFileDescriptor(target, "rw")?.use { pfd ->
+                        DownloadMuxer.mux(videoTemp, audioTemp, pfd.fileDescriptor)
+                    } ?: false
+
+                    if (!muxed) {
+                        Log.w(TAG, "Mux failed for ${request.title}, falling back to progressive")
                     }
                 }
+
+                if (!muxed) {
+                    val fallback = progressive
+                        ?: throw java.io.IOException("Mux failed and no progressive stream")
+                    // Re-create the row: a failed mux may have written a partial
+                    // container into the existing one.
+                    storage.delete(target)
+                    val retryTarget = storage.createPending(fileName, DownloadMediaType.VIDEO)
+                        ?: throw java.io.IOException("Could not recreate storage entry")
+                    pendingTarget = retryTarget
+
+                    storage.openOutput(retryTarget)?.use { out ->
+                        downloadStream(request, fallback.url, out, 0.1f, 1f)
+                    } ?: throw java.io.IOException("Could not open output")
+
+                    storage.publish(retryTarget)
+                    recordVideo(request, retryTarget, fallback.resolution)
+                    pendingTarget = null
+                } else {
+                    storage.publish(target)
+                    recordVideo(request, target, chosen.resolution)
+                    pendingTarget = null
+                }
+
+                finishSuccess(request)
+                true
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                cleanUpCancelled(request, pendingTarget)
+                throw e
+            } catch (e: Exception) {
+                pendingTarget?.let { storage.delete(it) }
+                throw e
+            } finally {
+                videoTemp?.delete()
+                audioTemp?.delete()
+                activeDownloadCalls.remove(request.id)
             }
+        }
 
-            Log.d(TAG, "Download complete for: ${song.title}")
+    /**
+     * Stream [url] into [out], reporting progress scaled into
+     * [fromFraction]..[toFraction] of the overall download. Throws on a
+     * truncated transfer so a short read is never published as a complete file.
+     */
+    private suspend fun downloadStream(
+        request: DownloadRequest,
+        url: String,
+        out: java.io.OutputStream,
+        fromFraction: Float,
+        toFraction: Float
+    ) {
+        val call = client.newCall(Request.Builder().url(url).build())
+        activeDownloadCalls[request.id] = call
 
-            // Create new song object pointing to local file
-            val downloadedSong = song.copy(
-                uri = Uri.fromFile(file),
-                source = SongSource.LOCAL
-            )
+        val response = call.execute()
+        if (!response.isSuccessful) {
+            response.close()
+            throw java.io.IOException("HTTP ${response.code}")
+        }
+        val body = response.body ?: throw java.io.IOException("Empty body")
 
-            // Update list
-            val currentList = _downloadedSongs.value.toMutableList()
-            currentList.add(downloadedSong)
-            _downloadedSongs.value = currentList
-            saveMetadata()
+        val totalBytes = body.contentLength()
+        var bytesDownloaded = 0L
+        val buffer = ByteArray(BUFFER_SIZE)
+        val span = toFraction - fromFraction
 
-            updateProgress(song.id, song, 1f, DownloadStatus.DOWNLOADED)
-            
-            // Remove from progress after a short delay
-            kotlinx.coroutines.delay(1000)
-            removeProgress(song.id)
+        body.byteStream().use { input ->
+            var read: Int
+            while (input.read(buffer).also { read = it } != -1) {
+                // Throws CancellationException if this task was cancelled,
+                // unwinding into the caller's handler.
+                kotlinx.coroutines.currentCoroutineContext().ensureActive()
 
-        } catch (e: java.io.IOException) {
-            // Check if this was a cancellation
-            if (!_downloadingIds.value.contains(song.id)) {
-                Log.d(TAG, "Download was cancelled for ${song.title}")
-                removeProgress(song.id)
-            } else {
-                Log.e(TAG, "Failed to download song ${song.title}", e)
-                updateProgress(song.id, song, 0f, DownloadStatus.FAILED)
+                out.write(buffer, 0, read)
+                bytesDownloaded += read
+
+                val fraction = if (totalBytes > 0) {
+                    fromFraction + (bytesDownloaded.toFloat() / totalBytes * span)
+                } else {
+                    fromFraction + span / 2f // Indeterminate
+                }
+                updateProgress(
+                    request, fraction, DownloadStatus.DOWNLOADING,
+                    bytesDownloaded, totalBytes
+                )
             }
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to download song ${song.title}", e)
-            updateProgress(song.id, song, 0f, DownloadStatus.FAILED)
-        } finally {
-            _downloadingIds.value = _downloadingIds.value - song.id
-            activeDownloadCalls.remove(song.id)
+        }
+
+        if (totalBytes > 0 && bytesDownloaded < totalBytes) {
+            throw java.io.IOException("Truncated: $bytesDownloaded/$totalBytes")
         }
     }
 
-    suspend fun downloadPlaylist(songs: List<Song>) {
-        _downloadQueue.value = songs.filter { !isDownloaded(it.id) }
-        
-        for (song in _downloadQueue.value) {
-            downloadSong(song)
-        }
-        
-        _downloadQueue.value = emptyList()
+    private fun recordVideo(request: DownloadRequest, uri: Uri, quality: String?) {
+        _downloadedVideos.value = _downloadedVideos.value + DownloadedVideo(
+            id = request.id,
+            title = request.title,
+            channelName = request.subtitle,
+            uri = uri,
+            thumbnailUrl = request.thumbnailUrl,
+            durationMs = request.durationMs,
+            quality = quality
+        )
+        saveVideoMetadata()
     }
 
+    private fun finishSuccess(request: DownloadRequest) {
+        updateProgress(request, 1f, DownloadStatus.DOWNLOADED)
+        _downloadingIds.value = _downloadingIds.value - request.id
+        removeProgressAfterCompletion(request.id)
+        Log.d(TAG, "Downloaded ${request.title}")
+    }
+
+    /**
+     * NonCancellable: the job is already cancelled, so a plain suspend cleanup
+     * here would itself be cancelled and leak the pending row.
+     */
+    private suspend fun cleanUpCancelled(request: DownloadRequest, pendingTarget: Uri?) {
+        withContext(kotlinx.coroutines.NonCancellable) {
+            pendingTarget?.let { storage.delete(it) }
+            _downloadingIds.value = _downloadingIds.value - request.id
+            removeProgress(request.id)
+        }
+    }
+
+    /**
+     * Clear a finished download from the progress map after a beat, so the UI
+     * shows the completed state briefly instead of the row vanishing.
+     * Deliberately not tied to the task's job, which is about to end.
+     */
+    private fun removeProgressAfterCompletion(songId: String) {
+        repositoryScope.launch {
+            kotlinx.coroutines.delay(COMPLETION_LINGER_MS)
+            val entry = _downloadProgress.value[songId]
+            if (entry?.status == DownloadStatus.DOWNLOADED) {
+                val current = _downloadProgress.value.toMutableMap()
+                current.remove(songId)
+                _downloadProgress.value = current
+            }
+        }
+    }
+
+    /**
+     * Cancel a queued or in-flight download. Safe to call for an id that is
+     * neither.
+     */
     fun cancelDownload(songId: String) {
         Log.d(TAG, "Cancelling download for $songId")
-        
-        // Cancel the OkHttp call if active
-        activeDownloadCalls[songId]?.cancel()
-        activeDownloadCalls.remove(songId)
-        
-        // Remove from downloading set (this triggers the checks in downloadSong)
-        _downloadingIds.value = _downloadingIds.value - songId
-        removeProgress(songId)
-        
-        // Delete partial file if exists
-        val partialFile = File(musicDir, "${songId}.m4a")
-        if (partialFile.exists()) {
-            partialFile.delete()
+
+        repositoryScope.launch {
+            val wasQueued = queueMutex.withLock {
+                val before = _downloadQueue.value
+                val after = before.filterNot { it.id == songId }
+                _downloadQueue.value = after
+                before.size != after.size
+            }
+
+            if (!wasQueued && songId == activeId) {
+                // Cancel the HTTP call as well as the job: a blocking read on
+                // the socket will not notice job cancellation on its own.
+                activeDownloadCalls[songId]?.cancel()
+                activeJob?.cancel()
+            }
+
+            _downloadingIds.value = _downloadingIds.value - songId
+            removeProgress(songId)
         }
+    }
+
+    /** Cancel everything, queued and active. */
+    fun cancelAll() {
+        repositoryScope.launch {
+            val cleared = queueMutex.withLock {
+                val queued = _downloadQueue.value
+                _downloadQueue.value = emptyList()
+                queued
+            }
+            cleared.forEach { removeProgress(it.id) }
+            activeId?.let { id ->
+                activeDownloadCalls[id]?.cancel()
+                activeJob?.cancel()
+                removeProgress(id)
+            }
+            _downloadingIds.value = emptySet()
+        }
+    }
+
+    /** Re-queue a download that previously failed. */
+    fun retryDownload(request: DownloadRequest) {
+        repositoryScope.launch {
+            removeProgress(request.id)
+            enqueue(listOf(request))
+        }
+    }
+
+    /** Delete a completed video download. */
+    fun deleteVideoDownload(videoId: String) {
+        val current = _downloadedVideos.value
+        val video = current.find { it.id == videoId } ?: return
+        storage.delete(video.uri)
+        _downloadedVideos.value = current - video
+        saveVideoMetadata()
     }
 
     fun deleteDownload(songId: String) {
         val currentList = _downloadedSongs.value.toMutableList()
         val songToDelete = currentList.find { it.id == songId } ?: return
 
-        songToDelete.uri?.path?.let { path ->
-            File(path).delete()
+        songToDelete.uri?.let { uri ->
+            if (uri.scheme == "file") {
+                // Legacy entry that never made it through migration.
+                uri.path?.let { File(it).delete() }
+            } else {
+                storage.delete(uri)
+            }
         }
 
         currentList.remove(songToDelete)
@@ -349,14 +930,23 @@ class DownloadRepository(private val context: Context) {
     }
     
     fun getDownloadStatus(songId: String): DownloadStatus {
-        if (_downloadingIds.value.contains(songId)) return DownloadStatus.DOWNLOADING
         if (isDownloaded(songId)) return DownloadStatus.DOWNLOADED
+        // The progress map distinguishes queued from in-flight from failed;
+        // downloadingIds only says "somewhere in the pipeline".
+        _downloadProgress.value[songId]?.let { return it.status }
+        if (_downloadingIds.value.contains(songId)) return DownloadStatus.QUEUED
         return DownloadStatus.NOT_DOWNLOADED
     }
     
+    /**
+     * A song the user already had on the device, as opposed to one Koda
+     * downloaded. Previously inferred from the file living outside filesDir,
+     * which stopped working once downloads moved to shared storage - our own
+     * downloads are outside filesDir now too. Membership in the downloaded set
+     * is the direct question.
+     */
     fun isLocalOriginal(song: Song): Boolean {
-        return song.source == SongSource.LOCAL && 
-               (song.uri?.path?.startsWith(context.filesDir.path) == false)
+        return song.source == SongSource.LOCAL && !isDownloaded(song.id)
     }
 
     fun clearFailedDownloads() {

--- a/app/src/main/java/com/ivor/ivormusic/data/DownloadRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/DownloadRepository.kt
@@ -405,7 +405,10 @@ class DownloadRepository private constructor(private val context: Context) {
             DownloadStatus.DOWNLOADED -> notificationHelper.showDownloadComplete(
                 songId = request.id,
                 songTitle = request.title,
-                artistName = request.subtitle
+                artistName = request.subtitle,
+                // Already in memory from the progress notification, which spent
+                // the whole download displaying it.
+                artwork = NotificationArtworkLoader.cached(request.thumbnailUrl)
             )
             DownloadStatus.FAILED -> notificationHelper.showDownloadFailed(
                 songId = request.id,

--- a/app/src/main/java/com/ivor/ivormusic/data/DownloadStorage.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/DownloadStorage.kt
@@ -1,0 +1,187 @@
+package com.ivor.ivormusic.data
+
+import android.content.ContentUris
+import android.content.ContentValues
+import android.content.Context
+import android.net.Uri
+import android.os.Environment
+import android.provider.MediaStore
+import android.util.Log
+import java.io.OutputStream
+
+/**
+ * Where a download lands in the user's shared storage.
+ *
+ * Both live under the public Downloads directory so they show up in the Files
+ * app as Downloads > Koda > Music / Video. [Environment.DIRECTORY_DOWNLOADS] is
+ * the string "Download" (singular) even though Files displays it as "Downloads"
+ * - do not spell it out by hand.
+ */
+enum class DownloadMediaType(
+    val folderName: String,
+    val mimeType: String,
+    val extension: String
+) {
+    MUSIC("Music", "audio/mp4", "m4a"),
+    VIDEO("Video", "video/mp4", "mp4");
+
+    val relativePath: String
+        get() = "${Environment.DIRECTORY_DOWNLOADS}/Koda/$folderName"
+}
+
+/**
+ * Writes downloads into shared storage through MediaStore so they are visible
+ * and manageable in the Files app, rather than hidden in the app's private
+ * filesDir.
+ *
+ * Consequences worth knowing about, because they shape the repository:
+ *  - the user can delete these files behind our back, so stored metadata must
+ *    be reconciled against MediaStore rather than trusted,
+ *  - files survive uninstall,
+ *  - no storage permission is needed for entries this app created (API 29+),
+ *    which is why this never touches MANAGE_EXTERNAL_STORAGE.
+ *
+ * Writes go out as IS_PENDING and are only published on success, so a partial
+ * transfer never appears in the Files app as a playable file.
+ */
+class DownloadStorage(private val context: Context) {
+
+    companion object {
+        private const val TAG = "DownloadStorage"
+
+        /** Characters that are illegal in FAT/exFAT names, plus control chars. */
+        private val ILLEGAL_FILENAME_CHARS = Regex("""[\\/:*?"<>|\x00-\x1F]""")
+
+        /**
+         * Cap on the name portion. Most Android volumes are exFAT with a 255
+         * byte limit; multi-byte titles can blow past that well before 255
+         * characters, so this stays conservative.
+         */
+        private const val MAX_NAME_LENGTH = 100
+    }
+
+    private val resolver get() = context.contentResolver
+
+    private val collection: Uri
+        get() = MediaStore.Downloads.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+
+    /**
+     * Turn a title/artist into something safe and readable on disk. These names
+     * are user-facing now, so "Blinding Lights - The Weeknd.m4a" beats the old
+     * "<videoId>.m4a".
+     */
+    fun buildFileName(title: String, artist: String, type: DownloadMediaType): String {
+        val base = if (artist.isBlank()) title else "$title - $artist"
+        val safe = ILLEGAL_FILENAME_CHARS.replace(base, "")
+            .replace(Regex("""\s+"""), " ")
+            .trim()
+            .trim('.')
+            .take(MAX_NAME_LENGTH)
+            .trim()
+            .ifBlank { "Koda download" }
+        return "$safe.${type.extension}"
+    }
+
+    /**
+     * Create a pending entry and return its URI, or null if MediaStore refused.
+     * The file stays invisible to other apps until [publish].
+     */
+    fun createPending(displayName: String, type: DownloadMediaType): Uri? {
+        return try {
+            val values = ContentValues().apply {
+                put(MediaStore.MediaColumns.DISPLAY_NAME, displayName)
+                put(MediaStore.MediaColumns.MIME_TYPE, type.mimeType)
+                put(MediaStore.MediaColumns.RELATIVE_PATH, type.relativePath)
+                put(MediaStore.MediaColumns.IS_PENDING, 1)
+            }
+            resolver.insert(collection, values)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to create MediaStore entry for $displayName", e)
+            null
+        }
+    }
+
+    fun openOutput(uri: Uri): OutputStream? {
+        return try {
+            resolver.openOutputStream(uri)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to open output for $uri", e)
+            null
+        }
+    }
+
+    /** Clear IS_PENDING, making the file visible in the Files app. */
+    fun publish(uri: Uri) {
+        try {
+            val values = ContentValues().apply {
+                put(MediaStore.MediaColumns.IS_PENDING, 0)
+            }
+            resolver.update(uri, values, null, null)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to publish $uri", e)
+        }
+    }
+
+    /**
+     * Delete a download. Returns false when the row was already gone, which is
+     * a normal outcome if the user deleted it from the Files app.
+     */
+    fun delete(uri: Uri): Boolean {
+        return try {
+            resolver.delete(uri, null, null) > 0
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to delete $uri", e)
+            false
+        }
+    }
+
+    /**
+     * Whether the row still exists. Used to drop metadata for files the user
+     * removed outside the app.
+     */
+    fun exists(uri: Uri): Boolean {
+        return try {
+            resolver.query(
+                uri,
+                arrayOf(MediaStore.MediaColumns._ID),
+                null,
+                null,
+                null
+            )?.use { it.moveToFirst() } ?: false
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    /**
+     * Every published file this app owns under the given Koda folder, keyed by
+     * URI. Lets the repository reconcile in one query rather than probing each
+     * stored entry individually.
+     */
+    fun listExisting(type: DownloadMediaType): Map<Uri, String> {
+        val result = mutableMapOf<Uri, String>()
+        try {
+            resolver.query(
+                collection,
+                arrayOf(
+                    MediaStore.MediaColumns._ID,
+                    MediaStore.MediaColumns.DISPLAY_NAME
+                ),
+                "${MediaStore.MediaColumns.RELATIVE_PATH} LIKE ?",
+                arrayOf("${type.relativePath}%"),
+                null
+            )?.use { cursor ->
+                val idColumn = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns._ID)
+                val nameColumn =
+                    cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DISPLAY_NAME)
+                while (cursor.moveToNext()) {
+                    val uri = ContentUris.withAppendedId(collection, cursor.getLong(idColumn))
+                    result[uri] = cursor.getString(nameColumn) ?: ""
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to list ${type.relativePath}", e)
+        }
+        return result
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/data/NotificationArtworkLoader.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/NotificationArtworkLoader.kt
@@ -1,0 +1,78 @@
+package com.ivor.ivormusic.data
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import androidx.core.graphics.drawable.toBitmap
+import coil.imageLoader
+import coil.request.ImageRequest
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.util.Collections
+
+/**
+ * Fetches album/thumbnail artwork for notification large icons.
+ *
+ * Notifications are built synchronously - the foreground service has to be able
+ * to produce one immediately - but artwork arrives over the network. So loading
+ * is split: [cached] answers instantly with whatever is already in memory, and
+ * [load] fetches then lets the caller rebuild. A notification therefore appears
+ * at once with no icon and gains the artwork a moment later, rather than
+ * blocking on the image.
+ *
+ * Bitmaps are held in a tiny LRU-ish map. Notification icons are small and a
+ * download queue only touches a handful of items, so this is deliberately
+ * simpler than a real cache; Coil's own disk cache does the heavy lifting on
+ * repeat loads.
+ */
+object NotificationArtworkLoader {
+
+    /**
+     * Cap on the decoded icon. Android scales notification large icons down to
+     * roughly this anyway, and holding full-size album art would be wasteful.
+     */
+    private const val ICON_SIZE_PX = 256
+
+    private const val MAX_ENTRIES = 16
+
+    private val cache = Collections.synchronizedMap(
+        object : LinkedHashMap<String, Bitmap>(MAX_ENTRIES, 0.75f, true) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Bitmap>) =
+                size > MAX_ENTRIES
+        }
+    )
+
+    /** Whatever is already decoded for [url], without touching the network. */
+    fun cached(url: String?): Bitmap? = url?.let { cache[it] }
+
+    /**
+     * Fetch and decode [url], returning null on any failure - artwork is
+     * decoration, so a miss must never disturb the download itself.
+     */
+    suspend fun load(context: Context, url: String?): Bitmap? {
+        if (url.isNullOrBlank()) return null
+        cache[url]?.let { return it }
+
+        return withContext(Dispatchers.IO) {
+            try {
+                val request = ImageRequest.Builder(context)
+                    .data(url)
+                    .size(ICON_SIZE_PX, ICON_SIZE_PX)
+                    .allowHardware(false) // Hardware bitmaps cannot cross into a notification
+                    .build()
+
+                // The shared singleton loader, so this hits the same memory and
+                // disk cache the UI already filled rather than starting cold.
+                val drawable = context.imageLoader.execute(request).drawable
+                    ?: return@withContext null
+                val bitmap = (drawable as? BitmapDrawable)?.bitmap
+                    ?: drawable.toBitmap(ICON_SIZE_PX, ICON_SIZE_PX)
+
+                cache[url] = bitmap
+                bitmap
+            } catch (e: Exception) {
+                null
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
@@ -186,6 +186,19 @@ class ThemePreferences(context: Context) {
             VIDEO_QUALITY_AUTO, "2160p", "1440p", "1080p", "720p", "480p", "360p", "144p"
         )
         private const val DEFAULT_VIDEO_QUALITY = "1080p"
+
+        /**
+         * Video player session state that outlives a single video. Unlike the
+         * settings above these have no Settings UI and no StateFlow: nothing
+         * observes them reactively, they are read once when the player starts
+         * and written when the user changes them in the player itself.
+         */
+        private const val KEY_VIDEO_REPEAT = "video_repeat"
+        private const val KEY_VIDEO_BRIGHTNESS = "video_brightness"
+
+        /** Stored brightness sentinel meaning "never set, follow the system". */
+        const val VIDEO_BRIGHTNESS_UNSET = -1f
+
         private const val KEY_EXCLUDED_FOLDERS = "excluded_folders"
         private const val KEY_CACHE_ENABLED = "cache_enabled"
         private const val KEY_MAX_CACHE_SIZE_MB = "max_cache_size_mb"
@@ -557,6 +570,30 @@ class ThemePreferences(context: Context) {
     fun setDefaultVideoQuality(quality: String) {
         prefs.edit().putString(KEY_DEFAULT_VIDEO_QUALITY, quality).apply()
         _defaultVideoQuality.value = quality
+    }
+
+    /**
+     * Whether the video player loops the current video (repeat) instead of
+     * auto-playing the next related one. Sticks across videos and app
+     * restarts. Defaults to off, i.e. auto-play.
+     */
+    fun isVideoRepeatEnabled(): Boolean = prefs.getBoolean(KEY_VIDEO_REPEAT, false)
+
+    fun setVideoRepeatEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_VIDEO_REPEAT, enabled).apply()
+    }
+
+    /**
+     * Screen brightness (0..1) the user last dialed in with the fullscreen
+     * brightness drag, re-applied the next time a video goes fullscreen.
+     * [VIDEO_BRIGHTNESS_UNSET] means it was never set, so the window should
+     * keep following the system brightness.
+     */
+    fun getVideoBrightness(): Float =
+        prefs.getFloat(KEY_VIDEO_BRIGHTNESS, VIDEO_BRIGHTNESS_UNSET)
+
+    fun setVideoBrightness(value: Float) {
+        prefs.edit().putFloat(KEY_VIDEO_BRIGHTNESS, value.coerceIn(0f, 1f)).apply()
     }
 
     /**

--- a/app/src/main/java/com/ivor/ivormusic/service/DownloadService.kt
+++ b/app/src/main/java/com/ivor/ivormusic/service/DownloadService.kt
@@ -13,6 +13,7 @@ import androidx.core.content.ContextCompat
 import com.ivor.ivormusic.data.DownloadNotificationHelper
 import com.ivor.ivormusic.data.DownloadRepository
 import com.ivor.ivormusic.data.DownloadStatus
+import com.ivor.ivormusic.data.NotificationArtworkLoader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -70,6 +71,10 @@ class DownloadService : Service() {
     private lateinit var notificationHelper: DownloadNotificationHelper
     private var started = false
 
+    /** Artwork URLs already being fetched, so a fast progress stream does not
+     *  kick off the same load dozens of times. */
+    private val artworkRequested = mutableSetOf<String>()
+
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onCreate() {
@@ -104,6 +109,24 @@ class DownloadService : Service() {
                 progress.values.firstOrNull { it.status == DownloadStatus.DOWNLOADING } to queue.size
             }.collect { (active, queued) ->
                 if (active == null && queued == 0) return@collect
+
+                // Fetch artwork once per item, off the notification path. The
+                // first post for a song shows no icon; the fetch completes and
+                // the next progress update carries the album art. Kicking it off
+                // here rather than awaiting it keeps the foreground start
+                // immediate.
+                val artUrl = active?.request?.thumbnailUrl
+                if (artUrl != null && NotificationArtworkLoader.cached(artUrl) == null &&
+                    artworkRequested.add(artUrl)
+                ) {
+                    serviceScope.launch {
+                        NotificationArtworkLoader.load(this@DownloadService, artUrl)
+                        // Repost so the artwork lands even if this was the final
+                        // progress emission.
+                        refreshNotification()
+                    }
+                }
+
                 val notification = if (active != null) {
                     notificationHelper.buildProgressNotification(
                         songTitle = active.request.title,
@@ -112,7 +135,8 @@ class DownloadService : Service() {
                         bytesDownloaded = active.bytesDownloaded,
                         totalBytes = active.totalBytes,
                         queuedCount = queued,
-                        isVideo = active.request.isVideo
+                        isVideo = active.request.isVideo,
+                        artwork = NotificationArtworkLoader.cached(artUrl)
                     )
                 } else {
                     notificationHelper.buildProgressNotification(
@@ -150,7 +174,25 @@ class DownloadService : Service() {
             bytesDownloaded = active?.bytesDownloaded ?: 0,
             totalBytes = active?.totalBytes ?: 0,
             queuedCount = queued,
-            isVideo = active?.request?.isVideo ?: false
+            isVideo = active?.request?.isVideo ?: false,
+            artwork = NotificationArtworkLoader.cached(active?.request?.thumbnailUrl)
+        )
+    }
+
+    /**
+     * Repost the current state. Used when artwork finishes loading, since that
+     * may happen after the last progress emission.
+     */
+    private fun refreshNotification() {
+        val manager = NotificationManagerCompat.from(this)
+        if (!manager.areNotificationsEnabled()) return
+        val stillRunning = repository.downloadProgress.value.values.any {
+            it.status == DownloadStatus.DOWNLOADING
+        }
+        if (!stillRunning) return
+        manager.notify(
+            DownloadNotificationHelper.FOREGROUND_NOTIFICATION_ID,
+            buildCurrentNotification()
         )
     }
 

--- a/app/src/main/java/com/ivor/ivormusic/service/DownloadService.kt
+++ b/app/src/main/java/com/ivor/ivormusic/service/DownloadService.kt
@@ -1,0 +1,181 @@
+package com.ivor.ivormusic.service
+
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.ServiceCompat
+import androidx.core.content.ContextCompat
+import com.ivor.ivormusic.data.DownloadNotificationHelper
+import com.ivor.ivormusic.data.DownloadRepository
+import com.ivor.ivormusic.data.DownloadStatus
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+
+/**
+ * Keeps the process alive while downloads run.
+ *
+ * Transfers themselves live in [DownloadRepository], not here. Previously they
+ * ran in whatever coroutine scope the caller happened to have - usually a
+ * ViewModel's - so navigating away or letting the screen go killed the transfer
+ * mid-file. The repository now owns a process-scoped worker, and this service
+ * exists so Android does not reclaim that process while the worker is busy.
+ *
+ * It is also the owner of the progress notification: a foreground service must
+ * present one, and having two competing progress notifications would be worse
+ * than one that retitles itself as the queue advances.
+ */
+class DownloadService : Service() {
+
+    companion object {
+        private const val TAG = "DownloadService"
+
+        /**
+         * Bring the service up. Safe to call repeatedly; Android collapses
+         * repeat starts onto the running instance.
+         *
+         * Failure is non-fatal by design: if the platform refuses a background
+         * foreground-service start, downloads still proceed in the repository's
+         * own scope. They simply lose the protection against the process being
+         * reclaimed, which beats crashing.
+         */
+        fun start(context: Context) {
+            val intent = Intent(context, DownloadService::class.java)
+            try {
+                ContextCompat.startForegroundService(context, intent)
+            } catch (e: Exception) {
+                Log.w(TAG, "Could not start download service: ${e.message}")
+            }
+        }
+
+        fun stop(context: Context) {
+            try {
+                context.stopService(Intent(context, DownloadService::class.java))
+            } catch (e: Exception) {
+                Log.w(TAG, "Could not stop download service: ${e.message}")
+            }
+        }
+    }
+
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private lateinit var repository: DownloadRepository
+    private lateinit var notificationHelper: DownloadNotificationHelper
+    private var started = false
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        repository = DownloadRepository.getInstance(this)
+        notificationHelper = DownloadNotificationHelper(this)
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // Must go foreground within a few seconds of being started, so post a
+        // notification from whatever state is available right now rather than
+        // waiting for the first progress emission.
+        promoteToForeground(buildCurrentNotification())
+
+        if (!started) {
+            started = true
+            observeProgress()
+        }
+
+        // Not sticky: a restarted service with no queue would show an empty
+        // notification. The repository is the thing that knows whether work
+        // remains, and it restarts the service itself when it does.
+        return START_NOT_STICKY
+    }
+
+    private fun observeProgress() {
+        serviceScope.launch {
+            combine(
+                repository.downloadProgress,
+                repository.downloadQueue
+            ) { progress, queue ->
+                progress.values.firstOrNull { it.status == DownloadStatus.DOWNLOADING } to queue.size
+            }.collect { (active, queued) ->
+                if (active == null && queued == 0) return@collect
+                val notification = if (active != null) {
+                    notificationHelper.buildProgressNotification(
+                        songTitle = active.request.title,
+                        artistName = active.request.subtitle,
+                        progress = active.progress,
+                        bytesDownloaded = active.bytesDownloaded,
+                        totalBytes = active.totalBytes,
+                        queuedCount = queued,
+                        isVideo = active.request.isVideo
+                    )
+                } else {
+                    notificationHelper.buildProgressNotification(
+                        songTitle = "Preparing downloads",
+                        artistName = "",
+                        progress = 0f,
+                        bytesDownloaded = 0,
+                        totalBytes = 0,
+                        queuedCount = queued
+                    )
+                }
+                // notify() rather than startForeground(): the service is already
+                // foreground and re-promoting on every percent would be wasteful.
+                if (NotificationManagerCompat.from(this@DownloadService)
+                        .areNotificationsEnabled()
+                ) {
+                    NotificationManagerCompat.from(this@DownloadService)
+                        .notify(
+                            DownloadNotificationHelper.FOREGROUND_NOTIFICATION_ID,
+                            notification
+                        )
+                }
+            }
+        }
+    }
+
+    private fun buildCurrentNotification(): android.app.Notification {
+        val active = repository.downloadProgress.value.values
+            .firstOrNull { it.status == DownloadStatus.DOWNLOADING }
+        val queued = repository.downloadQueue.value.size
+        return notificationHelper.buildProgressNotification(
+            songTitle = active?.request?.title ?: "Preparing downloads",
+            artistName = active?.request?.subtitle ?: "",
+            progress = active?.progress ?: 0f,
+            bytesDownloaded = active?.bytesDownloaded ?: 0,
+            totalBytes = active?.totalBytes ?: 0,
+            queuedCount = queued,
+            isVideo = active?.request?.isVideo ?: false
+        )
+    }
+
+    private fun promoteToForeground(notification: android.app.Notification) {
+        try {
+            ServiceCompat.startForeground(
+                this,
+                DownloadNotificationHelper.FOREGROUND_NOTIFICATION_ID,
+                notification,
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+                } else {
+                    0
+                }
+            )
+        } catch (e: Exception) {
+            // Android 12+ throws when a foreground start is not permitted from
+            // the background. The transfer continues regardless.
+            Log.w(TAG, "startForeground refused: ${e.message}")
+        }
+    }
+
+    override fun onDestroy() {
+        serviceScope.cancel()
+        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
+        super.onDestroy()
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/service/MusicService.kt
+++ b/app/src/main/java/com/ivor/ivormusic/service/MusicService.kt
@@ -143,7 +143,7 @@ class MusicService : MediaLibraryService() {
         // default; the size and toggle stay live via observePreferences().
         CacheManager.initialize(this, themePreferences.maxCacheSizeMb.value)
         youtubeRepository = YouTubeRepository(this)
-        downloadRepository = DownloadRepository(this)
+        downloadRepository = DownloadRepository.getInstance(this)
 
         // 2. Setup Notifications & Live Updates
         setMediaNotificationProvider(LiveUpdateMediaNotificationProvider(this))

--- a/app/src/main/java/com/ivor/ivormusic/ui/artist/AlbumScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/artist/AlbumScreen.kt
@@ -31,6 +31,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.rounded.Album
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -44,10 +46,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
@@ -65,7 +70,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
 import androidx.compose.material3.MaterialShapes
 import androidx.compose.material3.toShape
 import coil.compose.AsyncImage
@@ -167,10 +172,9 @@ fun AlbumScreen(
                         fontWeight = FontWeight.Bold,
                         color = textColor
                     )
-                    Text(
-                        "${songs.size} songs",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = secondaryTextColor
+                    DownloadAllButton(
+                        songs = songs,
+                        primaryColor = primaryColor
                     )
                 }
                 Spacer(modifier = Modifier.height(12.dp))
@@ -374,6 +378,68 @@ private fun AlbumHeroHeader(
                     )
                 }
             }
+        }
+    }
+}
+
+/**
+ * Queues every track that is not already downloaded.
+ *
+ * Reports how many are still outstanding rather than just firing and going
+ * quiet, since a playlist download is a long serial job and the count is the
+ * only feedback available from this screen.
+ */
+@Composable
+private fun DownloadAllButton(
+    songs: List<Song>,
+    primaryColor: Color
+) {
+    val context = LocalContext.current
+    val repository = remember(context) {
+        com.ivor.ivormusic.data.DownloadRepository.getInstance(context)
+    }
+    val scope = rememberCoroutineScope()
+
+    val downloadedSongs by repository.downloadedSongs.collectAsState()
+    val progressMap by repository.downloadProgress.collectAsState()
+
+    val downloadedIds = downloadedSongs.map { it.id }.toSet()
+    val pending = songs.count { it.id !in downloadedIds }
+    val activeHere = songs.count { progressMap.containsKey(it.id) }
+    val allDone = pending == 0 && songs.isNotEmpty()
+
+    Surface(
+        onClick = {
+            if (!allDone) scope.launch { repository.downloadPlaylist(songs) }
+        },
+        shape = RoundedCornerShape(20.dp),
+        color = if (allDone) Color.Transparent else primaryColor.copy(alpha = 0.12f)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = if (allDone) {
+                    Icons.Rounded.CheckCircle
+                } else {
+                    Icons.Rounded.Download
+                },
+                contentDescription = "Download all",
+                modifier = Modifier.size(18.dp),
+                tint = if (allDone) primaryColor else primaryColor
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            Text(
+                text = when {
+                    allDone -> "Downloaded"
+                    activeHere > 0 -> "Downloading $activeHere"
+                    else -> "Download all"
+                },
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold,
+                color = if (allDone) primaryColor else primaryColor
+            )
         }
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/downloads/DownloadsScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
@@ -37,6 +37,7 @@ import androidx.compose.material.icons.rounded.Videocam
 import androidx.compose.material3.ButtonGroupDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
@@ -55,9 +56,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.DownloadMediaType
@@ -70,6 +74,36 @@ import com.ivor.ivormusic.data.Song
 private enum class DownloadsTab(val label: String) {
     MUSIC("Music"),
     VIDEO("Video")
+}
+
+/** Outer radius of a connected group. Matches AlbumScreen's track list. */
+private val SEGMENT_CORNER = 28.dp
+
+/**
+ * Shape for one row of a connected list: only the group's outer corners are
+ * rounded, so consecutive rows read as a single container rather than a stack
+ * of separate cards. A lone item is rounded on all four.
+ */
+private fun segmentedShape(index: Int, count: Int): Shape = when {
+    count == 1 -> RoundedCornerShape(SEGMENT_CORNER)
+    index == 0 -> RoundedCornerShape(topStart = SEGMENT_CORNER, topEnd = SEGMENT_CORNER)
+    index == count - 1 -> RoundedCornerShape(
+        bottomStart = SEGMENT_CORNER,
+        bottomEnd = SEGMENT_CORNER
+    )
+    else -> RectangleShape
+}
+
+/**
+ * Hairline between connected rows, inset past the artwork so it aligns with the
+ * text column rather than cutting the whole row in half.
+ */
+@Composable
+private fun SegmentDivider(inset: Dp) {
+    HorizontalDivider(
+        modifier = Modifier.padding(start = inset),
+        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.06f)
+    )
 }
 
 /**
@@ -238,29 +272,39 @@ private fun MusicTab(
     onCancel: (String) -> Unit,
     onRetry: (DownloadRequest) -> Unit
 ) {
+    // No spacedBy: rows in a connected group sit flush and are separated by
+    // dividers, not gaps. Section spacing is added explicitly instead.
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+        contentPadding = PaddingValues(16.dp)
     ) {
         if (progress.isNotEmpty()) {
             item { SectionHeader("In progress") }
-            items(progress, key = { "p_${it.songId}" }) {
-                ProgressCard(it, onCancel = onCancel, onRetry = onRetry)
+            itemsIndexed(progress, key = { _, it -> "p_${it.songId}" }) { index, item ->
+                ProgressCard(
+                    item = item,
+                    shape = segmentedShape(index, progress.size),
+                    onCancel = onCancel,
+                    onRetry = onRetry
+                )
+                if (index < progress.lastIndex) SegmentDivider(inset = 46.dp)
             }
+            item { Spacer(modifier = Modifier.height(24.dp)) }
         }
 
         if (songs.isNotEmpty()) {
             item { SectionHeader("Downloaded") }
-            items(songs, key = { "s_${it.id}" }) { song ->
+            itemsIndexed(songs, key = { _, it -> "s_${it.id}" }) { index, song ->
                 DownloadedRow(
                     title = song.title,
                     subtitle = song.artist,
                     artworkUrl = song.thumbnailUrl ?: song.albumArtUri?.toString(),
                     fallbackIcon = Icons.Rounded.MusicNote,
+                    shape = segmentedShape(index, songs.size),
                     onPlay = { onPlayQueue(songs, song) },
                     onDelete = { onDelete(song.id) }
                 )
+                if (index < songs.lastIndex) SegmentDivider(inset = 74.dp)
             }
         }
 
@@ -281,19 +325,25 @@ private fun VideoTab(
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+        contentPadding = PaddingValues(16.dp)
     ) {
         if (progress.isNotEmpty()) {
             item { SectionHeader("In progress") }
-            items(progress, key = { "p_${it.songId}" }) {
-                ProgressCard(it, onCancel = onCancel, onRetry = onRetry)
+            itemsIndexed(progress, key = { _, it -> "p_${it.songId}" }) { index, item ->
+                ProgressCard(
+                    item = item,
+                    shape = segmentedShape(index, progress.size),
+                    onCancel = onCancel,
+                    onRetry = onRetry
+                )
+                if (index < progress.lastIndex) SegmentDivider(inset = 46.dp)
             }
+            item { Spacer(modifier = Modifier.height(24.dp)) }
         }
 
         if (videos.isNotEmpty()) {
             item { SectionHeader("Downloaded") }
-            items(videos, key = { "v_${it.id}" }) { video ->
+            itemsIndexed(videos, key = { _, it -> "v_${it.id}" }) { index, video ->
                 DownloadedRow(
                     title = video.title,
                     subtitle = listOfNotNull(video.channelName, video.quality)
@@ -301,10 +351,12 @@ private fun VideoTab(
                         .joinToString(" • "),
                     artworkUrl = video.thumbnailUrl,
                     fallbackIcon = Icons.Rounded.Videocam,
+                    shape = segmentedShape(index, videos.size),
                     wideArtwork = true,
                     onPlay = { onPlay(video) },
                     onDelete = { onDelete(video.id) }
                 )
+                if (index < videos.lastIndex) SegmentDivider(inset = 110.dp)
             }
         }
 
@@ -320,13 +372,14 @@ private fun SectionHeader(text: String) {
         text = text,
         style = MaterialTheme.typography.titleSmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(bottom = 2.dp)
+        modifier = Modifier.padding(start = 4.dp, bottom = 10.dp)
     )
 }
 
 @Composable
 private fun ProgressCard(
     item: DownloadProgress,
+    shape: Shape,
     onCancel: (String) -> Unit,
     onRetry: (DownloadRequest) -> Unit
 ) {
@@ -335,7 +388,7 @@ private fun ProgressCard(
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
+        shape = shape,
         color = MaterialTheme.colorScheme.surfaceContainer
     ) {
         Column(modifier = Modifier.padding(14.dp)) {
@@ -416,6 +469,7 @@ private fun DownloadedRow(
     subtitle: String,
     artworkUrl: String?,
     fallbackIcon: androidx.compose.ui.graphics.vector.ImageVector,
+    shape: Shape,
     onPlay: () -> Unit,
     onDelete: () -> Unit,
     wideArtwork: Boolean = false
@@ -423,9 +477,11 @@ private fun DownloadedRow(
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(16.dp))
+            // Clip before clickable so the ripple follows the segment shape
+            // instead of bleeding past the rounded corners.
+            .clip(shape)
             .clickable(onClick = onPlay),
-        shape = RoundedCornerShape(16.dp),
+        shape = shape,
         color = MaterialTheme.colorScheme.surfaceContainer
     ) {
         Row(

--- a/app/src/main/java/com/ivor/ivormusic/ui/downloads/DownloadsScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/downloads/DownloadsScreen.kt
@@ -1,374 +1,520 @@
 package com.ivor.ivormusic.ui.downloads
 
-import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.rounded.*
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.Download
+import androidx.compose.material.icons.rounded.ErrorOutline
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Schedule
+import androidx.compose.material.icons.rounded.Videocam
+import androidx.compose.material3.ButtonGroupDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.ToggleButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import com.ivor.ivormusic.data.DownloadMediaType
 import com.ivor.ivormusic.data.DownloadProgress
+import com.ivor.ivormusic.data.DownloadRequest
 import com.ivor.ivormusic.data.DownloadStatus
+import com.ivor.ivormusic.data.DownloadedVideo
 import com.ivor.ivormusic.data.Song
 
+private enum class DownloadsTab(val label: String) {
+    MUSIC("Music"),
+    VIDEO("Video")
+}
+
+/**
+ * Downloads library, split by media type.
+ *
+ * Music and video are genuinely different things - one feeds the queue, the
+ * other opens the video player - so they get separate tabs rather than one
+ * mixed list. In-flight transfers appear under the tab they belong to, so a
+ * video downloading while the Music tab is open is not silently invisible.
+ */
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun DownloadsScreen(
     downloadedSongs: List<Song>,
+    downloadedVideos: List<DownloadedVideo>,
     activeDownloads: Map<String, DownloadProgress>,
     onBack: () -> Unit,
     onPlaySong: (Song) -> Unit,
     onPlayQueue: (List<Song>, Song) -> Unit = { _, song -> onPlaySong(song) },
+    onPlayVideo: (DownloadedVideo) -> Unit,
     onDeleteDownload: (String) -> Unit,
+    onDeleteVideo: (String) -> Unit,
     onCancelDownload: (String) -> Unit,
-    onRetryDownload: (Song) -> Unit,
+    onRetryDownload: (DownloadRequest) -> Unit,
+    onCancelAll: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val primaryColor = MaterialTheme.colorScheme.primary
-    val surfaceColor = MaterialTheme.colorScheme.surface
-    val onSurfaceColor = MaterialTheme.colorScheme.onSurface
-    val onSurfaceVariantColor = MaterialTheme.colorScheme.onSurfaceVariant
+    var selectedTab by remember { mutableStateOf(DownloadsTab.MUSIC) }
+
+    // Split by the media type of the request itself rather than by which list
+    // the finished item lands in, so queued and failed entries route correctly
+    // before anything has completed.
+    val musicProgress = activeDownloads.values
+        .filter { it.request.type == DownloadMediaType.MUSIC }
+        .sortedBy { it.status.ordinal }
+    val videoProgress = activeDownloads.values
+        .filter { it.request.type == DownloadMediaType.VIDEO }
+        .sortedBy { it.status.ordinal }
+
+    val activeCount = activeDownloads.values.count {
+        it.status == DownloadStatus.DOWNLOADING || it.status == DownloadStatus.QUEUED
+    }
 
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { 
+                title = {
                     Column {
                         Text("Downloads")
                         Text(
-                            "${downloadedSongs.size} songs • ${activeDownloads.size} active",
+                            text = buildString {
+                                append("${downloadedSongs.size} songs")
+                                append(" • ${downloadedVideos.size} videos")
+                                if (activeCount > 0) append(" • $activeCount active")
+                            },
                             style = MaterialTheme.typography.bodySmall,
-                            color = onSurfaceVariantColor
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
                 },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    if (activeCount > 0) {
+                        TextButton(onClick = onCancelAll) { Text("Stop all") }
                     }
                 }
             )
         }
     ) { paddingValues ->
-        LazyColumn(
+        Column(
             modifier = modifier
                 .fillMaxSize()
-                .padding(paddingValues),
-            contentPadding = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+                .padding(paddingValues)
         ) {
-            // Active Downloads Section
-            if (activeDownloads.isNotEmpty()) {
-                item {
-                    Text(
-                        "Downloading",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold,
-                        color = onSurfaceColor
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                }
-
-                items(activeDownloads.values.toList(), key = { "active_${it.songId}" }) { progress ->
-                    ActiveDownloadCard(
-                        progress = progress,
-                        onCancel = { onCancelDownload(progress.songId) },
-                        onRetry = { onRetryDownload(progress.song) },
-                        primaryColor = primaryColor,
-                        onSurfaceColor = onSurfaceColor,
-                        onSurfaceVariantColor = onSurfaceVariantColor
-                    )
-                }
-
-                item {
-                    Spacer(modifier = Modifier.height(16.dp))
-                }
-            }
-
-            // Downloaded Songs Section
-            if (downloadedSongs.isNotEmpty()) {
-                item {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            "Downloaded",
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold,
-                            color = onSurfaceColor
-                        )
-                        Text(
-                            "${downloadedSongs.sumOf { it.duration / 1000 / 60 }} min",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = onSurfaceVariantColor
-                        )
+            // M3 Expressive connected button group, matching LibraryScreen's
+            // view switcher.
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween)
+            ) {
+                DownloadsTab.entries.forEachIndexed { index, tab ->
+                    val selected = selectedTab == tab
+                    val pending = if (tab == DownloadsTab.MUSIC) {
+                        musicProgress.size
+                    } else {
+                        videoProgress.size
                     }
-                    Spacer(modifier = Modifier.height(8.dp))
-                }
-
-                items(downloadedSongs, key = { "downloaded_${it.id}" }) { song ->
-                    DownloadedSongCard(
-                        song = song,
-                        onPlay = { onPlayQueue(downloadedSongs, song) },
-                        onDelete = { onDeleteDownload(song.id) },
-                        primaryColor = primaryColor,
-                        onSurfaceColor = onSurfaceColor,
-                        onSurfaceVariantColor = onSurfaceVariantColor
-                    )
-                }
-            }
-
-            // Empty State
-            if (downloadedSongs.isEmpty() && activeDownloads.isEmpty()) {
-                item {
-                    Box(
+                    ToggleButton(
+                        checked = selected,
+                        onCheckedChange = { selectedTab = tab },
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .height(300.dp),
-                        contentAlignment = Alignment.Center
+                            .weight(1f)
+                            .height(48.dp),
+                        shapes = when (index) {
+                            0 -> ButtonGroupDefaults.connectedLeadingButtonShapes()
+                            DownloadsTab.entries.lastIndex ->
+                                ButtonGroupDefaults.connectedTrailingButtonShapes()
+                            else -> ButtonGroupDefaults.connectedMiddleButtonShapes()
+                        },
+                        contentPadding = PaddingValues(horizontal = 8.dp)
                     ) {
-                        Column(
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.Center
-                        ) {
-                            Icon(
-                                Icons.Rounded.CloudDownload,
-                                contentDescription = null,
-                                modifier = Modifier.size(64.dp),
-                                tint = onSurfaceVariantColor.copy(alpha = 0.5f)
-                            )
-                            Spacer(modifier = Modifier.height(16.dp))
-                            Text(
-                                "No Downloads",
-                                style = MaterialTheme.typography.titleLarge,
-                                color = onSurfaceVariantColor
-                            )
-                            Spacer(modifier = Modifier.height(8.dp))
-                            Text(
-                                "Downloaded songs will appear here",
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = onSurfaceVariantColor.copy(alpha = 0.7f)
-                            )
-                        }
+                        Icon(
+                            imageVector = if (tab == DownloadsTab.MUSIC) {
+                                Icons.Rounded.MusicNote
+                            } else {
+                                Icons.Rounded.Videocam
+                            },
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = if (pending > 0) "${tab.label} ($pending)" else tab.label,
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium,
+                            maxLines = 1
+                        )
                     }
+                }
+            }
+
+            AnimatedContent(
+                targetState = selectedTab,
+                transitionSpec = {
+                    fadeIn(spring(stiffness = Spring.StiffnessMediumLow)) togetherWith
+                        fadeOut(spring(stiffness = Spring.StiffnessMediumLow))
+                },
+                label = "downloads_tab"
+            ) { tab ->
+                when (tab) {
+                    DownloadsTab.MUSIC -> MusicTab(
+                        songs = downloadedSongs,
+                        progress = musicProgress,
+                        onPlayQueue = onPlayQueue,
+                        onDelete = onDeleteDownload,
+                        onCancel = onCancelDownload,
+                        onRetry = onRetryDownload
+                    )
+
+                    DownloadsTab.VIDEO -> VideoTab(
+                        videos = downloadedVideos,
+                        progress = videoProgress,
+                        onPlay = onPlayVideo,
+                        onDelete = onDeleteVideo,
+                        onCancel = onCancelDownload,
+                        onRetry = onRetryDownload
+                    )
                 }
             }
         }
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun ActiveDownloadCard(
-    progress: DownloadProgress,
-    onCancel: () -> Unit,
-    onRetry: () -> Unit,
-    primaryColor: Color,
-    onSurfaceColor: Color,
-    onSurfaceVariantColor: Color
+private fun MusicTab(
+    songs: List<Song>,
+    progress: List<DownloadProgress>,
+    onPlayQueue: (List<Song>, Song) -> Unit,
+    onDelete: (String) -> Unit,
+    onCancel: (String) -> Unit,
+    onRetry: (DownloadRequest) -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        if (progress.isNotEmpty()) {
+            item { SectionHeader("In progress") }
+            items(progress, key = { "p_${it.songId}" }) {
+                ProgressCard(it, onCancel = onCancel, onRetry = onRetry)
+            }
+        }
+
+        if (songs.isNotEmpty()) {
+            item { SectionHeader("Downloaded") }
+            items(songs, key = { "s_${it.id}" }) { song ->
+                DownloadedRow(
+                    title = song.title,
+                    subtitle = song.artist,
+                    artworkUrl = song.thumbnailUrl ?: song.albumArtUri?.toString(),
+                    fallbackIcon = Icons.Rounded.MusicNote,
+                    onPlay = { onPlayQueue(songs, song) },
+                    onDelete = { onDelete(song.id) }
+                )
+            }
+        }
+
+        if (songs.isEmpty() && progress.isEmpty()) {
+            item { EmptyState("No downloaded music", Icons.Rounded.MusicNote) }
+        }
+    }
+}
+
+@Composable
+private fun VideoTab(
+    videos: List<DownloadedVideo>,
+    progress: List<DownloadProgress>,
+    onPlay: (DownloadedVideo) -> Unit,
+    onDelete: (String) -> Unit,
+    onCancel: (String) -> Unit,
+    onRetry: (DownloadRequest) -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        if (progress.isNotEmpty()) {
+            item { SectionHeader("In progress") }
+            items(progress, key = { "p_${it.songId}" }) {
+                ProgressCard(it, onCancel = onCancel, onRetry = onRetry)
+            }
+        }
+
+        if (videos.isNotEmpty()) {
+            item { SectionHeader("Downloaded") }
+            items(videos, key = { "v_${it.id}" }) { video ->
+                DownloadedRow(
+                    title = video.title,
+                    subtitle = listOfNotNull(video.channelName, video.quality)
+                        .filter { it.isNotBlank() }
+                        .joinToString(" • "),
+                    artworkUrl = video.thumbnailUrl,
+                    fallbackIcon = Icons.Rounded.Videocam,
+                    wideArtwork = true,
+                    onPlay = { onPlay(video) },
+                    onDelete = { onDelete(video.id) }
+                )
+            }
+        }
+
+        if (videos.isEmpty() && progress.isEmpty()) {
+            item { EmptyState("No downloaded videos", Icons.Rounded.Videocam) }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(bottom = 2.dp)
+    )
+}
+
+@Composable
+private fun ProgressCard(
+    item: DownloadProgress,
+    onCancel: (String) -> Unit,
+    onRetry: (DownloadRequest) -> Unit
+) {
+    val failed = item.status == DownloadStatus.FAILED
+    val queued = item.status == DownloadStatus.QUEUED
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer
+    ) {
+        Column(modifier = Modifier.padding(14.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = when {
+                        failed -> Icons.Rounded.ErrorOutline
+                        queued -> Icons.Rounded.Schedule
+                        else -> Icons.Rounded.Download
+                    },
+                    contentDescription = null,
+                    tint = if (failed) {
+                        MaterialTheme.colorScheme.error
+                    } else {
+                        MaterialTheme.colorScheme.primary
+                    },
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = item.request.title,
+                        style = MaterialTheme.typography.bodyLarge,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = when {
+                            failed -> "Failed"
+                            queued -> "Waiting"
+                            item.totalBytes > 0 -> "%.1f / %.1f MB".format(
+                                item.bytesDownloaded / (1024 * 1024f),
+                                item.totalBytes / (1024 * 1024f)
+                            )
+                            else -> "Preparing"
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = if (failed) {
+                            MaterialTheme.colorScheme.error
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        }
+                    )
+                }
+
+                if (failed) {
+                    IconButton(onClick = { onRetry(item.request) }) {
+                        Icon(Icons.Rounded.Refresh, contentDescription = "Retry")
+                    }
+                }
+                IconButton(onClick = { onCancel(item.songId) }) {
+                    Icon(Icons.Rounded.Close, contentDescription = "Cancel")
+                }
+            }
+
+            if (!failed) {
+                Spacer(modifier = Modifier.height(10.dp))
+                if (queued) {
+                    LinearProgressIndicator(
+                        modifier = Modifier.fillMaxWidth(),
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                } else {
+                    LinearProgressIndicator(
+                        progress = { item.progress.coerceIn(0f, 1f) },
+                        modifier = Modifier.fillMaxWidth(),
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DownloadedRow(
+    title: String,
+    subtitle: String,
+    artworkUrl: String?,
+    fallbackIcon: androidx.compose.ui.graphics.vector.ImageVector,
+    onPlay: () -> Unit,
+    onDelete: () -> Unit,
+    wideArtwork: Boolean = false
 ) {
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .animateContentSize(),
-        shape = RoundedCornerShape(20.dp),
-        color = MaterialTheme.colorScheme.surfaceContainerHigh,
-        tonalElevation = 2.dp
-    ) {
-        Column(
-            modifier = Modifier.padding(16.dp)
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                // Thumbnail
-                Surface(
-                    modifier = Modifier.size(56.dp),
-                    shape = RoundedCornerShape(12.dp),
-                    color = MaterialTheme.colorScheme.surfaceVariant
-                ) {
-                    AsyncImage(
-                        model = progress.song.thumbnailUrl ?: progress.song.albumArtUri,
-                        contentDescription = null,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .clip(RoundedCornerShape(12.dp)),
-                        contentScale = ContentScale.Crop
-                    )
-                }
-
-                Spacer(modifier = Modifier.width(12.dp))
-
-                // Song Info
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = progress.song.title,
-                        style = MaterialTheme.typography.bodyLarge,
-                        fontWeight = FontWeight.Medium,
-                        color = onSurfaceColor,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                    Text(
-                        text = progress.song.artist,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = onSurfaceVariantColor,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                    
-                    Spacer(modifier = Modifier.height(4.dp))
-                    
-                    // Status text
-                    Text(
-                        text = when (progress.status) {
-                            DownloadStatus.DOWNLOADING -> {
-                                if (progress.totalBytes > 0) {
-                                    "${(progress.bytesDownloaded / 1024 / 1024)}MB / ${(progress.totalBytes / 1024 / 1024)}MB"
-                                } else {
-                                    "Downloading..."
-                                }
-                            }
-                            DownloadStatus.FAILED -> "Failed - Tap to retry"
-                            else -> ""
-                        },
-                        style = MaterialTheme.typography.labelSmall,
-                        color = if (progress.status == DownloadStatus.FAILED) 
-                            MaterialTheme.colorScheme.error 
-                        else 
-                            primaryColor
-                    )
-                }
-
-                // Action Button
-                if (progress.status == DownloadStatus.FAILED) {
-                    IconButton(onClick = onRetry) {
-                        Icon(
-                            Icons.Rounded.Refresh,
-                            contentDescription = "Retry",
-                            tint = primaryColor
-                        )
-                    }
-                } else {
-                    IconButton(onClick = onCancel) {
-                        Icon(
-                            Icons.Rounded.Close,
-                            contentDescription = "Cancel",
-                            tint = onSurfaceVariantColor
-                        )
-                    }
-                }
-            }
-
-            // Progress Bar
-            if (progress.status == DownloadStatus.DOWNLOADING) {
-                Spacer(modifier = Modifier.height(12.dp))
-                LinearProgressIndicator(
-                    progress = { progress.progress },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(4.dp)
-                        .clip(RoundedCornerShape(2.dp)),
-                    color = primaryColor,
-                    trackColor = primaryColor.copy(alpha = 0.2f)
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun DownloadedSongCard(
-    song: Song,
-    onPlay: () -> Unit,
-    onDelete: () -> Unit,
-    primaryColor: Color,
-    onSurfaceColor: Color,
-    onSurfaceVariantColor: Color
-) {
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
+            .clip(RoundedCornerShape(16.dp))
+            .clickable(onClick = onPlay),
         shape = RoundedCornerShape(16.dp),
-        color = MaterialTheme.colorScheme.surfaceContainerLow,
-        onClick = onPlay
+        color = MaterialTheme.colorScheme.surfaceContainer
     ) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(12.dp),
+            modifier = Modifier.padding(10.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // Thumbnail
-            Surface(
-                modifier = Modifier.size(48.dp),
-                shape = RoundedCornerShape(10.dp),
-                color = MaterialTheme.colorScheme.surfaceVariant
+            Box(
+                modifier = Modifier
+                    .size(width = if (wideArtwork) 88.dp else 52.dp, height = 52.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+                contentAlignment = Alignment.Center
             ) {
-                AsyncImage(
-                    model = song.thumbnailUrl ?: song.albumArtUri,
+                if (!artworkUrl.isNullOrBlank()) {
+                    AsyncImage(
+                        model = artworkUrl,
+                        contentDescription = null,
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.Crop
+                    )
+                } else {
+                    Icon(
+                        imageVector = fallbackIcon,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(22.dp)
+                    )
+                }
+                Icon(
+                    imageVector = Icons.Rounded.PlayArrow,
                     contentDescription = null,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .clip(RoundedCornerShape(10.dp)),
-                    contentScale = ContentScale.Crop
+                    tint = MaterialTheme.colorScheme.surface,
+                    modifier = Modifier.size(24.dp)
                 )
             }
 
             Spacer(modifier = Modifier.width(12.dp))
 
-            // Song Info
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = song.title,
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.Medium,
-                    color = onSurfaceColor,
+                    text = title,
+                    style = MaterialTheme.typography.bodyLarge,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
-                Text(
-                    text = song.artist,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = onSurfaceVariantColor,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
+                if (subtitle.isNotBlank()) {
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
             }
 
-            // Downloaded icon
-            Icon(
-                Icons.Rounded.CheckCircle,
-                contentDescription = "Downloaded",
-                tint = primaryColor.copy(alpha = 0.7f),
-                modifier = Modifier.size(20.dp)
-            )
-
-            Spacer(modifier = Modifier.width(8.dp))
-
-            // Delete button
             IconButton(onClick = onDelete) {
                 Icon(
-                    Icons.Rounded.Delete,
+                    imageVector = Icons.Rounded.Delete,
                     contentDescription = "Delete",
-                    tint = onSurfaceVariantColor
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun EmptyState(
+    message: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 96.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+            modifier = Modifier.size(56.dp)
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
@@ -86,7 +86,7 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     val userName: StateFlow<String?> = _userName.asStateFlow()
 
     // Downloads
-    private val downloadRepository = com.ivor.ivormusic.data.DownloadRepository(application)
+    private val downloadRepository = com.ivor.ivormusic.data.DownloadRepository.getInstance(application)
     val downloadedSongs = downloadRepository.downloadedSongs
     val downloadingIds = downloadRepository.downloadingIds
     val downloadProgress = downloadRepository.downloadProgress

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
@@ -108,7 +108,7 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
     val likedSongIds: StateFlow<Set<String>> = likedSongsRepository.likedSongIds
     
     // Downloads
-    private val downloadRepository = com.ivor.ivormusic.data.DownloadRepository(context)
+    private val downloadRepository = com.ivor.ivormusic.data.DownloadRepository.getInstance(context)
     val downloadedSongs = downloadRepository.downloadedSongs
     val downloadingIds = downloadRepository.downloadingIds
     val downloadProgress = downloadRepository.downloadProgress
@@ -995,6 +995,31 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
     
     fun cancelDownload(songId: String) {
         downloadRepository.cancelDownload(songId)
+    }
+
+    /**
+     * Re-queue a failed download. Distinct from toggleDownload, which would
+     * treat the leftover failed entry as a fresh request and leave it in the
+     * progress list.
+     */
+    fun retryDownload(request: com.ivor.ivormusic.data.DownloadRequest) {
+        downloadRepository.retryDownload(request)
+    }
+
+    val downloadedVideos = downloadRepository.downloadedVideos
+    val downloadQueue = downloadRepository.downloadQueue
+
+    fun downloadVideo(video: com.ivor.ivormusic.data.VideoItem) {
+        viewModelScope.launch { downloadRepository.downloadVideo(video) }
+    }
+
+    fun deleteVideoDownload(videoId: String) {
+        downloadRepository.deleteVideoDownload(videoId)
+    }
+
+    /** Cancel every queued and in-flight download. */
+    fun cancelAllDownloads() {
+        downloadRepository.cancelAll()
     }
     
     fun deleteDownload(songId: String) {

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/SaveToPlaylistSheet.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/SaveToPlaylistSheet.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.foundation.LocalOverscrollFactory
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -39,6 +40,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -182,36 +184,41 @@ fun SaveToPlaylistSheet(
                     )
                 }
                 else -> {
-                    LazyColumn(
-                        modifier = Modifier.heightIn(max = 340.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        items(playlists, key = { it.playlistId }) { playlist ->
-                            SaveTargetRow(
-                                title = playlist.title,
-                                subtitle = playlist.videoCountText,
-                                state = rowState(playlist.playlistId),
-                                onClick = { save(playlist.playlistId) },
-                                leading = {
-                                    if (!playlist.thumbnailUrl.isNullOrBlank()) {
-                                        AsyncImage(
-                                            model = playlist.thumbnailUrl,
-                                            contentDescription = null,
-                                            modifier = Modifier
-                                                .size(44.dp)
-                                                .clip(RoundedCornerShape(12.dp)),
-                                            contentScale = ContentScale.Crop
-                                        )
-                                    } else {
-                                        Icon(
-                                            imageVector = Icons.AutoMirrored.Rounded.PlaylistPlay,
-                                            contentDescription = null,
-                                            tint = MaterialTheme.colorScheme.primary,
-                                            modifier = Modifier.size(24.dp)
-                                        )
+                    // No overscroll: the list is capped at 340dp inside the sheet,
+                    // so the default stretch deforms the rows in place (while the
+                    // sheet itself stays put) instead of reading as an edge effect.
+                    CompositionLocalProvider(LocalOverscrollFactory provides null) {
+                        LazyColumn(
+                            modifier = Modifier.heightIn(max = 340.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            items(playlists, key = { it.playlistId }) { playlist ->
+                                SaveTargetRow(
+                                    title = playlist.title,
+                                    subtitle = playlist.videoCountText,
+                                    state = rowState(playlist.playlistId),
+                                    onClick = { save(playlist.playlistId) },
+                                    leading = {
+                                        if (!playlist.thumbnailUrl.isNullOrBlank()) {
+                                            AsyncImage(
+                                                model = playlist.thumbnailUrl,
+                                                contentDescription = null,
+                                                modifier = Modifier
+                                                    .size(44.dp)
+                                                    .clip(RoundedCornerShape(12.dp)),
+                                                contentScale = ContentScale.Crop
+                                            )
+                                        } else {
+                                            Icon(
+                                                imageVector = Icons.AutoMirrored.Rounded.PlaylistPlay,
+                                                contentDescription = null,
+                                                tint = MaterialTheme.colorScheme.primary,
+                                                modifier = Modifier.size(24.dp)
+                                            )
+                                        }
                                     }
-                                }
-                            )
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoHomeContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoHomeContent.kt
@@ -172,7 +172,10 @@ fun VideoHomeContent(
     }
 
     ExpressivePullToRefresh(
-        isRefreshing = isLoading,
+        // Only let the pull-to-refresh spinner represent a refresh over existing
+        // content. The empty-feed case shows its own centered indicator below, and
+        // driving both off the same flag renders two spinners at once.
+        isRefreshing = isLoading && videos.isNotEmpty(),
         onRefresh = onRefresh,
         modifier = Modifier.fillMaxSize()
     ) {

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -56,8 +56,11 @@ import androidx.compose.material.icons.outlined.ThumbUp
 import androidx.compose.material.icons.rounded.Autorenew
 import androidx.compose.material.icons.rounded.BrightnessHigh
 import androidx.compose.material.icons.rounded.BrightnessLow
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.ClosedCaption
 import androidx.compose.material.icons.rounded.ClosedCaptionOff
+import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.Error
 import androidx.compose.material.icons.rounded.ExpandMore
 import androidx.compose.material.icons.rounded.Forward10
@@ -94,6 +97,8 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -132,6 +137,7 @@ import com.ivor.ivormusic.data.VideoChapter
 import com.ivor.ivormusic.data.VideoEngagement
 import com.ivor.ivormusic.data.VideoItem
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import java.util.Locale
 
 // VideoPlayerScreen function removed.
@@ -1193,6 +1199,7 @@ fun VideoInfoSection(
             )
             SaveVideoButton(onClick = onSaveClick)
             ShareVideoButton(video = video)
+            DownloadVideoButton(video = video)
         }
 
         // Channel Info Surface (tap navigates to the channel)
@@ -1473,6 +1480,73 @@ private fun SaveVideoButton(onClick: () -> Unit) {
             )
             Text(
                 text = "Save",
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+    }
+}
+
+/**
+ * Download pill. Queues the video into the shared download repository, which
+ * fetches the best MP4 video and audio streams and remuxes them into
+ * Downloads/Koda/Video. Reflects queued/downloading/downloaded state so the
+ * pill is not a fire-and-forget button.
+ */
+@Composable
+private fun DownloadVideoButton(video: VideoItem) {
+    val context = LocalContext.current
+    val repository = remember(context) {
+        com.ivor.ivormusic.data.DownloadRepository.getInstance(context)
+    }
+    val scope = rememberCoroutineScope()
+
+    val downloadedVideos by repository.downloadedVideos.collectAsState()
+    val progressMap by repository.downloadProgress.collectAsState()
+
+    val downloaded = downloadedVideos.any { it.id == video.videoId }
+    val progress = progressMap[video.videoId]
+    val inFlight = progress != null &&
+        (progress.status == com.ivor.ivormusic.data.DownloadStatus.DOWNLOADING ||
+            progress.status == com.ivor.ivormusic.data.DownloadStatus.QUEUED)
+
+    Surface(
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        onClick = {
+            when {
+                downloaded -> repository.deleteVideoDownload(video.videoId)
+                inFlight -> repository.cancelDownload(video.videoId)
+                else -> scope.launch { repository.downloadVideo(video) }
+            }
+        }
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 12.dp, bottom = 12.dp)
+        ) {
+            Icon(
+                imageVector = when {
+                    downloaded -> Icons.Rounded.CheckCircle
+                    inFlight -> Icons.Rounded.Close
+                    else -> Icons.Rounded.Download
+                },
+                contentDescription = "Download",
+                modifier = Modifier.size(20.dp),
+                tint = if (downloaded) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.onSurface
+                }
+            )
+            Text(
+                text = when {
+                    downloaded -> "Downloaded"
+                    inFlight -> "${((progress?.progress ?: 0f) * 100).toInt()}%"
+                    else -> "Download"
+                },
                 style = MaterialTheme.typography.labelLarge,
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurface

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -133,6 +133,7 @@ import coil.compose.AsyncImage
 import kotlin.math.abs
 import kotlin.math.roundToInt
 import com.ivor.ivormusic.data.LikeStatus
+import com.ivor.ivormusic.data.ThemePreferences
 import com.ivor.ivormusic.data.VideoChapter
 import com.ivor.ivormusic.data.VideoEngagement
 import com.ivor.ivormusic.data.VideoItem
@@ -823,10 +824,20 @@ private fun PlayerGestureSurface(
         }
     }
 
-    // The brightness gesture overrides the window brightness; hand control
-    // back to the system when the fullscreen surface goes away.
+    val themePreferences = remember(context) { ThemePreferences(context) }
+
+    // The brightness gesture overrides the window brightness: re-apply the
+    // level the user last dialed in so every fullscreen video looks the same,
+    // and hand control back to the system when the surface goes away (the rest
+    // of the app must not stay stuck at the video's brightness).
     if (fullscreenGesturesEnabled) {
         DisposableEffect(activity) {
+            activity?.let { act ->
+                val saved = themePreferences.getVideoBrightness()
+                if (saved != ThemePreferences.VIDEO_BRIGHTNESS_UNSET) {
+                    setWindowBrightness(act, saved.coerceAtLeast(0.01f))
+                }
+            }
             onDispose {
                 activity?.let { setWindowBrightness(it, WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE) }
             }
@@ -946,6 +957,13 @@ private fun PlayerGestureSurface(
                                     change.consume()
                                 }
                             }
+                        }
+                        // Persist once the finger lifts, not on every frame of
+                        // the drag. Volume is deliberately not stored: it is
+                        // the system STREAM_MUSIC level, which already carries
+                        // over on its own.
+                        if (mode == 1 && leftSide) {
+                            themePreferences.setVideoBrightness(level)
                         }
                     }
                 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
@@ -92,7 +92,9 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
 
     private var captionsLoadedForVideoId: String? = null
 
-    private val _isLooping = MutableStateFlow(false)
+    // Repeat sticks across videos and app restarts, so seed it from prefs
+    // rather than defaulting to off on every player creation.
+    private val _isLooping = MutableStateFlow(themePreferences.isVideoRepeatEnabled())
     val isLooping: StateFlow<Boolean> = _isLooping.asStateFlow()
 
     private val _playbackSpeed = MutableStateFlow(1f)
@@ -234,6 +236,10 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
             .setHandleAudioBecomingNoisy(true)
             .build().apply {
             playWhenReady = true
+            // Repeat is persisted, so a fresh player must adopt the stored
+            // mode: otherwise the toolbar shows the repeat icon while the
+            // player silently auto-plays the next video instead of looping.
+            repeatMode = if (_isLooping.value) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
             addListener(object : Player.Listener {
                 override fun onIsPlayingChanged(isPlaying: Boolean) {
                     _isPlaying.value = isPlaying
@@ -382,6 +388,7 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
     fun toggleLooping() {
         _isLooping.value = !_isLooping.value
         _exoPlayer?.repeatMode = if (_isLooping.value) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
+        themePreferences.setVideoRepeatEnabled(_isLooping.value)
     }
 
     /** Set the playback speed for the current video. Resets to 1x on video change. */


### PR DESCRIPTION
## Why

The download feature had a few structural problems that fed each other:

- **State didn't agree with itself.** All download state lives in per-instance `StateFlow`s, but `MusicService`, `HomeViewModel` and `PlayerViewModel` each constructed their own `DownloadRepository`. A download started from the home screen was invisible on the Downloads screen, and the finished song only appeared after an app restart.
- **Downloads died when you navigated away**, because transfers ran in the caller's coroutine scope.
- **Files were hidden** in `filesDir`, and completeness was inferred from `File.exists()` — which a truncated download satisfies just as well as a complete one.
- **`downloadPlaylist` was a stub**: a bare sequential loop with no queue state, no cancel, no failure handling.
- **No video download at all.**

## What changed

### Storage
Downloads now go to `Downloads/Koda/Music` and `Downloads/Koda/Video` via MediaStore, so they're visible in the Files app. Writes are `IS_PENDING` and only published on success, so a cancelled or failed transfer never appears as a playable file.

Existing downloads migrate on first launch — one file at a time, metadata rewritten after each, so an interrupted migration resumes rather than restarting. Copy-then-delete per file means peak extra disk is one file, not a duplicate library. Both entry shapes stay readable, which keeps the list working before, during and after the move.

### State and execution
`DownloadRepository` is a process-wide singleton with a **private constructor**, so the multi-instance divergence can't be reintroduced by calling the constructor again.

Transfers run in a process-scoped serial worker behind a `dataSync` foreground service. Cancellation is the task's own `Job` plus the OkHttp call — the call matters because a thread blocked reading a socket won't notice job cancellation. Previously `_downloadingIds` was both the state and the stop signal.

Failed attempts retry with backoff and **re-resolve the stream URL each time**, since a retry against an expired googlevideo link fails identically to the attempt before it. Added a truncation check so a short read throws instead of being published.

Progress emissions are throttled to whole-percent changes — which matters now that the screen actually receives them.

### Video
`DownloadMuxer` joins the best MP4 video and audio streams with `MediaMuxer`. YouTube only serves a single ready-made file at 360p, so remuxing is what makes a watchable download possible. It's a container copy, not a transcode. Codecs the MP4 muxer rejects fall back to the progressive stream.

### Notifications
Live Updates now use the real `androidx.core` 1.17 APIs (`setRequestPromotedOngoing`, `NotificationCompat.ProgressStyle`) instead of reflecting into hidden methods inside silent `catch {}` blocks. Gated on a new setting *and* on `canPostPromotedNotifications()`, so the toggle can't claim a promotion the system has refused.

Note: the official guide shows `ProgressStyle.setProgress(max, progress, indeterminate)`. That signature doesn't exist — verified against `core-1.17.0.aar` with `javap`. It's `setProgress(int)`, and there is no `setProgressMax`; the maximum is the sum of the segment lengths.

### UI
Downloads screen gains Music/Video tabs on an Expressive connected button group, matching `LibraryScreen`'s view switcher. Download actions wired up from the video player and from an album's track list.

## Not done

- **No resume across process death.** Retry restarts the file. Real resume needs HTTP `Range` plus persisting which pending URI belongs to which download.
- **Downloaded videos open in the system player.** `VideoPlayerViewModel.playVideo` drives the two-phase InnerTube resolution and there's no stream to resolve for a local file; wiring local playback means bypassing a path that's deliberately tuned.
- `MANAGE_EXTERNAL_STORAGE` is still declared in the manifest and is now unnecessary.

## Testing

⚠️ **This has not been compiled or run.** The repo convention is not to build unprompted. Largest unverified surface is the rewritten engine, the new service, and the `MediaMuxer` code, which can really only be validated by running it — suggest `./gradlew compileDebugKotlin` then an actual music and video download on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
