### PR TITLE
Search radio, mini player play/pause, Live Update fix, and a rebuilt music home

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
 
     defaultConfig {
         applicationId = "com.ivor.ivormusic"
-        minSdk = 30
+        minSdk = 31
         targetSdk = 36
         versionCode = 21
         versionName = "4.3"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
 
     defaultConfig {
         applicationId = "com.ivor.ivormusic"
-        minSdk = 31
+        minSdk = 30
         targetSdk = 36
         versionCode = 21
         versionName = "4.3"

--- a/app/src/main/java/com/ivor/ivormusic/service/LiveUpdateMediaNotificationProvider.kt
+++ b/app/src/main/java/com/ivor/ivormusic/service/LiveUpdateMediaNotificationProvider.kt
@@ -34,7 +34,7 @@ class LiveUpdateMediaNotificationProvider(
     // entries for one feature.
     private val defaultProvider = DefaultMediaNotificationProvider.Builder(context)
         .setChannelId(MusicProgressLiveUpdate.CHANNEL_ID)
-        .setChannelNameResourceId(com.ivor.ivormusic.R.string.now_playing_channel_name)
+        .setChannelName(com.ivor.ivormusic.R.string.now_playing_channel_name)
         .build()
     
     companion object {

--- a/app/src/main/java/com/ivor/ivormusic/service/LiveUpdateMediaNotificationProvider.kt
+++ b/app/src/main/java/com/ivor/ivormusic/service/LiveUpdateMediaNotificationProvider.kt
@@ -28,13 +28,41 @@ class LiveUpdateMediaNotificationProvider(
     private val context: Context
 ) : MediaNotification.Provider {
     
-    private val defaultProvider = DefaultMediaNotificationProvider.Builder(context).build()
+    // Pointed at the same channel as MusicProgressLiveUpdate. Left to itself,
+    // DefaultMediaNotificationProvider creates its own "Now playing" channel,
+    // and the system notification settings screen lists two identical-looking
+    // entries for one feature.
+    private val defaultProvider = DefaultMediaNotificationProvider.Builder(context)
+        .setChannelId(MusicProgressLiveUpdate.CHANNEL_ID)
+        .setChannelNameResourceId(com.ivor.ivormusic.R.string.now_playing_channel_name)
+        .build()
     
     companion object {
         private const val TAG = "LiveUpdateMediaNotificationProvider"
 
         /** What NotificationCompat.setRequestPromotedOngoing writes. */
         private const val EXTRA_REQUEST_PROMOTED_ONGOING = "android.requestPromotedOngoing"
+
+        /**
+         * Remove the channel Media3 created for itself before we started
+         * sharing one. Without this an upgrading user still sees two "Now
+         * playing" entries in system settings - the shared one, plus the old
+         * one sitting there empty forever.
+         *
+         * Safe to call every start: deleting an absent channel is a no-op.
+         */
+        fun deleteLegacyMediaChannel(context: Context) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+            if (DefaultMediaNotificationProvider.DEFAULT_CHANNEL_ID ==
+                MusicProgressLiveUpdate.CHANNEL_ID
+            ) return
+            runCatching {
+                androidx.core.app.NotificationManagerCompat.from(context)
+                    .deleteNotificationChannel(
+                        DefaultMediaNotificationProvider.DEFAULT_CHANNEL_ID
+                    )
+            }
+        }
     }
     
     override fun createNotification(

--- a/app/src/main/java/com/ivor/ivormusic/service/MusicProgressLiveUpdate.kt
+++ b/app/src/main/java/com/ivor/ivormusic/service/MusicProgressLiveUpdate.kt
@@ -41,8 +41,13 @@ import com.ivor.ivormusic.data.ThemePreferences
 class MusicProgressLiveUpdate(private val context: Context) {
 
     companion object {
-        private const val CHANNEL_ID = "music_live_update"
-        private const val CHANNEL_NAME = "Now Playing"
+        /**
+         * Shared with the MediaStyle notification: [LiveUpdateMediaNotificationProvider]
+         * points Media3's DefaultMediaNotificationProvider at this id so the two
+         * playback notifications sit on one channel. Media3 otherwise creates
+         * its own, and system settings lists "Now playing" twice.
+         */
+        const val CHANNEL_ID = "music_live_update"
         private const val NOTIFICATION_ID = 9999
 
         /**
@@ -50,6 +55,37 @@ class MusicProgressLiveUpdate(private val context: Context) {
          * prepare-then-transfer split, so the bar is one full-width segment.
          */
         private const val PLAYBACK_SEGMENT = 100
+
+        /**
+         * Create the shared playback channel. Called unconditionally from
+         * MusicService.onCreate - not from this class's init - because the
+         * media notification needs the channel on every API level, while this
+         * class only exists on API 36+.
+         *
+         * Channel settings are frozen at creation, so getting silence right
+         * here is the only chance: a channel that ships with sound cannot be
+         * quietened by a later app update.
+         */
+        fun ensureChannel(context: Context) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                context.getString(R.string.now_playing_channel_name),
+                // Must stay above IMPORTANCE_MIN or the notification becomes
+                // ineligible for promotion to a Live Update. LOW is already
+                // silent; the explicit nulls below make that non-negotiable
+                // rather than a property of the importance constant.
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = "Shows what's currently playing"
+                setShowBadge(false)
+                setSound(null, null)
+                enableVibration(false)
+                enableLights(false)
+                lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+            }
+            NotificationManagerCompat.from(context).createNotificationChannel(channel)
+        }
     }
 
     private val notificationManager = NotificationManagerCompat.from(context)
@@ -63,24 +99,9 @@ class MusicProgressLiveUpdate(private val context: Context) {
     private var lastArtwork: android.graphics.Bitmap? = null
 
     init {
-        createNotificationChannel()
-    }
-
-    private fun createNotificationChannel() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(
-                CHANNEL_ID,
-                CHANNEL_NAME,
-                // Must stay above IMPORTANCE_MIN or the notification becomes
-                // ineligible for promotion to a Live Update.
-                NotificationManager.IMPORTANCE_LOW
-            ).apply {
-                description = "Shows what's currently playing"
-                setShowBadge(false)
-                lockscreenVisibility = Notification.VISIBILITY_PUBLIC
-            }
-            notificationManager.createNotificationChannel(channel)
-        }
+        // Idempotent: the service creates this too, before the media provider
+        // is installed. Harmless to repeat, and keeps this class usable alone.
+        ensureChannel(context)
     }
 
     /**
@@ -192,6 +213,9 @@ class MusicProgressLiveUpdate(private val context: Context) {
             .setLargeIcon(artwork)
             .setOngoing(true)
             .setOnlyAlertOnce(true)
+            // Belt and braces with the channel: a progress readout that ticks
+            // ~150 times a song must never make a sound.
+            .setSilent(true)
             .setContentIntent(contentIntent)
             .setCategory(NotificationCompat.CATEGORY_PROGRESS)
             .setPriority(NotificationCompat.PRIORITY_LOW)

--- a/app/src/main/java/com/ivor/ivormusic/service/MusicProgressLiveUpdate.kt
+++ b/app/src/main/java/com/ivor/ivormusic/service/MusicProgressLiveUpdate.kt
@@ -31,7 +31,12 @@ import com.ivor.ivormusic.data.ThemePreferences
  * chrome to hand someone who did not ask for it.
  *
  * Promotion is only ever a *request*; the system decides, so nothing here may
- * assume the chip actually appeared.
+ * assume the chip actually appeared. When it is refused this degrades to an
+ * ordinary progress notification in the shade rather than vanishing - the same
+ * fallback the download notification has always had. Gating the post on
+ * promotion instead is what made this feature look broken everywhere except a
+ * Pixel emulator: plenty of Android 16 builds answer false from
+ * [NotificationManagerCompat.canPostPromotedNotifications].
  */
 class MusicProgressLiveUpdate(private val context: Context) {
 
@@ -79,14 +84,28 @@ class MusicProgressLiveUpdate(private val context: Context) {
     }
 
     /**
-     * Whether a promoted playback notification can actually be posted right
+     * Whether the user has asked for the playback notification at all. The
+     * platform check lives inside [ThemePreferences.isLivePlaybackUpdatesEnabled].
+     *
+     * Deliberately separate from [canPostLiveUpdates]: this decides whether to
+     * *post*, that one only decides whether to ask for promotion.
+     */
+    private fun isEnabled(): Boolean = ThemePreferences.isLivePlaybackUpdatesEnabled(context)
+
+    /**
+     * Whether promotion to a status bar chip can actually be requested right
      * now: the user's in-app setting and the system-level permission both have
-     * to agree. The platform check lives inside
-     * [ThemePreferences.isLivePlaybackUpdatesEnabled].
+     * to agree.
+     *
+     * A false here must never suppress the notification itself - see
+     * [updateProgress]. Many Android 16 builds (OEM skins especially) report
+     * false from [NotificationManagerCompat.canPostPromotedNotifications], and
+     * gating the post on it meant playback showed nothing at all on those
+     * devices while downloads degraded gracefully to an ordinary progress
+     * notification.
      */
     fun canPostLiveUpdates(): Boolean =
-        ThemePreferences.isLivePlaybackUpdatesEnabled(context) &&
-            notificationManager.canPostPromotedNotifications()
+        isEnabled() && notificationManager.canPostPromotedNotifications()
 
     /**
      * Show or update the Live Update with current playback progress. A no-op
@@ -107,11 +126,14 @@ class MusicProgressLiveUpdate(private val context: Context) {
         // silhouette - so this is the only place the cover can appear.
         artwork: android.graphics.Bitmap? = null
     ) {
-        if (!canPostLiveUpdates()) {
+        if (!isEnabled()) {
             hide()
             return
         }
         if (durationMs <= 0) return
+        // Same guard DownloadService uses before its notify(): notifications
+        // switched off app-wide makes the post a silent no-op anyway.
+        if (!notificationManager.areNotificationsEnabled()) return
 
         val progress = ((currentPositionMs.toFloat() / durationMs) * 100).toInt().coerceIn(0, 100)
         val remainingMs = (durationMs - currentPositionMs).coerceAtLeast(0)
@@ -177,7 +199,10 @@ class MusicProgressLiveUpdate(private val context: Context) {
             // Colorized and promoted are mutually exclusive; a colorized
             // notification is silently refused promotion.
             .setColorized(false)
-            .setRequestPromotedOngoing(true)
+            // Requesting promotion is harmless when the system has it switched
+            // off; the compat layer drops it and this stays an ordinary
+            // progress notification in the shade. Matches the download path.
+            .setRequestPromotedOngoing(canPostLiveUpdates())
             .setShortCriticalText(chipText)
             .build()
 

--- a/app/src/main/java/com/ivor/ivormusic/service/MusicService.kt
+++ b/app/src/main/java/com/ivor/ivormusic/service/MusicService.kt
@@ -151,6 +151,12 @@ class MusicService : MediaLibraryService() {
         downloadRepository = DownloadRepository.getInstance(this)
 
         // 2. Setup Notifications & Live Updates
+        // Create the shared playback channel before the media provider is
+        // installed, so it exists with our settings (silent, no badge, public
+        // on the lock screen) rather than whatever Media3 would default to.
+        // Channel settings are immutable once created.
+        MusicProgressLiveUpdate.ensureChannel(this)
+        LiveUpdateMediaNotificationProvider.deleteLegacyMediaChannel(this)
         setMediaNotificationProvider(LiveUpdateMediaNotificationProvider(this))
         if (android.os.Build.VERSION.SDK_INT >= 36) {
             musicProgressLiveUpdate = MusicProgressLiveUpdate(this)

--- a/app/src/main/java/com/ivor/ivormusic/ui/components/MiniPlayer.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/components/MiniPlayer.kt
@@ -1,6 +1,7 @@
 package com.ivor.ivormusic.ui.components
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.fadeIn
@@ -9,7 +10,10 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -43,15 +47,18 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.Song
+import com.ivor.ivormusic.ui.player.rememberPlayerHaptics
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -65,6 +72,15 @@ fun MiniPlayerContent(
     onNextClick: () -> Unit,
     onClick: () -> Unit
 ) {
+    val playerHaptics = rememberPlayerHaptics()
+
+    // Toggling while a track is still resolving would call play() again rather
+    // than cancelling the pending start (togglePlayPause keys off isPlaying),
+    // so the artwork goes inert for exactly the window the play/pause button
+    // is replaced by the loading indicator. A tap then falls through to the
+    // pill's own onClick and expands, as it always did.
+    val artworkTogglesPlayback = !(isBuffering && playWhenReady)
+
     // Transparent: the ExpandablePlayer container draws the pill background.
     // A second opaque surface here created a visible "pill behind a pill"
     // (its own shadow + tonal tint), and its drag handler swallowed the
@@ -81,9 +97,35 @@ fun MiniPlayerContent(
                 .padding(8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // Album Art with Circular Progress Ring
+            // Album Art with Circular Progress Ring — doubles as the
+            // play/pause target, so the most-hit part of the pill toggles
+            // playback instead of only expanding the player.
+            val artworkInteraction = remember { MutableInteractionSource() }
+            val artworkPressed by artworkInteraction.collectIsPressedAsState()
+            val artworkScale by animateFloatAsState(
+                targetValue = if (artworkPressed) 0.92f else 1f,
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioMediumBouncy,
+                    stiffness = Spring.StiffnessMediumLow
+                ),
+                label = "miniArtworkScale"
+            )
+
             Box(
-                modifier = Modifier.size(52.dp),
+                modifier = Modifier
+                    .size(52.dp)
+                    .clip(CircleShape)
+                    .clickable(
+                        interactionSource = artworkInteraction,
+                        indication = null,
+                        enabled = artworkTogglesPlayback,
+                        onClickLabel = if (isPlaying) "Pause" else "Play",
+                        role = Role.Button,
+                        onClick = {
+                            playerHaptics.playPause(!isPlaying)
+                            onPlayPauseClick()
+                        }
+                    ),
                 contentAlignment = Alignment.Center
             ) {
                 val trackColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.2f)
@@ -114,10 +156,13 @@ fun MiniPlayerContent(
                     )
                 }
                 
-                // Album art thumbnail (slightly smaller to fit inside ring)
+                // Album art thumbnail (slightly smaller to fit inside ring).
+                // Only the cover springs on press — the ring is a progress
+                // readout and would read as a glitch if it scaled with it.
                 Box(
                     modifier = Modifier
                         .size(44.dp)
+                        .scale(artworkScale)
                         .clip(CircleShape)
                         .background(MaterialTheme.colorScheme.surfaceVariant),
                     contentAlignment = Alignment.Center
@@ -202,7 +247,11 @@ fun MiniPlayerContent(
                 }
             } else {
                 FilledIconButton(
-                    onClick = onPlayPauseClick,
+                    onClick = {
+                        // Same action as the artwork tap, so same feedback.
+                        playerHaptics.playPause(!isPlaying)
+                        onPlayPauseClick()
+                    },
                     modifier = Modifier.size(44.dp),
                     shapes = IconButtonDefaults.shapes(), // Bouncy shape morphing
                     colors = IconButtonDefaults.filledIconButtonColors(

--- a/app/src/main/java/com/ivor/ivormusic/ui/components/Skeleton.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/components/Skeleton.kt
@@ -1,0 +1,87 @@
+package com.ivor.ivormusic.ui.components
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Loading placeholders that stand in for content at its real size and shape.
+ *
+ * The point is that a screen's chrome - top bar, section titles, navigation -
+ * has nothing to wait for and should never be replaced by a spinner. Only the
+ * regions actually blocked on data get covered, and they keep their layout, so
+ * nothing jumps when the data lands.
+ *
+ * A slow alpha pulse rather than a travelling gradient: it reads as "not ready"
+ * without competing with the staggered entrance animations the real content
+ * plays on arrival. Time-driven, so tween rather than spring.
+ */
+private const val SKELETON_PULSE_MS = 900
+
+/**
+ * The shared pulse. Hoist this once per screen and pass it down so every
+ * placeholder breathes in step - separate transitions drift apart and the
+ * screen starts to twinkle.
+ */
+@Composable
+fun rememberSkeletonAlpha(): Float {
+    val transition = rememberInfiniteTransition(label = "skeletonPulse")
+    val alpha by transition.animateFloat(
+        initialValue = 0.28f,
+        targetValue = 0.62f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(SKELETON_PULSE_MS, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "skeletonAlpha"
+    )
+    return alpha
+}
+
+/**
+ * A single placeholder block. Size it with [modifier] to match whatever it is
+ * standing in for; [shape] should match too, so the swap to real content is a
+ * fill rather than a reflow.
+ */
+@Composable
+fun SkeletonBox(
+    modifier: Modifier = Modifier,
+    shape: Shape = RoundedCornerShape(16.dp),
+    alpha: Float = rememberSkeletonAlpha()
+) {
+    Box(
+        modifier = modifier
+            .clip(shape)
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = alpha))
+    )
+}
+
+/** Placeholder for a line of text, sized like the type it replaces. */
+@Composable
+fun SkeletonTextLine(
+    width: Dp,
+    height: Dp,
+    modifier: Modifier = Modifier,
+    alpha: Float = rememberSkeletonAlpha()
+) {
+    SkeletonBox(
+        modifier = modifier.size(width = width, height = height),
+        shape = RoundedCornerShape(height / 2),
+        alpha = alpha
+    )
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -21,9 +23,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowForward
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.LibraryMusic
 import androidx.compose.material.icons.filled.MoreVert
@@ -60,6 +65,7 @@ import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
@@ -67,7 +73,6 @@ import androidx.compose.material3.NavigationItemIconPosition
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.carousel.HorizontalMultiBrowseCarousel
-import androidx.compose.material3.carousel.HorizontalUncontainedCarousel
 import androidx.compose.material3.carousel.rememberCarouselState
 import androidx.compose.material3.carousel.CarouselState
 import androidx.compose.material3.HorizontalFloatingToolbar
@@ -97,6 +102,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -168,7 +174,12 @@ fun HomeScreen(
     
     // Use local songs or YouTube songs (which includes fallback search results if not logged in)
     val songs = if (loadLocalSongs) localSongs else youtubeSongs
-    
+
+    // Local play history, for the "Jump back in" rail. Free (a file read, no
+    // network), and refreshed whenever the Home tab comes back into view so a
+    // song played since the last look shows up.
+    val recentlyPlayed by viewModel.recentlyPlayed.collectAsState()
+
     val currentSong by playerViewModel.currentSong.collectAsState()
     val isPlaying by playerViewModel.isPlaying.collectAsState()
     val isBuffering by playerViewModel.isBuffering.collectAsState()
@@ -246,6 +257,13 @@ fun HomeScreen(
     // The Subscriptions/History tabs (2/3) only exist in video mode
     LaunchedEffect(videoMode) {
         if (!videoMode && selectedTab > 2) selectedTab = 0
+    }
+
+    // Re-read the history when Home becomes the active tab. Playback writes an
+    // entry only after 15s, so coming back from the player is exactly when the
+    // rail has something new to show.
+    LaunchedEffect(selectedTab, videoMode) {
+        if (selectedTab == 0 && !videoMode) viewModel.refreshRecentlyPlayed()
     }
 
     // Auth Dialog State
@@ -388,17 +406,23 @@ fun HomeScreen(
                                     modeToggleState = modeToggleState
                                 )
                             }
-                            // Music Mode: Show original content
-                            else if (isLoading && songs.isEmpty()) {
-                                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                                    LoadingIndicator(
-                                        modifier = Modifier.size(48.dp),
-                                        color = MaterialTheme.colorScheme.primary
-                                    )
-                                }
-                            } else {
+                            // Music Mode: Show original content. The first load
+                            // renders the real screen with placeholders in the
+                            // data-backed sections rather than a full-screen
+                            // spinner - the top bar, titles and nav have
+                            // nothing to wait for.
+                            else {
                                 YourMixContent(
                                     songs = songs,
+                                    isInitialLoading = isLoading && songs.isEmpty(),
+                                    recentlyPlayed = recentlyPlayed,
+                                    onRecentClick = { song ->
+                                        // Resume from the history rail: the
+                                        // recents are the queue, not the mix.
+                                        playerViewModel.playQueue(recentlyPlayed, song)
+                                        showPlayerSheet = true
+                                    },
+                                    onShowAllInLibrary = { selectedTab = 2 },
                                     onSongClick = { song ->
                                         playerViewModel.playQueue(songs, song)
                                         showPlayerSheet = true
@@ -440,6 +464,10 @@ fun HomeScreen(
                         onPlayQueue = { songList, song ->
                             // Use the visible song list (YouTube results or filtered local songs)
                             playerViewModel.playQueue(songList, song)
+                            showPlayerSheet = true
+                        },
+                        onPlayRadio = { song ->
+                            playerViewModel.playSongRadio(song)
                             showPlayerSheet = true
                         },
                         onVideoClick = { video ->
@@ -814,6 +842,22 @@ fun HomeScreen(
 @Composable
 fun YourMixContent(
     songs: List<Song>,
+    /**
+     * First load with nothing to show yet. The screen still renders in full;
+     * only the sections that are actually waiting on data are replaced by
+     * placeholders of the same size.
+     */
+    isInitialLoading: Boolean = false,
+    /** Local play history for the "Jump back in" rail. Empty for a new user. */
+    recentlyPlayed: List<Song> = emptyList(),
+    onRecentClick: (Song) -> Unit = {},
+    /**
+     * Carousels on a vertically-scrolling page need a way to reach every item
+     * without scrolling sideways; this backs the arrow button in each header.
+     * The Library tab is that page - it renders the same [songs] list
+     * vertically, plus its own recently-played rail.
+     */
+    onShowAllInLibrary: () -> Unit = {},
     onSongClick: (Song) -> Unit,
     onPlayClick: () -> Unit,
     onProfileClick: () -> Unit,
@@ -833,9 +877,16 @@ fun YourMixContent(
     val textColor = MaterialTheme.colorScheme.onBackground
     
     val isRefreshing by viewModel.isLoading.collectAsState()
-    
+
+    // One pulse shared by every placeholder on the screen, so they breathe in
+    // step instead of twinkling independently.
+    val skeletonAlpha = com.ivor.ivormusic.ui.components.rememberSkeletonAlpha()
+
     ExpressivePullToRefresh(
-        isRefreshing = isRefreshing,
+        // The refresh spinner is for a refresh the user asked for. On first
+        // load the placeholders already say "loading", and showing both reads
+        // as two competing indicators.
+        isRefreshing = isRefreshing && !isInitialLoading,
         onRefresh = { viewModel.refresh(excludedFolders, manualScan) },
         modifier = Modifier.fillMaxSize()
     ) {
@@ -864,12 +915,20 @@ fun YourMixContent(
                     alpha = if (visible) 1f else 0f
                     translationY = if (visible) 0f else 40f
                 }) {
-                    HeroSection(songs = songs, onPlayClick = onPlayClick, isDarkMode = isDarkMode)
+                    HeroSection(
+                        songs = songs,
+                        onPlayClick = onPlayClick,
+                        isDarkMode = isDarkMode,
+                        isLoading = isInitialLoading,
+                        skeletonAlpha = skeletonAlpha
+                    )
                 }
             }
-            
+
             item {
-                if (songs.isNotEmpty()) {
+                if (isInitialLoading) {
+                    OrganicSongLayoutSkeleton(skeletonAlpha = skeletonAlpha)
+                } else if (songs.isNotEmpty()) {
                     var visible by remember { mutableStateOf(false) }
                     LaunchedEffect(Unit) { kotlinx.coroutines.delay(200); visible = true }
                     Box(Modifier.graphicsLayer {
@@ -890,7 +949,21 @@ fun YourMixContent(
                     translationY = if (visible) 0f else 30f
                 }) {
                     Spacer(modifier = Modifier.height(32.dp))
-                    RecentAlbumsSection(songs = songs, onSongClick = onSongClick, isDarkMode = isDarkMode)
+                    if (isInitialLoading) {
+                        HomeCarouselSkeleton(
+                            title = "Recent Albums",
+                            itemWidth = 200.dp,
+                            itemHeight = 240.dp,
+                            skeletonAlpha = skeletonAlpha
+                        )
+                    } else {
+                        RecentAlbumsSection(
+                            songs = songs,
+                            onSongClick = onSongClick,
+                            isDarkMode = isDarkMode,
+                            onShowAll = onShowAllInLibrary
+                        )
+                    }
                 }
             }
             
@@ -901,8 +974,25 @@ fun YourMixContent(
                     alpha = if (visible) 1f else 0f
                     translationY = if (visible) 0f else 30f
                 }) {
-                    Spacer(modifier = Modifier.height(24.dp))
-                    QuickPicksSection(songs = songs, onSongClick = onSongClick, isDarkMode = isDarkMode)
+                    if (isInitialLoading) {
+                        Spacer(modifier = Modifier.height(24.dp))
+                        HomeCarouselSkeleton(
+                            title = "Jump back in",
+                            itemWidth = 140.dp,
+                            itemHeight = 140.dp,
+                            captionLines = true,
+                            skeletonAlpha = skeletonAlpha
+                        )
+                    } else if (recentlyPlayed.isNotEmpty()) {
+                        // Nothing to resume for a brand new user, and an empty
+                        // "Jump back in" is worse than no section at all.
+                        Spacer(modifier = Modifier.height(24.dp))
+                        JumpBackInSection(
+                            songs = recentlyPlayed,
+                            onSongClick = onRecentClick,
+                            onShowAll = onShowAllInLibrary
+                        )
+                    }
                 }
             }
             item { Spacer(modifier = Modifier.height(32.dp)) }
@@ -1034,13 +1124,16 @@ fun TopBarSection(
 fun HeroSection(
     songs: List<Song>,
     onPlayClick: () -> Unit,
-    isDarkMode: Boolean = true
+    isDarkMode: Boolean = true,
+    /** First load: the artist line has no data yet, the rest of this is static. */
+    isLoading: Boolean = false,
+    skeletonAlpha: Float = com.ivor.ivormusic.ui.components.rememberSkeletonAlpha()
 ) {
     val firstSong = songs.firstOrNull()
     val secondSong = songs.getOrNull(1)
     val textColor = MaterialTheme.colorScheme.onBackground
     val secondaryTextColor = MaterialTheme.colorScheme.onSurfaceVariant
-    
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -1063,16 +1156,27 @@ fun HeroSection(
             )
             
             Spacer(modifier = Modifier.height(8.dp))
-            
-            Text(
-                text = (firstSong?.artist.takeIf { !it.isNullOrBlank() && !it.startsWith("Unknown", ignoreCase = true) } ?: "Unknown Artist").let { artist ->
-                    (secondSong?.artist.takeIf { !it.isNullOrBlank() && !it.startsWith("Unknown", ignoreCase = true) })?.let { second -> "$artist, $second" } ?: artist
-                },
-                style = MaterialTheme.typography.bodyMedium.copy(fontSize = 14.sp),
-                color = secondaryTextColor,
-                maxLines = 1,
-                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
-            )
+
+            if (isLoading) {
+                // Same 20dp band the artist line occupies, so the title above
+                // and the layout below do not shift when the names arrive.
+                com.ivor.ivormusic.ui.components.SkeletonTextLine(
+                    width = 168.dp,
+                    height = 14.dp,
+                    modifier = Modifier.padding(vertical = 3.dp),
+                    alpha = skeletonAlpha
+                )
+            } else {
+                Text(
+                    text = (firstSong?.artist.takeIf { !it.isNullOrBlank() && !it.startsWith("Unknown", ignoreCase = true) } ?: "Unknown Artist").let { artist ->
+                        (secondSong?.artist.takeIf { !it.isNullOrBlank() && !it.startsWith("Unknown", ignoreCase = true) })?.let { second -> "$artist, $second" } ?: artist
+                    },
+                    style = MaterialTheme.typography.bodyMedium.copy(fontSize = 14.sp),
+                    color = secondaryTextColor,
+                    maxLines = 1,
+                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                )
+            }
         }
         
         // Right side - Large Play button with shape morphing
@@ -1091,6 +1195,120 @@ fun HeroSection(
                     contentDescription = "Play",
                     modifier = Modifier.size(IconButtonDefaults.largeIconSize)
                 )
+            }
+        }
+    }
+}
+
+/**
+ * [OrganicSongLayout] with the artwork not yet loaded: the same rotated pill
+ * and two circles, at the same sizes and offsets, so the collage does not
+ * rearrange itself when the songs arrive.
+ */
+@Composable
+private fun OrganicSongLayoutSkeleton(
+    skeletonAlpha: Float
+) {
+    BoxWithConstraints(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(480.dp)
+    ) {
+        if (maxWidth <= 0.dp || maxHeight <= 0.dp) return@BoxWithConstraints
+
+        val boxWidth = maxWidth
+        val boxHeight = maxHeight
+
+        com.ivor.ivormusic.ui.components.SkeletonBox(
+            modifier = Modifier
+                .width(260.dp)
+                .height(500.dp)
+                .align(Alignment.Center)
+                .offset(x = 0.dp, y = 30.dp)
+                .graphicsLayer { rotationZ = 30f },
+            shape = RoundedCornerShape(50),
+            alpha = skeletonAlpha
+        )
+
+        com.ivor.ivormusic.ui.components.SkeletonBox(
+            modifier = Modifier
+                .size(boxWidth * 0.29f)
+                .align(Alignment.TopStart)
+                .offset(x = boxWidth * 0.04f, y = boxHeight * 0.05f)
+                .graphicsLayer { rotationZ = -10f },
+            shape = CircleShape,
+            alpha = skeletonAlpha
+        )
+
+        com.ivor.ivormusic.ui.components.SkeletonBox(
+            modifier = Modifier
+                .size(boxWidth * 0.26f)
+                .align(Alignment.BottomEnd)
+                .offset(x = boxWidth * (-0.05f), y = 0.dp)
+                .graphicsLayer { rotationZ = 5f },
+            shape = CircleShape,
+            alpha = skeletonAlpha
+        )
+    }
+}
+
+/**
+ * Stand-in for one of the home carousels. The section title is real - it never
+ * depended on the data - and only the cards are placeholders.
+ *
+ * A plain Row rather than a carousel: the M3 carousels are driven by an item
+ * count and a scroll state that would be thrown away a moment later, and the
+ * user cannot meaningfully scroll placeholders anyway.
+ */
+@Composable
+private fun HomeCarouselSkeleton(
+    title: String,
+    itemWidth: Dp,
+    itemHeight: Dp,
+    skeletonAlpha: Float,
+    /** Quick Picks puts a title/artist under each card; Recent Albums does not. */
+    captionLines: Boolean = false
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp)
+        )
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState(), enabled = false)
+                .padding(horizontal = 20.dp),
+            horizontalArrangement = Arrangement.spacedBy(if (captionLines) 12.dp else 8.dp)
+        ) {
+            repeat(4) {
+                Column(modifier = Modifier.width(itemWidth)) {
+                    com.ivor.ivormusic.ui.components.SkeletonBox(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(itemHeight),
+                        // Matches the M3 carousel item radius the real cards use
+                        shape = RoundedCornerShape(28.dp),
+                        alpha = skeletonAlpha
+                    )
+                    if (captionLines) {
+                        Spacer(modifier = Modifier.height(10.dp))
+                        com.ivor.ivormusic.ui.components.SkeletonTextLine(
+                            width = itemWidth * 0.85f,
+                            height = 12.dp,
+                            alpha = skeletonAlpha
+                        )
+                        Spacer(modifier = Modifier.height(6.dp))
+                        com.ivor.ivormusic.ui.components.SkeletonTextLine(
+                            width = itemWidth * 0.55f,
+                            height = 10.dp,
+                            alpha = skeletonAlpha
+                        )
+                    }
+                }
             }
         }
     }
@@ -1374,6 +1592,7 @@ fun SearchContent(
     songs: List<Song>,
     onSongClick: (Song) -> Unit,
     onPlayQueue: (List<Song>, Song?) -> Unit = { _, song -> song?.let { onSongClick(it) } },
+    onPlayRadio: (Song) -> Unit = { song -> onPlayQueue(listOf(song), song) },
     onVideoClick: (VideoItem) -> Unit = {},
     onProfileClick: () -> Unit = {},
     contentPadding: PaddingValues,
@@ -1475,6 +1694,7 @@ fun SearchContent(
                     songs = songs,
                     onSongClick = onSongClick,
                     onPlayQueue = onPlayQueue,
+                    onPlayRadio = onPlayRadio,
                     onVideoClick = onVideoClick,
                     onArtistClick = { artistItem -> viewedArtist = artistItem },
                     onAlbumClick = { albumItem -> viewedPlaylist = albumItem },
@@ -1500,25 +1720,20 @@ fun SearchContent(
 fun RecentAlbumsSection(
     songs: List<Song>,
     onSongClick: (Song) -> Unit,
-    isDarkMode: Boolean = true
+    isDarkMode: Boolean = true,
+    onShowAll: (() -> Unit)? = null
 ) {
     if (songs.isEmpty()) return
-    
-    val textColor = MaterialTheme.colorScheme.onSurface
+
     val cardBgColor = MaterialTheme.colorScheme.surfaceContainerHigh
-    
+
     // We need at least one large, one medium, one small for full effect,
     // but the component handles fewer items gracefully.
     val state = rememberCarouselState { songs.size }
-    
+
     Column(modifier = Modifier.fillMaxWidth()) {
-        Text(
-            text = "Recent Albums",
-            style = MaterialTheme.typography.headlineSmall,
-            color = textColor,
-            modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp)
-        )
-        
+        HomeSectionHeader(title = "Recent Albums", onShowAll = onShowAll)
+
         HorizontalMultiBrowseCarousel(
             state = state,
             preferredItemWidth = 200.dp,
@@ -1531,7 +1746,9 @@ fun RecentAlbumsSection(
             val song = songs[index]
             Box(
                 modifier = Modifier
-                    .maskClip(MaterialTheme.shapes.medium)
+                    // 28dp is the M3 carousel item radius; shapes.medium (12dp)
+                    // made these read as generic cards.
+                    .maskClip(RoundedCornerShape(28.dp))
                     .background(cardBgColor)
                     .clickable { onSongClick(song) }
             ) {
@@ -1557,86 +1774,140 @@ fun RecentAlbumsSection(
     }
 }
 
+/**
+ * Section header for a horizontal shelf: the title, plus the arrow button
+ * Material requires so every item is reachable without scrolling sideways.
+ *
+ * [onShowAll] is nullable because the arrow is only honest when there is
+ * somewhere fuller to go.
+ */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-fun QuickPicksSection(
+private fun HomeSectionHeader(
+    title: String,
+    onShowAll: (() -> Unit)? = null
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 20.dp, end = 8.dp, top = 8.dp, bottom = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f)
+        )
+        if (onShowAll != null) {
+            // Default size on purpose: M3's own 40dp container carries a 48dp
+            // touch target, and pinning it smaller would break that.
+            FilledTonalIconButton(
+                onClick = onShowAll,
+                shapes = IconButtonDefaults.shapes()
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Rounded.ArrowForward,
+                    contentDescription = "Show all $title",
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+        }
+    }
+}
+
+/** Square artwork edge, and the rail's item width. */
+private val ARTWORK_SIZE = 140.dp
+
+/** Space between artwork and the first caption line. */
+private val CAPTION_GAP = 8.dp
+
+/**
+ * The user's own play history, newest first - the "resume what you were doing"
+ * rail. Distinct from the mix above it on purpose: this is the one section on
+ * the screen that is not a recommendation.
+ *
+ * A LazyRow of cards, not a carousel. Both M3 carousel layouts mask their items
+ * to a shrinking rect at the container edges, and that mask covers the whole
+ * item - so captions under the artwork get sliced mid-word ("Let Down" renders
+ * as "et Down"). Material's own guidance points here: if carousel items need
+ * real text, use a series of cards instead. Recent Albums above keeps the
+ * carousel because its items are pure artwork with nothing to clip.
+ */
+@Composable
+fun JumpBackInSection(
     songs: List<Song>,
     onSongClick: (Song) -> Unit,
-    isDarkMode: Boolean = true
+    onShowAll: (() -> Unit)? = null
 ) {
     if (songs.isEmpty()) return
-    
+
     val textColor = MaterialTheme.colorScheme.onSurface
     val secondaryTextColor = MaterialTheme.colorScheme.onSurfaceVariant
     val cardBgColor = MaterialTheme.colorScheme.surfaceContainerHigh
-    
-    val state = rememberCarouselState { songs.size }
-    
+
     Column(modifier = Modifier.fillMaxWidth()) {
-        Text(
-            text = "Quick Picks",
-            style = MaterialTheme.typography.headlineSmall,
-            color = textColor,
-            modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp)
-        )
-        
-        HorizontalUncontainedCarousel(
-            state = state,
-            itemWidth = 140.dp,
-            itemSpacing = 12.dp,
+        HomeSectionHeader(title = "Jump back in", onShowAll = onShowAll)
+
+        LazyRow(
+            modifier = Modifier.fillMaxWidth(),
             contentPadding = PaddingValues(horizontal = 20.dp),
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(210.dp)
-        ) { index ->
-            val song = songs[index]
-            Column(
-                 modifier = Modifier
-                    .width(140.dp)
-                    .clickable { onSongClick(song) }
-            ) {
-                // Song Image
-                Box(
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            items(songs, key = { "recent_${it.id}" }) { song ->
+                // No clip on this column: a rounded clip here is what rounds
+                // the corners off the caption text underneath the artwork.
+                // Only the artwork itself gets a shape.
+                Column(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .height(140.dp)
-                        .clip(RoundedCornerShape(16.dp))
-                        .background(cardBgColor)
+                        .width(ARTWORK_SIZE)
+                        .clickable { onSongClick(song) }
                 ) {
-                      if (song.albumArtUri != null || song.thumbnailUrl != null) {
-                        AsyncImage(
-                            model = song.highResThumbnailUrl ?: song.albumArtUri ?: song.thumbnailUrl,
-                            contentDescription = song.title,
-                            modifier = Modifier.fillMaxSize(),
-                            contentScale = ContentScale.Crop
-                        )
-                    } else {
-                        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                             Icon(
-                                imageVector = Icons.Rounded.MusicNote,
-                                contentDescription = null,
-                                tint = Color.Gray,
-                                modifier = Modifier.size(24.dp)
+                    Box(
+                        modifier = Modifier
+                            .size(ARTWORK_SIZE)
+                            .clip(RoundedCornerShape(28.dp))
+                            .background(cardBgColor)
+                    ) {
+                        if (song.albumArtUri != null || song.thumbnailUrl != null) {
+                            AsyncImage(
+                                model = song.highResThumbnailUrl ?: song.albumArtUri ?: song.thumbnailUrl,
+                                contentDescription = song.title,
+                                modifier = Modifier.fillMaxSize(),
+                                contentScale = ContentScale.Crop
                             )
+                        } else {
+                            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                                Icon(
+                                    imageVector = Icons.Rounded.MusicNote,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.size(24.dp)
+                                )
+                            }
                         }
                     }
+
+                    Spacer(modifier = Modifier.height(CAPTION_GAP))
+
+                    // No fixed row height: the column wraps its content, so the
+                    // captions grow with the user's font scale instead of being
+                    // cut off by a hardcoded carousel height.
+                    Text(
+                        text = song.title.takeIf { it.isNotBlank() && !it.startsWith("Unknown", ignoreCase = true) } ?: "Untitled Song",
+                        maxLines = 1,
+                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = textColor
+                    )
+                    Text(
+                        text = song.artist.takeIf { it.isNotBlank() && !it.startsWith("Unknown", ignoreCase = true) } ?: "Unknown Artist",
+                        maxLines = 1,
+                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = secondaryTextColor
+                    )
                 }
-                
-                Spacer(modifier = Modifier.height(8.dp))
-                
-                // Song Title
-                Text(
-                    text = song.title.takeIf { !it.isNullOrBlank() && !it.startsWith("Unknown", ignoreCase = true) } ?: "Untitled Song",
-                    maxLines = 1,
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = textColor
-                )
-                  Text(
-                    text = song.artist.takeIf { !it.isNullOrBlank() && !it.startsWith("Unknown", ignoreCase = true) } ?: "Unknown Artist",
-                    maxLines = 1,
-                    style = MaterialTheme.typography.labelMedium,
-                    color = secondaryTextColor
-                )
             }
         }
     }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
@@ -95,6 +95,10 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
     // Stats tracking
     private var lastRecordedSongId: String? = null
     private var playRecordingJob: Job? = null
+
+    // In-flight radio fill for the last playSongRadio() seed
+    private var radioJob: Job? = null
+    private var radioSeedId: String? = null
     
     // Flag to prevent listener from restoring song after clear
     private var isPlayerCleared = false
@@ -631,6 +635,67 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
         }
     }
     
+    /**
+     * Start a radio from [song]: play it right away, then fill the queue with
+     * YouTube's related-songs mix for that track (the same RDAMVM radio
+     * YouTube Music autoplays into).
+     *
+     * This is the right behaviour for a one-off tap — a search result or a
+     * pasted link — where the surrounding list is a set of same-titled matches
+     * rather than a real playlist, so queueing it means hearing the same song
+     * six times from six uploaders.
+     *
+     * Local songs have no radio to fetch, so they just play on their own; list
+     * playback for those still goes through [playQueue].
+     */
+    fun playSongRadio(song: Song) {
+        if (song.source != com.ivor.ivormusic.data.SongSource.YOUTUBE) {
+            playSong(song)
+            return
+        }
+
+        playQueue(listOf(song))
+
+        radioJob?.cancel()
+        // Claim the auto-queue slot synchronously: the media-item transition
+        // that playQueue() just triggered lands on the main thread after this
+        // returns and would otherwise fire its own continuation fetch for the
+        // same seed.
+        _isLoadingMore.value = true
+        radioSeedId = song.id
+        radioJob = viewModelScope.launch {
+            try {
+                var radio = youTubeRepository.getRelatedSongs(song.id)
+                    .filter { it.id != song.id }
+
+                // Radio came back empty (no /next mix, or the call failed):
+                // fall back to the taste-profile continuation so the user
+                // isn't left with a one-song queue.
+                if (radio.isEmpty()) {
+                    radio = recommendationEngine.getQueueContinuation(
+                        currentSong = song,
+                        excludeIds = setOf(song.id),
+                        limit = 20
+                    )
+                }
+
+                // Only extend if the user is still on this radio — a tap on
+                // something else while /next was in flight must not graft the
+                // old mix onto the new queue.
+                val queue = _currentQueue.value
+                if (radio.isNotEmpty() && queue.size == 1 && queue[0].id == song.id) {
+                    addToQueue(radio)
+                }
+            } catch (e: Exception) {
+                android.util.Log.e("PlayerViewModel", "Radio fetch failed for ${song.id}", e)
+            } finally {
+                // A cancelled predecessor must not release the flag it no
+                // longer owns — only the current seed clears it.
+                if (radioSeedId == song.id) _isLoadingMore.value = false
+            }
+        }
+    }
+
     /**
      * Jump to a song that is already in the queue without rebuilding the
      * player's timeline, so buffered and prefetched data is kept.

--- a/app/src/main/java/com/ivor/ivormusic/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/search/SearchScreen.kt
@@ -181,6 +181,12 @@ fun SearchScreen(
     songs: List<Song>,
     onSongClick: (Song) -> Unit,
     onPlayQueue: (List<Song>, Song) -> Unit = { _, song -> onSongClick(song) },
+    /**
+     * Play a single YouTube result and continue into its radio. Used instead of
+     * [onPlayQueue] for loose result lists, where the neighbouring entries are
+     * other uploads of the same title rather than a playlist worth queueing.
+     */
+    onPlayRadio: (Song) -> Unit = { song -> onPlayQueue(listOf(song), song) },
     onVideoClick: (VideoItem) -> Unit = {},
     onArtistClick: (ArtistItem) -> Unit = {},
     onAlbumClick: (PlaylistDisplayItem) -> Unit = {},
@@ -540,8 +546,7 @@ fun SearchScreen(
                                         if (videoMode) {
                                             onVideoClick(video)
                                         } else {
-                                            val song = video.toSong()
-                                            onPlayQueue(listOf(song), song)
+                                            onPlayRadio(video.toSong())
                                         }
                                     }
                                 )
@@ -1049,7 +1054,9 @@ fun SearchScreen(
                     itemsIndexed(youtubeResults) { index, song ->
                         SearchSongCard(
                             song = song,
-                            onClick = { onPlayQueue(youtubeResults, song) },
+                            // Radio, not the result list: the other hits are
+                            // usually the same track from other uploaders.
+                            onClick = { onPlayRadio(song) },
                             cardColor = cardColor,
                             textColor = textColor,
                             secondaryTextColor = secondaryTextColor,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,11 @@
 <resources>
     <string name="app_name">Koda</string>
+
+    <!--
+      Shared by the MediaStyle notification and the playback progress Live
+      Update. Media3's DefaultMediaNotificationProvider creates its own channel
+      unless pointed at this one, which is how the system settings screen ended
+      up listing "Now playing" twice.
+    -->
+    <string name="now_playing_channel_name">Now playing</string>
 </resources>


### PR DESCRIPTION
Four independent pieces of work, one commit each so they can be reviewed (or reverted) separately.

## Not compile-verified

Per `CLAUDE.md` I haven't run Gradle — nothing here has been built or run on a device. Worth an `installDebug` before merging; the home screen commit in particular touches a lot of layout.

## 1. Live playback updates now work off a Pixel emulator

Reported as "download Live Updates work, playback ones don't, on every device except the emulator."

Root cause is an asymmetry between the two paths. `DownloadNotificationHelper` uses the promotion check only to decide whether to *ask*:

```kotlin
.setRequestPromotedOngoing(canPostLiveUpdates())
```

`MusicProgressLiveUpdate` used it to decide whether to post **at all**. So wherever `canPostPromotedNotifications()` returns false — common on OEM Android 16 builds, and the chip UI itself landed in a Pixel QPR rather than the initial API 36 release — downloads degraded to an ordinary progress notification and playback rendered nothing.

Split into `isEnabled()` (post?) and `canPostLiveUpdates()` (request promotion?). Strictly additive: every case that posted before still posts.

**Known tradeoff:** on affected devices users now get a progress notification *alongside* the MediaStyle one. That's inherent to matching the download behaviour here, and the setting's "status bar chip" wording will overstate what they get.

**Still open:** the app requests promotion twice for one session — `LiveUpdateMediaNotificationProvider` stamps it on the MediaStyle notification and this one requests it too. Left alone deliberately: if what works on the emulator is the *media* notification's chip, removing it breaks the one working case.

## 2. Mini player artwork toggles playback

Largest target in the pill, previously only expanded the player. Same handler as the button, so state flows through the existing `isPlaying` StateFlow.

- Spring press-scale on the cover only — the progress ring is a readout, scaling it reads as a glitch.
- Inert while a track resolves, matching the window where the button becomes a spinner. `togglePlayPause()` keys off `isPlaying`, so a tap there would restart rather than cancel a pending play.
- Swipe-to-expand and swipe-to-dismiss still work from the artwork; `clickable` doesn't consume drag movement.
- Gave the existing button the haptic it was missing.

## 3. Search results start a radio

Tapping a search result queued the whole result list — six uploads of the same title in a row.

`playSongRadio()` plays the tap immediately, then fills from `getRelatedSongs()` (the `RDAMVM` `/next` mix), falling back to the taste-profile continuation if empty. Guards: only appends while the queue is still that seed, and claims the auto-queue flag synchronously so the transition listener doesn't duplicate the fetch.

Scoped to YouTube search results and the pasted-link hero. Local results, resolved playlists, Your Mix and Library still queue their list — those are real playlists.

## 4. Music home rebuilt

**Loading.** First load replaced the whole screen with a centred spinner, hiding the top bar, settings and nav — none of which wait on data. Now the real screen renders throughout with placeholders only where songs are missing. One shared alpha pulse so they breathe in step; pull-to-refresh suppressed during first load so there's one indicator rather than two.

**Redundancy.** Recent Albums, Quick Picks and the organic collage all rendered the same `songs` list. Quick Picks is replaced by **Jump back in**, backed by the play history `HomeViewModel` already builds for the Library — no network cost, genuinely different data, and it gives the screen a hierarchy: discover → browse → resume.

**Three M3 gaps closed:** carousels on a vertically-scrolling page now carry the required "show all" affordance; items use the 28dp carousel radius (was 12dp/16dp); down from three competing full-width shelves to two, leaving the collage as the clear hero.

**Jump back in is a LazyRow, not a carousel.** Both carousel layouts mask the whole item near the container edges, which sliced captions mid-word — "Let Down" rendered as "et Down". Material's guidance is to use a series of cards when items need real text. Recent Albums keeps its carousel; pure artwork, nothing to clip.

## Worth checking on device

- Two different search results tapped in quick succession — the second radio should win cleanly.
- Mini player: tap cover to pause, then swipe up from the cover to confirm expand still beats the tap.
- Jump back in captions at a raised system font scale.
- Fresh install: the mix and history overlap at first, since the first things you play *are* the mix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMzkb2GreXzeZyXAHaLkZJ
