### PR TITLE
Open shared YouTube links, and stop captions from reloading the video

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,23 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Koda** (repo dir `TheMusicApp`, package `com.ivor.ivormusic`) — an Android music & video player powered by YouTube Music, built entirely with Kotlin + Jetpack Compose using Material 3 Expressive. No official YouTube API keys: all data comes from NewPipe Extractor and direct InnerTube API calls.
 
+## How to work here (read before writing any code)
+
+This is a shipped consumer app with real users, not a scratch project. The bar is "would a person using this on their phone every day be happy with it", not "does it compile and satisfy the literal request". Put in the effort up front — the user should not have to come back and ask you to think about the experience.
+
+**Think the feature through before you touch a file.** For anything user-facing — a new screen, a control, a gesture, a setting, a fix that changes behaviour — work out first:
+
+- **The actual use case.** Who taps this, when, and what were they doing right before? A control that is technically correct but three taps deep, or that sits where the thumb cannot reach, has failed.
+- **The states.** Loading, empty, error, offline, signed out, single item, hundreds of items, very long titles, missing thumbnail, no artwork colors. Every one of these happens in this app constantly — YouTube fails, sessions expire, feeds come back empty. Handle them in the first pass, do not bolt them on later.
+- **What it does to what already exists.** Does it fight the mini-player, the video overlay, PiP, the nav bar, an open sheet, a landscape rotation, back-gesture handling? Does it break the signed-out path? Overlays and the tab system in this app are easy to break from a distance.
+- **Feel, not just function.** Motion, hit targets, haptics, whether state changes are legible. See the UI conventions section — springs for touch, M3 Expressive components, never a hardcoded color.
+
+**Ask before you build, not after.** If the request leaves a real design decision open — where something lives, what happens in a case the user did not mention, two reasonable behaviours with different feels — ask. A short question with two or three concrete options is always cheaper than an implementation that gets thrown away. Ask up front, in one batch, not drip-fed mid-implementation. Do not ask about things you can settle yourself by reading the code or following existing convention.
+
+**Say what you decided and what you did not do.** When you finish, briefly note the edge cases you handled, the assumptions you made, and anything you deliberately left out. If you shipped something you think is the wrong UX, say so plainly instead of quietly implementing it.
+
+**Do not do the minimum.** A "quick fix" that leaves the surrounding flow broken is not a fix. If the real problem is one layer below the reported symptom, fix it there and say why.
+
 ## Commands
 
 ```powershell

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,6 +114,13 @@ dependencies {
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.media3.exoplayer)
+    // DefaultMediaSourceFactory loads DashMediaSource / HlsMediaSource
+    // reflectively and throws "Module missing for content type" without these.
+    // Load-bearing: the NewPipe stream fallback returns a DASH manifest for
+    // some videos and an HLS URL for every live stream, so a video player
+    // without them dead-ends on "Source error" for exactly those.
+    implementation(libs.androidx.media3.exoplayer.dash)
+    implementation(libs.androidx.media3.exoplayer.hls)
     implementation(libs.androidx.media3.ui)
     implementation(libs.androidx.media3.session)
     implementation(libs.accompanist.permissions)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,10 +29,16 @@
         android:requestLegacyExternalStorage="true"
         android:enableOnBackInvokedCallback="true"
         android:theme="@style/Theme.App.Starting">
+        <!--
+            singleTop so a link shared while Koda is already open is delivered
+            to the running instance through onNewIntent, instead of stacking a
+            second MainActivity on top of the live players.
+        -->
         <activity
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
+            android:launchMode="singleTop"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|smallestScreenSize"
             android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustResize"
@@ -43,6 +49,56 @@
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <!--
+                Android's share sheet. A mime type is the only filter the
+                manifest can express, so Koda is offered for any shared text and
+                sorts out whether it holds a YouTube link at handling time.
+            -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+
+            <!--
+                "Open with" for YouTube links. Paths are constrained to what the
+                app can actually play, so Koda is not offered for channel or
+                account URLs it would only fail on. music.youtube.com links open
+                in the music player, the rest in the video player.
+            -->
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:scheme="http" />
+                <data android:host="youtu.be" />
+                <data android:pathPattern="/.*" />
+            </intent-filter>
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:scheme="http" />
+                <data android:host="youtube.com" />
+                <data android:host="www.youtube.com" />
+                <data android:host="m.youtube.com" />
+                <data android:host="music.youtube.com" />
+                <data android:pathPrefix="/watch" />
+                <data android:pathPrefix="/playlist" />
+                <data android:pathPrefix="/shorts/" />
+                <data android:pathPrefix="/live/" />
+                <data android:pathPrefix="/embed/" />
+                <data android:pathPrefix="/v/" />
             </intent-filter>
         </activity>
         

--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.ivor.ivormusic
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -14,6 +15,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.remember
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
@@ -37,11 +39,23 @@ import com.ivor.ivormusic.ui.theme.ThemeMode
 
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.ivor.ivormusic.ui.onboarding.OnboardingScreen
+import com.ivor.ivormusic.ui.share.PendingSharedLink
+import com.ivor.ivormusic.ui.share.SharedLinkHandler
+import com.ivor.ivormusic.ui.share.sharedLinkText
 
 class MainActivity : ComponentActivity() {
+
+    // A YouTube link shared or opened into Koda, picked up by SharedLinkHandler
+    // inside the composition. Snapshot state so a link arriving while the app is
+    // already running reaches the UI without restarting anything.
+    private var pendingSharedLink by androidx.compose.runtime.mutableStateOf<PendingSharedLink?>(null)
+    private var sharedLinkCounter = 0L
+
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
+
+        takeSharedLink(intent)
 
         // Remove splash instantly when ready — the AVD entrance animation is the show
         splashScreen.setOnExitAnimationListener { it.remove() }
@@ -101,6 +115,7 @@ class MainActivity : ComponentActivity() {
             IvorMusicTheme(darkTheme = isDarkTheme, colorPalette = colorPalette, amoledDark = amoledTheme) {
                 Box(modifier = Modifier.fillMaxSize()) {
                     MusicApp(
+                        pendingSharedLink = pendingSharedLink,
                         currentThemeMode = themeMode,
                         onThemeModeChange = { themeViewModel.setThemeMode(it) },
                         amoledTheme = amoledTheme,
@@ -173,10 +188,34 @@ class MainActivity : ComponentActivity() {
             }
         }
     }
+
+    /**
+     * A link shared into Koda while it was already running is delivered here
+     * rather than through a fresh onCreate, thanks to singleTop.
+     */
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        takeSharedLink(intent)
+    }
+
+    /**
+     * Pick up the YouTube link an intent carries, if it has one, and neutralize
+     * the intent so it cannot fire twice - the activity is recreated on theme
+     * and locale changes, and would otherwise replay the same link each time.
+     */
+    private fun takeSharedLink(intent: Intent?) {
+        val text = intent?.sharedLinkText() ?: return
+        intent.action = Intent.ACTION_MAIN
+        intent.data = null
+        intent.removeExtra(Intent.EXTRA_TEXT)
+        pendingSharedLink = PendingSharedLink(text, ++sharedLinkCounter)
+    }
 }
 
 @Composable
 fun MusicApp(
+    pendingSharedLink: PendingSharedLink?,
     currentThemeMode: ThemeMode,
     onThemeModeChange: (ThemeMode) -> Unit,
     amoledTheme: Boolean,
@@ -580,6 +619,23 @@ fun MusicApp(
         com.ivor.ivormusic.ui.shorts.ShortsPlayerOverlay(
             viewModel = shortsPlayerViewModel,
             hiddenActions = shortsHiddenActions
+        )
+
+        // Opens YouTube links shared into the app. Held back until onboarding
+        // is done, so a share cannot jump the first-run flow.
+        SharedLinkHandler(
+            pendingLink = pendingSharedLink,
+            enabled = onboardingCompleted,
+            localOnlyMode = localOnlyMode,
+            homeViewModel = homeViewModel,
+            playerViewModel = playerViewModel,
+            videoPlayerViewModel = videoPlayerViewModel,
+            onNavigateHome = {
+                navController.navigate("home") {
+                    popUpTo("home") { inclusive = false }
+                    launchSingleTop = true
+                }
+            }
         )
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -398,6 +398,32 @@ fun MusicApp(
         )
     }
 
+    // Keep the ViewModel's PiP flag current so it can suppress auto-play
+    // (advancing to the next video while in PiP means the user returns to
+    // a video they did not put there).
+    androidx.compose.runtime.LaunchedEffect(isInPipMode) {
+        videoPlayerViewModel.setInPipMode(isInPipMode)
+    }
+
+    // Opens YouTube links shared into the app. Composed above the PiP
+    // early return so its remembered deduplication token survives PiP
+    // transitions; disabled while in PiP so it does not try to navigate
+    // or start a new video inside the tiny window.
+    SharedLinkHandler(
+        pendingLink = pendingSharedLink,
+        enabled = onboardingCompleted && !isInPipMode,
+        localOnlyMode = localOnlyMode,
+        homeViewModel = homeViewModel,
+        playerViewModel = playerViewModel,
+        videoPlayerViewModel = videoPlayerViewModel,
+        onNavigateHome = {
+            navController.navigate("home") {
+                popUpTo("home") { inclusive = false }
+                launchSingleTop = true
+            }
+        }
+    )
+
     // In system PiP the app is just a video surface. Returning here keeps the
     // NavHost, both players and every overlay out of the composition entirely,
     // rather than letting them draw and animate behind a window nobody can see
@@ -689,22 +715,6 @@ fun MusicApp(
             hiddenActions = shortsHiddenActions
         )
 
-        // Opens YouTube links shared into the app. Held back until onboarding
-        // is done, so a share cannot jump the first-run flow.
-        SharedLinkHandler(
-            pendingLink = pendingSharedLink,
-            enabled = onboardingCompleted,
-            localOnlyMode = localOnlyMode,
-            homeViewModel = homeViewModel,
-            playerViewModel = playerViewModel,
-            videoPlayerViewModel = videoPlayerViewModel,
-            onNavigateHome = {
-                navController.navigate("home") {
-                    popUpTo("home") { inclusive = false }
-                    launchSingleTop = true
-                }
-            }
-        )
     }
 }
 

--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.ivor.ivormusic
 
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -39,6 +40,7 @@ import com.ivor.ivormusic.ui.theme.ThemeMode
 
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.ivor.ivormusic.ui.onboarding.OnboardingScreen
+import com.ivor.ivormusic.ui.video.enterPipMode
 import com.ivor.ivormusic.ui.share.PendingSharedLink
 import com.ivor.ivormusic.ui.share.SharedLinkHandler
 import com.ivor.ivormusic.ui.share.sharedLinkText
@@ -50,6 +52,18 @@ class MainActivity : ComponentActivity() {
     // already running reaches the UI without restarting anything.
     private var pendingSharedLink by androidx.compose.runtime.mutableStateOf<PendingSharedLink?>(null)
     private var sharedLinkCounter = 0L
+
+    // True while the app is in system Picture-in-Picture. Held here rather than
+    // inside the video overlay because the whole app has to stand down in PiP:
+    // the NavHost used to keep composing and animating behind the window, and
+    // any gap around the video showed app chrome instead of black.
+    private var isInPipMode by androidx.compose.runtime.mutableStateOf(false)
+
+    // Set by the video player so onUserLeaveHint can enter PiP with the right
+    // window shape on Android 11, where setAutoEnterEnabled does not exist.
+    private var pipVideoAspectRatio: Float? = null
+    private var pipVideoBounds: android.graphics.Rect? = null
+    private var pipEligible = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
@@ -116,6 +130,12 @@ class MainActivity : ComponentActivity() {
                 Box(modifier = Modifier.fillMaxSize()) {
                     MusicApp(
                         pendingSharedLink = pendingSharedLink,
+                        isInPipMode = isInPipMode,
+                        onPipStateChanged = { eligible, aspectRatio, bounds ->
+                            pipEligible = eligible
+                            pipVideoAspectRatio = aspectRatio
+                            pipVideoBounds = bounds
+                        },
                         currentThemeMode = themeMode,
                         onThemeModeChange = { themeViewModel.setThemeMode(it) },
                         amoledTheme = amoledTheme,
@@ -189,6 +209,29 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    override fun onPictureInPictureModeChanged(
+        isInPictureInPictureMode: Boolean,
+        newConfig: android.content.res.Configuration
+    ) {
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
+        isInPipMode = isInPictureInPictureMode
+    }
+
+    /**
+     * Entering PiP on the way out of the app.
+     *
+     * On API 31+ the system does this itself from setAutoEnterEnabled, which
+     * handles the gesture-nav swipe up as well and animates better, so this
+     * only covers Android 11 and 12 where that flag does not exist.
+     */
+    @Deprecated("Deprecated in Java")
+    override fun onUserLeaveHint() {
+        super.onUserLeaveHint()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) return
+        if (!pipEligible || isInPipMode) return
+        enterPipMode(this, pipVideoAspectRatio, pipVideoBounds)
+    }
+
     /**
      * A link shared into Koda while it was already running is delivered here
      * rather than through a fresh onCreate, thanks to singleTop.
@@ -216,6 +259,8 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun MusicApp(
     pendingSharedLink: PendingSharedLink?,
+    isInPipMode: Boolean,
+    onPipStateChanged: (eligible: Boolean, aspectRatio: Float?, bounds: android.graphics.Rect?) -> Unit,
     currentThemeMode: ThemeMode,
     onThemeModeChange: (ThemeMode) -> Unit,
     amoledTheme: Boolean,
@@ -338,6 +383,29 @@ fun MusicApp(
     val isVideoOverlayExpanded by videoPlayerViewModel.isExpanded.collectAsState()
     val hasVideoMiniPlayer = overlayVideo != null && !isVideoOverlayExpanded
     val musicPillVisible = playerViewModel.currentSong.collectAsState().value != null
+
+    // Keep the Activity's PiP inputs current. It needs them outside the
+    // composition, in onUserLeaveHint, where there is no way to read state.
+    val pipAspectRatio by videoPlayerViewModel.videoAspectRatio.collectAsState()
+    val pipBounds by videoPlayerViewModel.videoSurfaceBounds.collectAsState()
+    androidx.compose.runtime.LaunchedEffect(
+        overlayVideo, isVideoOverlayExpanded, pipAspectRatio, pipBounds
+    ) {
+        onPipStateChanged(
+            overlayVideo != null && isVideoOverlayExpanded,
+            pipAspectRatio,
+            pipBounds
+        )
+    }
+
+    // In system PiP the app is just a video surface. Returning here keeps the
+    // NavHost, both players and every overlay out of the composition entirely,
+    // rather than letting them draw and animate behind a window nobody can see
+    // them in.
+    if (isInPipMode) {
+        com.ivor.ivormusic.ui.video.PipVideoSurface(viewModel = videoPlayerViewModel)
+        return
+    }
 
     Box(
         modifier = Modifier

--- a/app/src/main/java/com/ivor/ivormusic/data/ChunkedStreamDataSource.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/ChunkedStreamDataSource.kt
@@ -28,7 +28,8 @@ import androidx.media3.datasource.TransferListener
  * googlevideo URLs are bound to their issuing InnerTube client through the
  * `?c=` query param and answer 403 when the playback UA does not match.
  *
- * Non-googlevideo URIs pass straight through to the delegate unchunked.
+ * URIs that are not chunkable progressive googlevideo streams - see
+ * [shouldChunk] - pass straight through to the delegate unchunked.
  */
 @UnstableApi
 class ChunkedStreamDataSource private constructor(
@@ -61,8 +62,24 @@ class ChunkedStreamDataSource private constructor(
 
         private val CONTENT_RANGE_REGEX = Regex("""bytes (\d+)-(\d+)/(\d+|\*)""")
 
-        private fun isGoogleVideo(uri: android.net.Uri): Boolean =
-            uri.host?.endsWith(".googlevideo.com") == true
+        /**
+         * Whether chunking applies to [uri].
+         *
+         * Only progressive googlevideo URLs benefit, and those are exactly the
+         * ones carrying a query string (`?expire=...&itag=...`). The live
+         * pipeline's URLs are all path-style with no query at all - the HLS
+         * variant and media playlists on manifest.googlevideo.com, and the
+         * segment URLs they point at - and chunking actively hurts there: a
+         * segment answers 200 with neither Content-Length nor Content-Range
+         * even when a Range is sent, so [openChunk] assumes a full 10 MB
+         * chunk, hits EOF at ~300 KB, reopens at the new position, and the
+         * server re-serves the whole segment from the start. It terminates,
+         * but every segment gets downloaded twice. Verified August 2026.
+         */
+        private fun shouldChunk(uri: android.net.Uri): Boolean {
+            if (uri.host?.endsWith(".googlevideo.com") != true) return false
+            return !uri.query.isNullOrEmpty()
+        }
     }
 
     private var currentSpec: DataSpec? = null
@@ -94,7 +111,7 @@ class ChunkedStreamDataSource private constructor(
         )
         currentSpec = dataSpec
         position = dataSpec.position
-        chunked = isGoogleVideo(dataSpec.uri)
+        chunked = shouldChunk(dataSpec.uri)
         if (!chunked) {
             return delegate.open(dataSpec)
         }

--- a/app/src/main/java/com/ivor/ivormusic/data/LiveChatModels.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/LiveChatModels.kt
@@ -1,0 +1,195 @@
+package com.ivor.ivormusic.data
+
+/**
+ * Models for YouTube live chat.
+ *
+ * Shapes verified against the live InnerTube API August 2026 - see
+ * [YouTubeRepository.pollLiveChat] for the endpoint and renderer notes.
+ */
+
+/**
+ * One inline piece of a chat message. Chat text arrives as a run list where
+ * each run is either plain text or an emoji, so a message cannot be flattened
+ * to a String without losing the custom channel emoji.
+ */
+sealed interface LiveChatRun {
+    data class Text(val text: String) : LiveChatRun
+
+    /**
+     * [imageUrl] is null for standard unicode emoji, whose [label] already
+     * holds the character and renders as ordinary text. Channel-custom emoji
+     * carry an opaque id and must be drawn from [imageUrl].
+     */
+    data class Emoji(val label: String, val imageUrl: String?) : LiveChatRun
+}
+
+/** Author badge kinds YouTube exposes on a chat message. */
+enum class LiveChatBadgeKind { OWNER, MODERATOR, VERIFIED, MEMBER }
+
+/**
+ * A badge beside an author's name. Owner/moderator/verified arrive as an
+ * iconType and render as a vector; member badges are per-channel artwork and
+ * arrive as a [imageUrl] thumbnail instead.
+ */
+data class LiveChatBadge(
+    val kind: LiveChatBadgeKind,
+    val tooltip: String,
+    val imageUrl: String? = null,
+)
+
+data class LiveChatAuthor(
+    val name: String,
+    val channelId: String? = null,
+    val photoUrl: String? = null,
+    val badges: List<LiveChatBadge> = emptyList(),
+) {
+    val isOwner: Boolean get() = badges.any { it.kind == LiveChatBadgeKind.OWNER }
+    val isModerator: Boolean get() = badges.any { it.kind == LiveChatBadgeKind.MODERATOR }
+    val isMember: Boolean get() = badges.any { it.kind == LiveChatBadgeKind.MEMBER }
+}
+
+/**
+ * A single entry in the chat stream. Ordinary messages dominate by a wide
+ * margin; the paid/membership/gift variants are rare but visually loud, which
+ * is why they are separate types rather than flags on [Text].
+ */
+sealed interface LiveChatMessage {
+    val id: String
+    val timestampUsec: Long
+
+    /**
+     * Null only for [System] notices, which YouTube itself authors. Declared
+     * here so a ban - which deletes every message from one channel at once -
+     * can be applied without branching over every variant.
+     */
+    val author: LiveChatAuthor?
+
+    data class Text(
+        override val id: String,
+        override val timestampUsec: Long,
+        override val author: LiveChatAuthor,
+        val runs: List<LiveChatRun>,
+    ) : LiveChatMessage
+
+    /**
+     * A Super Chat, or a Super Sticker when [stickerUrl] is set. The colors come
+     * from YouTube (ARGB ints, unsigned 32-bit) rather than the app theme - they
+     * are part of the amount tier and are the one place a non-ColorScheme color
+     * is correct.
+     */
+    data class Paid(
+        override val id: String,
+        override val timestampUsec: Long,
+        override val author: LiveChatAuthor,
+        val runs: List<LiveChatRun>,
+        val amountText: String,
+        val headerBackgroundColor: Long,
+        val headerTextColor: Long,
+        val bodyBackgroundColor: Long,
+        val bodyTextColor: Long,
+        /** Artwork for a Super Sticker; null for an ordinary Super Chat. */
+        val stickerUrl: String? = null,
+    ) : LiveChatMessage
+
+    /** A new or renewed channel membership. */
+    data class Membership(
+        override val id: String,
+        override val timestampUsec: Long,
+        override val author: LiveChatAuthor,
+        val headline: String,
+        val tierName: String?,
+    ) : LiveChatMessage
+
+    /**
+     * A gift, delivered in the newer viewModel format rather than as a
+     * renderer, so it carries no timestamp of its own - ordering comes from
+     * its position in the action list.
+     */
+    data class Gift(
+        override val id: String,
+        override val timestampUsec: Long,
+        override val author: LiveChatAuthor,
+        val text: String,
+        val giftImageUrl: String?,
+    ) : LiveChatMessage
+
+    /** A YouTube system notice, e.g. "Subscribers-only mode". */
+    data class System(
+        override val id: String,
+        override val timestampUsec: Long,
+        val runs: List<LiveChatRun>,
+    ) : LiveChatMessage {
+        override val author: LiveChatAuthor? get() = null
+    }
+}
+
+/**
+ * The pinned card above the chat: either a message the creator pinned or the
+ * auto-generated chat summary.
+ */
+data class LiveChatBanner(
+    val id: String,
+    val author: LiveChatAuthor?,
+    val runs: List<LiveChatRun>,
+    val isSummary: Boolean,
+)
+
+/** Entry point for a chat stream, from the watch-next response. */
+data class LiveChatSession(
+    val continuation: String,
+)
+
+/**
+ * One poll's worth of chat. [timeoutMs] is the server-dictated delay before
+ * the next poll - honour it rather than picking an interval.
+ *
+ * [sendParams] is the opaque token a send_message call must echo back. It
+ * rides every poll response rather than the session, and is present even when
+ * signed out, so it is not on its own permission to post.
+ *
+ * Moderation arrives as three separate action shapes, all of which have to be
+ * applied or a deleted message stays on screen forever: [removedIds] (one
+ * message), [removedAuthorIds] (every message from one channel, which is what a
+ * ban emits) and [replacements] (a message edited in place, keyed by the id it
+ * supersedes).
+ */
+data class LiveChatPage(
+    val messages: List<LiveChatMessage> = emptyList(),
+    val removedIds: Set<String> = emptySet(),
+    val removedAuthorIds: Set<String> = emptySet(),
+    val replacements: Map<String, LiveChatMessage> = emptyMap(),
+    val banner: LiveChatBanner? = null,
+    /** A removeBannerForLiveChatCommand: the pinned card should come down. */
+    val bannerCleared: Boolean = false,
+    /**
+     * Why the composer is unavailable ("Subscribers-only mode", slow mode, a
+     * ban), from liveChatRestrictedParticipationRenderer. Null when chat is
+     * open to the viewer.
+     */
+    val restrictionMessage: String? = null,
+    val nextContinuation: String? = null,
+    val timeoutMs: Long = 10_000L,
+    val sendParams: String? = null,
+    val maxMessageLength: Int = 200,
+)
+
+/**
+ * Outcome of a send. The response echoes the accepted message back as a normal
+ * chat item, so [echo] can be shown immediately rather than waiting up to a
+ * poll interval for it to come round again - the id matches the one the poll
+ * will later deliver, so the ordinary dedupe drops the duplicate.
+ */
+data class LiveChatSendResult(
+    val success: Boolean,
+    val echo: LiveChatMessage? = null,
+    val error: String? = null,
+)
+
+/**
+ * Live counters that change while watching, from the updated_metadata endpoint.
+ */
+data class LiveMetadata(
+    val viewerCountText: String? = null,
+    val shortViewerCount: String? = null,
+    val dateText: String? = null,
+)

--- a/app/src/main/java/com/ivor/ivormusic/data/SessionCookieJar.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/SessionCookieJar.kt
@@ -1,0 +1,54 @@
+package com.ivor.ivormusic.data
+
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.HttpUrl
+
+/**
+ * Keeps the stored YouTube session in step with the cookies Google re-issues
+ * while the app is using it.
+ *
+ * The session used to be a snapshot taken once in the login WebView and then
+ * replayed forever. Google rotates the session cookies (notably the
+ * `__Secure-1PSIDTS` / `__Secure-3PSIDTS` pair) as requests go out, so the
+ * frozen copy went stale on its own after a while: YouTube kept answering
+ * `logged_in: 0` with an empty subscriptions feed and no account name, while
+ * the app still believed it was signed in because a cookie string existed.
+ * The only way out was signing out and back in, repeatedly.
+ *
+ * This jar is deliberately write-only. [loadForRequest] returns nothing
+ * because every authenticated call in [YouTubeRepository] builds its own
+ * `Cookie` header alongside the matching per-origin SAPISIDHASH - OkHttp's
+ * bridge interceptor *replaces* that header when a jar hands back cookies, so
+ * serving them here would clobber the header the caller carefully assembled.
+ */
+class SessionCookieJar(private val sessionManager: SessionManager) : CookieJar {
+
+    private val lock = Any()
+
+    override fun loadForRequest(url: HttpUrl): List<Cookie> = emptyList()
+
+    override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+        if (cookies.isEmpty()) return
+        // googlevideo and other CDN hosts hand out cookies that have nothing to
+        // do with the account session.
+        val host = url.host
+        if (!host.endsWith("youtube.com") && !host.endsWith("google.com")) return
+
+        val now = System.currentTimeMillis()
+        val updates = cookies.asSequence()
+            // An expired or emptied cookie is a deletion. Applying those is how
+            // a single unlucky response could sign the user out, so they are
+            // ignored - refreshes only.
+            .filter { it.value.isNotBlank() && it.expiresAt > now }
+            .associate { it.name to it.value }
+        if (updates.isEmpty()) return
+
+        synchronized(lock) {
+            val existing = sessionManager.getCookies()
+            if (existing.isNullOrBlank()) return
+            val merged = YouTubeAuthUtils.mergeCookies(existing, updates)
+            if (merged != existing) sessionManager.saveCookies(merged)
+        }
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/data/SessionManager.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/SessionManager.kt
@@ -3,6 +3,9 @@ package com.ivor.ivormusic.data
 import android.content.Context
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * Manages session cookies for YouTube Music authentication.
@@ -49,9 +52,36 @@ class SessionManager(context: Context) {
 
     /**
      * Save session cookies obtained from WebView.
+     *
+     * Also the refresh path for [SessionCookieJar], so it does not touch the
+     * expired flag - only a deliberate sign-in clears that. Use [startSession]
+     * when the user has just logged in.
      */
     fun saveCookies(cookies: String) {
         prefs.edit().putString(KEY_COOKIES, cookies).apply()
+    }
+
+    /**
+     * Begin a session the user has just signed into: store the cookies and
+     * drop any "YouTube rejected us" verdict left over from the dead one, so
+     * the account screens come back without waiting for a response to prove it.
+     */
+    fun startSession(cookies: String) {
+        saveCookies(cookies)
+        setSessionExpired(false)
+    }
+
+    /**
+     * Record that YouTube answered an authenticated request as anonymous, or
+     * that it accepted one. Cookies are left alone either way - they are the
+     * only thing a later refresh has to work with, and clearing them on a
+     * single bad response would sign people out over a hiccup.
+     */
+    fun setSessionExpired(expired: Boolean) {
+        if (_sessionExpired.value != expired) {
+            if (expired) android.util.Log.w("SessionManager", "YouTube rejected the session as signed out")
+            _sessionExpired.value = expired
+        }
     }
 
     /**
@@ -66,10 +96,15 @@ class SessionManager(context: Context) {
      */
     fun clearSession() {
         prefs.edit().clear().apply()
+        _sessionExpired.value = false
     }
 
     /**
      * Check if user is logged in.
+     *
+     * Deliberately still just "cookies exist", so requests keep going out and
+     * a rotation can revive a session that looked dead. [sessionExpired] is
+     * what the UI should read before showing account-only content.
      */
     fun isLoggedIn(): Boolean {
         return !getCookies().isNullOrBlank()
@@ -84,6 +119,16 @@ class SessionManager(context: Context) {
     }
 
     companion object {
+        /**
+         * True once YouTube has answered an authenticated call as anonymous.
+         *
+         * Companion-scoped on purpose: with no DI every ViewModel news up its
+         * own SessionManager, so an instance flow would never reach the screens
+         * that need to react - the same reason visitorData is cached up here.
+         */
+        private val _sessionExpired = MutableStateFlow(false)
+        val sessionExpired: StateFlow<Boolean> = _sessionExpired.asStateFlow()
+
         private const val PREFS_FILE_NAME = "yt_music_session"
         private const val KEY_COOKIES = "session_cookies"
         private const val KEY_USER_NAME = "user_name"

--- a/app/src/main/java/com/ivor/ivormusic/data/VideoItem.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/VideoItem.kt
@@ -115,7 +115,14 @@ data class VideoQuality(
     val url: String,
     val format: String? = null, // e.g. "mp4", "webm"
     val isDASH: Boolean = false,
-    val audioUrl: String? = null // For non-DASH adaptive streams
+    val audioUrl: String? = null, // For non-DASH adaptive streams
+    /**
+     * Set on entries resolved from a live broadcast. Live streams only ever
+     * play through the adaptive manifest - their progressive URLs are segment
+     * endpoints, not byte-addressable files - so this doubles as the player's
+     * "this video is live" signal.
+     */
+    val isLive: Boolean = false
 )
 
 /**
@@ -145,7 +152,14 @@ data class WatchNextData(
     val engagement: VideoEngagement?,
     val updatedVideoItem: VideoItem?,
     val relatedVideos: List<VideoItem>,
-    val chapters: List<VideoChapter> = emptyList()
+    val chapters: List<VideoChapter> = emptyList(),
+    /**
+     * Live chat start token, when the video is a broadcast with chat enabled.
+     * It rides this response so opening the chat panel costs no extra /next -
+     * the watch-next tree is a multi-megabyte parse and re-fetching it was the
+     * single biggest cost of opening chat.
+     */
+    val liveChatContinuation: String? = null
 )
 
 /**

--- a/app/src/main/java/com/ivor/ivormusic/data/WebVttParser.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/WebVttParser.kt
@@ -1,0 +1,117 @@
+package com.ivor.ivormusic.data
+
+/**
+ * One subtitle cue: [text] is on screen from [startMs] to [endMs] of media time.
+ */
+data class VttCue(
+    val startMs: Long,
+    val endMs: Long,
+    val text: String
+)
+
+/**
+ * Minimal WebVTT reader for YouTube's timedtext output.
+ *
+ * Koda renders captions itself rather than handing them to ExoPlayer as a
+ * sideloaded text track: a sideloaded track is part of the media source, so
+ * every caption change rebuilt the source and threw away the whole video
+ * buffer. Parsing here keeps the CC toggle free and instant.
+ *
+ * Only what timedtext actually emits is supported - cue timings, multi-line
+ * payloads, and the inline markup auto-generated captions carry. Cue settings
+ * (alignment, position, region) are read and discarded; captions are laid out
+ * by the overlay instead.
+ */
+object WebVttParser {
+
+    private val TIMESTAMP = Regex("""(\d+):(\d{2})(?::(\d{2}))?[.,](\d{1,3})""")
+
+    /** Inline markup: <c>, </c>, <b>, and the <00:00:01.234> word timings. */
+    private val TAG = Regex("<[^>]*>")
+
+    fun parse(vtt: String): List<VttCue> {
+        val lines = vtt.lines()
+        val cues = mutableListOf<VttCue>()
+        var i = 0
+
+        while (i < lines.size) {
+            val arrow = lines[i].indexOf("-->")
+            if (arrow < 0) {
+                i++
+                continue
+            }
+            val start = parseTimestamp(lines[i].substring(0, arrow))
+            val end = parseTimestamp(lines[i].substring(arrow + 3))
+            i++
+
+            // The payload runs to the next blank line, whether or not the
+            // timings above it parsed.
+            val payload = buildString {
+                while (i < lines.size && lines[i].isNotBlank()) {
+                    if (isNotEmpty()) append('\n')
+                    append(lines[i])
+                    i++
+                }
+            }
+            if (start == null || end == null || end <= start) continue
+
+            val text = cleanCueText(payload)
+            if (text.isEmpty()) continue
+
+            // Auto-generated captions repeat a line across back-to-back cues as
+            // it scrolls. Extending the previous cue instead of adding a
+            // duplicate stops the overlay flickering on every hand-off.
+            val previous = cues.lastOrNull()
+            if (previous != null && previous.text == text && start <= previous.endMs) {
+                cues[cues.lastIndex] = previous.copy(endMs = maxOf(previous.endMs, end))
+            } else {
+                cues.add(VttCue(start, end, text))
+            }
+        }
+
+        return cues.sortedBy { it.startMs }
+    }
+
+    /**
+     * Milliseconds from the first timestamp in [raw], which is either
+     * HH:MM:SS.mmm or MM:SS.mmm. Anything after it (cue settings such as
+     * "align:start position:0%") is ignored.
+     */
+    private fun parseTimestamp(raw: String): Long? {
+        val match = TIMESTAMP.find(raw) ?: return null
+        val (first, second, third, fraction) = match.destructured
+        val millis = fraction.padEnd(3, '0').toLong()
+        return if (third.isEmpty()) {
+            first.toLong() * 60_000 + second.toLong() * 1_000 + millis
+        } else {
+            first.toLong() * 3_600_000 + second.toLong() * 60_000 + third.toLong() * 1_000 + millis
+        }
+    }
+
+    /**
+     * Strip markup first, then decode entities - the other order would turn an
+     * escaped "&lt;i&gt;" into a tag and delete the text inside it.
+     */
+    private fun cleanCueText(raw: String): String =
+        TAG.replace(raw, "")
+            .replace("&lrm;", "")
+            .replace("&rlm;", "")
+            .replace("&nbsp;", " ")
+            .replace("&lt;", "<")
+            .replace("&gt;", ">")
+            .replace("&quot;", "\"")
+            .replace("&#39;", "'")
+            .replace("&amp;", "&")
+            .lines()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .joinToString("\n")
+
+    /**
+     * The cue covering [positionMs], or null when there is a gap. Cues are
+     * ordered and non-overlapping in practice, so a binary search would work,
+     * but lists are small and playback only asks a few times a second.
+     */
+    fun cueAt(cues: List<VttCue>, positionMs: Long): VttCue? =
+        cues.firstOrNull { positionMs in it.startMs until it.endMs }
+}

--- a/app/src/main/java/com/ivor/ivormusic/data/YouTubeAuthUtils.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/YouTubeAuthUtils.kt
@@ -63,6 +63,49 @@ object YouTubeAuthUtils {
     }
 
     /**
+     * Cookies Google rotates during a live session, on top of whatever the jar
+     * already carries. The `*SIDTS` pair in particular is re-issued every few
+     * hours, and a session that keeps replaying the value captured at login
+     * eventually gets answered as signed out - `logged_in: 0` in the
+     * responseContext, an empty subscriptions feed, and a null account name,
+     * all while the SAPISIDHASH still computes fine because SAPISID itself
+     * lives for years. That is what made signing in wear off and need doing
+     * again. Verified against a dead emulator session, August 2026.
+     */
+    private val REFRESHABLE_COOKIE_NAMES = setOf(
+        "SID", "HSID", "SSID", "APISID", "SAPISID", "LOGIN_INFO", "SIDCC",
+        "__Secure-1PSID", "__Secure-3PSID",
+        "__Secure-1PAPISID", "__Secure-3PAPISID",
+        "__Secure-1PSIDTS", "__Secure-3PSIDTS",
+        "__Secure-1PSIDCC", "__Secure-3PSIDCC"
+    )
+
+    /**
+     * Fold freshly issued cookie values into a stored cookie string.
+     *
+     * Only names already present, or in [REFRESHABLE_COOKIE_NAMES], are taken -
+     * every response also sets throwaway cookies (YSC, VISITOR_INFO1_LIVE, ad
+     * and consent state) that would bloat the header without authenticating
+     * anything. Order is preserved and nothing is ever removed: this can only
+     * make a session fresher, never tear one down.
+     */
+    fun mergeCookies(existing: String, updates: Map<String, String>): String {
+        val merged = LinkedHashMap<String, String>()
+        existing.split(";").forEach { part ->
+            val pair = part.trim().split("=", limit = 2)
+            val name = pair.firstOrNull()?.takeIf { it.isNotBlank() } ?: return@forEach
+            merged[name] = pair.getOrNull(1).orEmpty()
+        }
+        updates.forEach { (name, value) ->
+            if (value.isBlank()) return@forEach
+            if (name in REFRESHABLE_COOKIE_NAMES || merged.containsKey(name)) {
+                merged[name] = value
+            }
+        }
+        return merged.entries.joinToString("; ") { "${it.key}=${it.value}" }
+    }
+
+    /**
      * Generates the SAPISIDHASH required for authenticated requests.
      */
     fun getAuthorizationHeader(cookieString: String, origin: String = "https://music.youtube.com"): String? {

--- a/app/src/main/java/com/ivor/ivormusic/data/YouTubeLinkParser.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/YouTubeLinkParser.kt
@@ -28,6 +28,23 @@ object YouTubeLinkParser {
     private val VIDEO_PATH_ROOTS = setOf("shorts", "live", "embed", "v")
 
     /**
+     * Parse the first YouTube link found anywhere in [text].
+     *
+     * Unlike [parse], which expects the whole string to be the URL, this
+     * tolerates the surrounding prose that share sheets attach - YouTube's own
+     * share action sends "Video title\nhttps://youtu.be/id", and other apps add
+     * their own wrappers. Returns null when no YouTube link is present.
+     */
+    fun parseFromSharedText(text: String): ParsedYouTubeLink? =
+        text.split(' ', '\n', '\r', '\t', '<', '>', '"')
+            .asSequence()
+            .mapNotNull { token -> parse(token.trim().trimEnd(*TRAILING_PUNCTUATION)) }
+            .firstOrNull()
+
+    /** Sentence punctuation that ends up glued to a URL in shared prose. */
+    private val TRAILING_PUNCTUATION = charArrayOf('.', ',', ';', ':', '!', '?', ')', ']', '}', '\'')
+
+    /**
      * Parse [input] as a YouTube link. Returns null when the text is not a
      * YouTube URL, i.e. it should be treated as a normal search query.
      */

--- a/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
@@ -87,6 +87,12 @@ class YouTubeRepository(private val context: Context) {
         // browse params selecting a channel's Videos tab (protobuf: "videos")
         private const val CHANNEL_VIDEOS_TAB_PARAMS = "EgZ2aWRlb3PyBgQKAjoA"
 
+        // YouTube's own account verdict, in the responseContext tracking params
+        // of every InnerTube response: {"key":"logged_in","value":"0"|"1"}.
+        // Tolerant of the pretty-printed spacing so it matches either form.
+        private val LOGGED_IN_TRACKING_PARAM =
+            Regex("\"logged_in\"\\s*,\\s*\"value\"\\s*:\\s*\"([01])\"")
+
         // ANDROID_VR is the recommended client for audio extraction in 2026:
         //  - Does NOT require a PO Token (unlike WEB / ANDROID / IOS / MWEB).
         //  - Returns direct, unobfuscated stream URLs (no signatureCipher to decrypt).
@@ -168,6 +174,10 @@ class YouTubeRepository(private val context: Context) {
             }
             chain.proceed(chain.request())
         }
+        // Folds Google's rotated session cookies back into storage. Without it
+        // the login snapshot goes stale on its own and every authenticated
+        // endpoint quietly answers as signed out. See SessionCookieJar.
+        .cookieJar(SessionCookieJar(sessionManager))
         .connectTimeout(30, TimeUnit.SECONDS)
         .readTimeout(30, TimeUnit.SECONDS)
         .build()
@@ -1779,7 +1789,7 @@ class YouTubeRepository(private val context: Context) {
 
         return try {
             val response = okHttpClient.newCall(request).execute()
-            response.body?.string() ?: ""
+            (response.body?.string() ?: "").also { noteSessionState(it) }
         } catch (e: Exception) {
             e.printStackTrace()
             ""
@@ -3800,14 +3810,21 @@ class YouTubeRepository(private val context: Context) {
             streamExtractor.fetchPage()
             
             val qualities = mutableListOf<VideoQuality>()
-            
+            val isLiveStream = streamExtractor.streamType == StreamType.LIVE_STREAM ||
+                streamExtractor.streamType == StreamType.AUDIO_LIVE_STREAM
+
             // 1. DASH/HLS (best quality, adaptive)
             streamExtractor.dashMpdUrl?.takeIf { it.isNotBlank() }?.let { url ->
-                qualities.add(VideoQuality("Auto (Best)", url, "DASH", true))
+                qualities.add(VideoQuality("Auto (Best)", url, "DASH", true, isLive = isLiveStream))
             } ?: streamExtractor.hlsUrl?.takeIf { it.isNotBlank() }?.let { url ->
-                qualities.add(VideoQuality("Auto (HLS)", url, "HLS", true))
+                qualities.add(VideoQuality("Auto (HLS)", url, "HLS", true, isLive = isLiveStream))
             }
-            
+
+            // A live broadcast's progressive URLs are segment endpoints that
+            // stall a progressive reader, so the adaptive manifest above is the
+            // only usable entry - see parseQualitiesFromStreamingData.
+            if (isLiveStream) return@withContext qualities
+
             // 2. Adaptive Streams (video + separate audio)
             val videoOnlyStreams = streamExtractor.videoOnlyStreams
             val audioStreams = streamExtractor.audioStreams
@@ -3871,6 +3888,50 @@ class YouTubeRepository(private val context: Context) {
                 transfer == "COLOR_TRANSFER_CHARACTERISTICS_ARIB_STD_B67"
         }
         val preferHdr = ThemePreferences.isPreferHdrEnabled(context)
+
+        fun labelHeight(label: String): Int = label.takeWhile { it.isDigit() }.toIntOrNull() ?: 0
+        fun labelFps(label: String): Int =
+            label.substringAfter("p", "").takeWhile { it.isDigit() }.toIntOrNull() ?: 30
+
+        // A live broadcast is the one case where the progressive URLs in
+        // adaptiveFormats are unusable: they are segment endpoints (live=1,
+        // noclen=1, targetDurationSec=2), so an unbounded GET returns one ~2s
+        // segment and then EOF, and the bounded ranged GET ChunkedStreamDataSource
+        // issues blocks until it times out - the "live video opens but never
+        // plays" failure. The HLS variant playlist is the only sane source:
+        // media3-exoplayer-hls handles the segment protocol, the DVR window and
+        // ABR itself. hlsManifestUrl is present on live /player responses and
+        // absent on VODs (verified against ANDROID_VR, August 2026), so it is
+        // also the live signal.
+        //
+        // Every rendition lives inside that one manifest, so the ladder here is
+        // labels only: each entry carries the same URL, and picking one caps the
+        // track selector instead of swapping the media source (see
+        // VideoPlayerViewModel.setQuality). That keeps ABR working under the cap
+        // and makes a quality change free - no re-prepare, no rebuffer, which
+        // matters more on live than anywhere else. The labels come from the same
+        // /player response the manifest did, so building the ladder costs no
+        // extra network call.
+        val hlsManifestUrl = streamingData.optString("hlsManifestUrl").takeIf { it.isNotBlank() }
+        if (hlsManifestUrl != null) {
+            fun liveEntry(label: String) =
+                VideoQuality(label, hlsManifestUrl, "HLS", isDASH = true, isLive = true)
+
+            val ladder = adaptive
+                .filter {
+                    it.optString("mimeType").startsWith("video/") &&
+                        (preferHdr || !isHdrFormat(it))
+                }
+                .mapNotNull { it.optString("qualityLabel").takeIf { label -> label.isNotEmpty() } }
+                .distinct()
+                .sortedWith(
+                    compareByDescending<String> { labelHeight(it) }
+                        .thenByDescending { if (it.contains("HDR", true)) 1 else 0 }
+                        .thenByDescending { labelFps(it) }
+                )
+
+            return listOf(liveEntry("Auto")) + ladder.map(::liveEntry)
+        }
 
         // Best separate audio track; prefer AAC (mp4a) for broad hardware support,
         // then highest bitrate.
@@ -3937,13 +3998,11 @@ class YouTubeRepository(private val context: Context) {
         // Highest resolution first; at equal height an HDR variant (only
         // present when opted in) outranks SDR so the default pick lands on
         // it, then 60fps variants before 30fps.
-        fun height(label: String): Int = label.takeWhile { it.isDigit() }.toIntOrNull() ?: 0
         fun hdr(label: String): Int = if (label.contains("HDR", ignoreCase = true)) 1 else 0
-        fun fps(label: String): Int = label.substringAfter("p", "").takeWhile { it.isDigit() }.toIntOrNull() ?: 30
         return qualities.sortedWith(
-            compareByDescending<VideoQuality> { height(it.resolution) }
+            compareByDescending<VideoQuality> { labelHeight(it.resolution) }
                 .thenByDescending { hdr(it.resolution) }
-                .thenByDescending { fps(it.resolution) }
+                .thenByDescending { labelFps(it.resolution) }
         )
     }
 
@@ -4104,7 +4163,7 @@ class YouTubeRepository(private val context: Context) {
         return try {
             okHttpClient.newCall(builder.build()).execute().use { response ->
                 if (response.isSuccessful) {
-                    response.body?.string()
+                    response.body?.string()?.also { noteSessionState(it) }
                 } else {
                     android.util.Log.w("YouTubeRepo", "watch api $endpoint HTTP ${response.code}")
                     null
@@ -4114,6 +4173,23 @@ class YouTubeRepository(private val context: Context) {
             android.util.Log.e("YouTubeRepo", "watch api $endpoint failed", e)
             null
         }
+    }
+
+    /**
+     * Read YouTube's own verdict on the session out of a response.
+     *
+     * Every InnerTube response reports `logged_in` in its responseContext
+     * tracking params. When the app sent cookies and a SAPISIDHASH and still
+     * gets `0` back, the stored session is dead - which used to surface only as
+     * an empty subscriptions tab and a blank account name, with no hint that
+     * signing in again was what was needed. A `1` clears the flag, so a session
+     * revived by a cookie rotation heals itself without a round trip through
+     * the login screen.
+     */
+    private fun noteSessionState(body: String) {
+        if (!sessionManager.isLoggedIn()) return
+        val match = LOGGED_IN_TRACKING_PARAM.find(body) ?: return
+        sessionManager.setSessionExpired(match.groupValues[1] == "0")
     }
 
     /**
@@ -4158,7 +4234,8 @@ class YouTubeRepository(private val context: Context) {
                 } catch (e: Exception) {
                     android.util.Log.w("YouTubeRepo", "chapters parse failed for $videoId", e)
                     emptyList()
-                }
+                },
+                liveChatContinuation = parseLiveChatContinuation(root)
             )
         } catch (e: Exception) {
             android.util.Log.e("YouTubeRepo", "getWatchNextData failed", e)
@@ -4204,6 +4281,522 @@ class YouTubeRepository(private val context: Context) {
             .put("videoId", videoId)
         val raw = postWatchApi("next", body) ?: return null
         return org.json.JSONObject(raw)
+    }
+
+    // ============================================================
+    // Live chat (InnerTube WEB client against www.youtube.com)
+    // ============================================================
+
+    /**
+     * Open a live chat stream for [videoId], returning the first continuation
+     * token and the send token.
+     *
+     * The entry point rides the same /next response the player already parses:
+     * contents.twoColumnWatchNextResults.conversationBar.liveChatRenderer, with
+     * the start token at continuations[0].reloadContinuationData.continuation.
+     * conversationBar is absent entirely when the video is not live or the
+     * creator disabled chat, which is the "no chat" signal - not an error.
+     *
+     * Reading chat needs no account: a signed-out poll returns the full
+     * backlog. Sending does, so [LiveChatSession.sendParams] is only meaningful
+     * alongside [isLoggedIn].
+     *
+     * Verified against the live /next API August 2026.
+     */
+    suspend fun getLiveChatSession(videoId: String): LiveChatSession? = withContext(Dispatchers.IO) {
+        try {
+            val root = fetchWatchNextRoot(videoId) ?: return@withContext null
+            parseLiveChatContinuation(root)?.let { LiveChatSession(continuation = it) }
+        } catch (e: Exception) {
+            android.util.Log.e("YouTubeRepo", "getLiveChatSession failed for $videoId", e)
+            null
+        }
+    }
+
+    /**
+     * Pull the chat start token out of an already-fetched watch-next response.
+     *
+     * conversationBar is absent entirely when the video is not live or the
+     * creator disabled chat, which is the "no chat" signal - not an error.
+     *
+     * A finished broadcast that kept its chat exposes the *replay* under this
+     * same key. Nothing consumes that today - the panel is gated on isLive -
+     * but it is the hook if replay chat is ever wanted.
+     */
+    private fun parseLiveChatContinuation(root: org.json.JSONObject): String? {
+        val renderer = root.optJSONObject("contents")
+            ?.optJSONObject("twoColumnWatchNextResults")
+            ?.optJSONObject("conversationBar")
+            ?.optJSONObject("liveChatRenderer")
+            ?: return null
+
+        // Sub-menu entry 0 is "Top chat" and entry 1 "Live chat"; the top-level
+        // continuation matches whichever the creator defaulted to, and is the
+        // one the web player opens with.
+        return renderer.optJSONArray("continuations")
+            ?.optJSONObject(0)
+            ?.optJSONObject("reloadContinuationData")
+            ?.optString("continuation")
+            ?.takeIf { it.isNotBlank() }
+    }
+
+    /**
+     * Poll one page of live chat.
+     *
+     * continuationContents.liveChatContinuation carries the new actions plus
+     * the next token in continuations[0].invalidationContinuationData, whose
+     * timeoutMs (10s on every stream sampled) is the interval the server wants
+     * between polls. The first poll returns the whole visible backlog, roughly
+     * 70 messages; subsequent polls return only what arrived since.
+     *
+     * Action shapes handled, in order of how often they actually appear:
+     * addChatItemAction (text/paid/membership/gift/system items),
+     * addBannerToLiveChatCommand (pinned message or chat summary) and
+     * removeChatItemAction (a message deleted after it was already rendered).
+     * These were verified against the live live_chat/get_live_chat API
+     * August 2026.
+     *
+     * NOT yet probed against a live response, and so to be treated as
+     * best-effort until they are: markChatItemAsDeletedAction,
+     * markChatItemsByAuthorAsDeletedAction, replaceChatItemAction,
+     * removeBannerForLiveChatCommand, liveChatPaidStickerRenderer and
+     * liveChatRestrictedParticipationRenderer. Each one is an additive branch
+     * that no-ops when the key is absent, so a wrong guess costs the feature
+     * rather than the chat - but confirm the shapes before relying on them.
+     */
+    suspend fun pollLiveChat(continuation: String): LiveChatPage? = withContext(Dispatchers.IO) {
+        try {
+            val body = org.json.JSONObject()
+                .put("context", webContext())
+                .put("continuation", continuation)
+            val raw = postWatchApi("live_chat/get_live_chat", body) ?: return@withContext null
+            val chat = org.json.JSONObject(raw)
+                .optJSONObject("continuationContents")
+                ?.optJSONObject("liveChatContinuation")
+                ?: return@withContext null
+
+            // Either invalidationContinuationData (the usual live tick) or
+            // timedContinuationData / reloadContinuationData; all three hold the
+            // next token and a timeout under different keys.
+            val nextData = chat.optJSONArray("continuations")?.optJSONObject(0)?.let { c ->
+                c.optJSONObject("invalidationContinuationData")
+                    ?: c.optJSONObject("timedContinuationData")
+                    ?: c.optJSONObject("reloadContinuationData")
+            }
+
+            val actions = chat.optJSONArray("actions")
+            val messages = mutableListOf<LiveChatMessage>()
+            val removed = mutableSetOf<String>()
+            val removedAuthors = mutableSetOf<String>()
+            val replacements = mutableMapOf<String, LiveChatMessage>()
+            var banner: LiveChatBanner? = null
+            var bannerCleared = false
+
+            for (i in 0 until (actions?.length() ?: 0)) {
+                val action = actions?.optJSONObject(i) ?: continue
+                action.optJSONObject("addChatItemAction")?.optJSONObject("item")?.let { item ->
+                    parseLiveChatItem(item, fallbackOrder = i)?.let(messages::add)
+                }
+                action.optJSONObject("removeChatItemAction")
+                    ?.optString("targetItemId")
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let(removed::add)
+                // What a moderator delete actually emits. The renderer carries a
+                // "deleted by" placeholder, but YouTube's own client collapses
+                // the row away, so the message is simply dropped.
+                action.optJSONObject("markChatItemAsDeletedAction")
+                    ?.optString("targetItemId")
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let(removed::add)
+                // A ban: every message from that channel disappears at once.
+                action.optJSONObject("markChatItemsByAuthorAsDeletedAction")
+                    ?.optString("externalChannelId")
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let(removedAuthors::add)
+                action.optJSONObject("replaceChatItemAction")?.let { replace ->
+                    val target = replace.optString("targetItemId").takeIf { it.isNotBlank() }
+                    val item = replace.optJSONObject("replacementItem")
+                    if (target != null && item != null) {
+                        parseLiveChatItem(item, fallbackOrder = i)?.let { replacements[target] = it }
+                    }
+                }
+                action.optJSONObject("addBannerToLiveChatCommand")
+                    ?.optJSONObject("bannerRenderer")
+                    ?.optJSONObject("liveChatBannerRenderer")
+                    ?.let { parseLiveChatBanner(it) }
+                    ?.let { banner = it }
+                if (action.has("removeBannerForLiveChatCommand")) bannerCleared = true
+            }
+
+            val actionPanel = chat.optJSONObject("actionPanel")
+            val inputRenderer = actionPanel?.optJSONObject("liveChatMessageInputRenderer")
+            // When chat is subscribers-only, members-only, in slow mode, or the
+            // viewer is banned, the input renderer is replaced wholesale by this
+            // one carrying the reason.
+            val restriction = actionPanel
+                ?.optJSONObject("liveChatRestrictedParticipationRenderer")
+                ?.let { getRunText(it.optJSONObject("message")) }
+                ?.takeIf { it.isNotBlank() }
+
+            LiveChatPage(
+                messages = messages,
+                removedIds = removed,
+                removedAuthorIds = removedAuthors,
+                replacements = replacements,
+                banner = banner,
+                bannerCleared = bannerCleared,
+                restrictionMessage = restriction,
+                nextContinuation = nextData?.optString("continuation")?.takeIf { it.isNotBlank() },
+                timeoutMs = nextData?.optLong("timeoutMs")?.takeIf { it > 0L } ?: 10_000L,
+                sendParams = inputRenderer
+                    ?.optJSONObject("sendButton")
+                    ?.optJSONObject("buttonRenderer")
+                    ?.optJSONObject("serviceEndpoint")
+                    ?.optJSONObject("sendLiveChatMessageEndpoint")
+                    ?.optString("params")
+                    ?.takeIf { it.isNotBlank() },
+                maxMessageLength = inputRenderer
+                    ?.optJSONObject("inputField")
+                    ?.optJSONObject("liveChatTextInputFieldRenderer")
+                    ?.optInt("maxCharacterLimit")
+                    ?.takeIf { it > 0 }
+                    ?: 200,
+            )
+        } catch (e: Exception) {
+            android.util.Log.e("YouTubeRepo", "pollLiveChat failed", e)
+            null
+        }
+    }
+
+    /**
+     * Post a message to a live chat. Requires login - the input renderer is
+     * present in the response even signed out, so its presence is not an auth
+     * signal.
+     *
+     * [params] is the opaque token from the poll response's
+     * actionPanel.liveChatMessageInputRenderer.sendButton, echoed back verbatim.
+     *
+     * An accepted message comes straight back as an addChatItemAction, so the
+     * result carries the parsed item: showing it at once is what makes sending
+     * feel instant instead of costing up to a full poll interval. Its id is the
+     * one the poll will hand back later, so the normal dedupe absorbs it.
+     */
+    suspend fun sendLiveChatMessage(params: String, text: String): LiveChatSendResult =
+        withContext(Dispatchers.IO) {
+            if (!isLoggedIn()) {
+                return@withContext LiveChatSendResult(false, error = "Sign in to chat")
+            }
+            try {
+                val body = org.json.JSONObject()
+                    .put("context", webContext())
+                    .put("params", params)
+                    .put(
+                        "richMessage",
+                        org.json.JSONObject().put(
+                            "textSegments",
+                            org.json.JSONArray().put(org.json.JSONObject().put("text", text))
+                        )
+                    )
+                    .put("clientMessageId", java.util.UUID.randomUUID().toString())
+                val raw = postWatchApi("live_chat/send_message", body)
+                    ?: return@withContext LiveChatSendResult(false, error = "Message not sent")
+                val root = org.json.JSONObject(raw)
+
+                val results = mutableListOf<org.json.JSONObject>()
+                findObjectsByKey(root, "addChatItemAction", results)
+                val echo = results.firstNotNullOfOrNull { action ->
+                    action.optJSONObject("item")?.let { parseLiveChatItem(it, fallbackOrder = 0) }
+                }
+                if (results.isNotEmpty()) {
+                    return@withContext LiveChatSendResult(true, echo = echo)
+                }
+
+                // A rejected message (slow mode, a word filter, a ban) answers
+                // 200 with an error string in place of the item.
+                val errors = mutableListOf<org.json.JSONObject>()
+                findObjectsByKey(root, "errorMessage", errors)
+                val reason = errors.firstNotNullOfOrNull { getRunText(it) }
+                    ?.takeIf { it.isNotBlank() }
+                LiveChatSendResult(false, error = reason ?: "Message not sent")
+            } catch (e: Exception) {
+                android.util.Log.e("YouTubeRepo", "sendLiveChatMessage failed", e)
+                LiveChatSendResult(false, error = "Message not sent")
+            }
+        }
+
+    /**
+     * Concurrent viewers and the "Started streaming ..." line for a live video.
+     *
+     * The updated_metadata endpoint is what the web player polls to keep those
+     * counters fresh without re-running /next. It asks for a 5s tick, which is
+     * far more often than a phone needs - call it on the chat's 10s cadence or
+     * slower.
+     *
+     * Verified against the live updated_metadata API August 2026.
+     */
+    suspend fun getLiveMetadata(videoId: String): LiveMetadata? = withContext(Dispatchers.IO) {
+        try {
+            val body = org.json.JSONObject()
+                .put("context", webContext())
+                .put("videoId", videoId)
+            val raw = postWatchApi("updated_metadata", body) ?: return@withContext null
+            val root = org.json.JSONObject(raw)
+
+            val viewCounts = mutableListOf<org.json.JSONObject>()
+            findObjectsByKey(root, "videoViewCountRenderer", viewCounts)
+            val viewCount = viewCounts.firstOrNull { it.optBoolean("isLive") } ?: viewCounts.firstOrNull()
+
+            val dateTexts = mutableListOf<org.json.JSONObject>()
+            findObjectsByKey(root, "updateDateTextAction", dateTexts)
+
+            LiveMetadata(
+                viewerCountText = getRunText(viewCount?.optJSONObject("viewCount"))
+                    ?.takeIf { it.isNotBlank() },
+                shortViewerCount = getRunText(viewCount?.optJSONObject("extraShortViewCount"))
+                    ?.takeIf { it.isNotBlank() },
+                dateText = getRunText(dateTexts.firstOrNull()?.optJSONObject("dateText"))
+                    ?.takeIf { it.isNotBlank() },
+            )
+        } catch (e: Exception) {
+            android.util.Log.e("YouTubeRepo", "getLiveMetadata failed for $videoId", e)
+            null
+        }
+    }
+
+    /**
+     * Turn one addChatItemAction item into a [LiveChatMessage].
+     *
+     * Renderer frequencies measured across 59 live chats (~3.3k messages):
+     * liveChatTextMessageRenderer dominates, then the system notice, then
+     * giftMessageViewModel, placeholder, Super Chat and membership. The
+     * placeholder is a slot for a message being moderated and carries only an
+     * id - it renders as nothing, so it is dropped here.
+     *
+     * [fallbackOrder] backfills a sort key for giftMessageViewModel, the one
+     * item that arrives without a timestamp of its own.
+     */
+    private fun parseLiveChatItem(item: org.json.JSONObject, fallbackOrder: Int): LiveChatMessage? {
+        try {
+            item.optJSONObject("liveChatTextMessageRenderer")?.let { r ->
+                val id = r.optString("id").takeIf { it.isNotBlank() } ?: return null
+                return LiveChatMessage.Text(
+                    id = id,
+                    timestampUsec = r.optString("timestampUsec").toLongOrNull() ?: 0L,
+                    author = parseLiveChatAuthor(r),
+                    runs = parseLiveChatRuns(r.optJSONObject("message")),
+                )
+            }
+
+            item.optJSONObject("liveChatPaidMessageRenderer")?.let { r ->
+                val id = r.optString("id").takeIf { it.isNotBlank() } ?: return null
+                return LiveChatMessage.Paid(
+                    id = id,
+                    timestampUsec = r.optString("timestampUsec").toLongOrNull() ?: 0L,
+                    author = parseLiveChatAuthor(r),
+                    // An amount-only Super Chat carries no message at all.
+                    runs = parseLiveChatRuns(r.optJSONObject("message")),
+                    amountText = getRunText(r.optJSONObject("purchaseAmountText")).orEmpty(),
+                    // Unsigned 32-bit ARGB - optInt would overflow.
+                    headerBackgroundColor = r.optLong("headerBackgroundColor"),
+                    headerTextColor = r.optLong("headerTextColor"),
+                    bodyBackgroundColor = r.optLong("bodyBackgroundColor"),
+                    bodyTextColor = r.optLong("bodyTextColor"),
+                )
+            }
+
+            // A Super Sticker: same paid tier colors, but the payload is artwork
+            // instead of a message, under a different set of color keys.
+            item.optJSONObject("liveChatPaidStickerRenderer")?.let { r ->
+                val id = r.optString("id").takeIf { it.isNotBlank() } ?: return null
+                val background = r.optLong("backgroundColor")
+                return LiveChatMessage.Paid(
+                    id = id,
+                    timestampUsec = r.optString("timestampUsec").toLongOrNull() ?: 0L,
+                    author = parseLiveChatAuthor(r),
+                    runs = emptyList(),
+                    amountText = getRunText(r.optJSONObject("purchaseAmountText")).orEmpty(),
+                    headerBackgroundColor = background,
+                    headerTextColor = r.optLong("authorNameTextColor"),
+                    bodyBackgroundColor = background,
+                    bodyTextColor = r.optLong("moneyChipTextColor"),
+                    stickerUrl = widestThumbnailUrl(
+                        r.optJSONObject("sticker")?.optJSONArray("thumbnails"),
+                        "url"
+                    )?.let { if (it.startsWith("//")) "https:$it" else it },
+                )
+            }
+
+            item.optJSONObject("liveChatMembershipItemRenderer")?.let { r ->
+                val id = r.optString("id").takeIf { it.isNotBlank() } ?: return null
+                return LiveChatMessage.Membership(
+                    id = id,
+                    timestampUsec = r.optString("timestampUsec").toLongOrNull() ?: 0L,
+                    author = parseLiveChatAuthor(r),
+                    headline = getRunText(r.optJSONObject("headerPrimaryText"))
+                        ?.takeIf { it.isNotBlank() }
+                        ?: "New member",
+                    tierName = getRunText(r.optJSONObject("headerSubtext"))
+                        ?.takeIf { it.isNotBlank() },
+                )
+            }
+
+            // Gifts use the newer viewModel format: flat "content" strings
+            // instead of run lists, an avatarViewModel instead of a thumbnail
+            // list, and no timestamp.
+            item.optJSONObject("giftMessageViewModel")?.let { vm ->
+                val id = vm.optString("id").takeIf { it.isNotBlank() } ?: return null
+                val avatar = vm.optJSONObject("authorAvatar")
+                    ?.optJSONObject("avatarViewModel")
+                    ?.optJSONObject("image")
+                    ?.optJSONArray("sources")
+                return LiveChatMessage.Gift(
+                    id = id,
+                    timestampUsec = fallbackOrder.toLong(),
+                    author = LiveChatAuthor(
+                        name = vm.optJSONObject("authorName")?.optString("content")?.trim().orEmpty(),
+                        photoUrl = widestThumbnailUrl(avatar, "url"),
+                    ),
+                    text = vm.optJSONObject("text")?.optString("content").orEmpty(),
+                    giftImageUrl = widestThumbnailUrl(vm.optJSONObject("giftImage")?.optJSONArray("sources"), "url")
+                        ?.let { if (it.startsWith("//")) "https:$it" else it },
+                )
+            }
+
+            item.optJSONObject("liveChatViewerEngagementMessageRenderer")?.let { r ->
+                val id = r.optString("id").takeIf { it.isNotBlank() } ?: return null
+                return LiveChatMessage.System(
+                    id = id,
+                    timestampUsec = r.optString("timestampUsec").toLongOrNull() ?: 0L,
+                    runs = parseLiveChatRuns(r.optJSONObject("message")),
+                )
+            }
+
+            return null
+        } catch (e: Exception) {
+            android.util.Log.w("YouTubeRepo", "parseLiveChatItem failed", e)
+            return null
+        }
+    }
+
+    /** Author name, avatar, channel id and badges, shared by every renderer. */
+    private fun parseLiveChatAuthor(renderer: org.json.JSONObject): LiveChatAuthor =
+        LiveChatAuthor(
+            name = getRunText(renderer.optJSONObject("authorName")).orEmpty(),
+            channelId = renderer.optString("authorExternalChannelId").takeIf { it.isNotBlank() },
+            photoUrl = widestThumbnailUrl(
+                renderer.optJSONObject("authorPhoto")?.optJSONArray("thumbnails"),
+                "url"
+            ),
+            badges = parseLiveChatBadges(renderer.optJSONArray("authorBadges")),
+        )
+
+    /**
+     * Badges come in two shapes: owner/moderator/verified as an icon.iconType,
+     * and channel memberships as per-channel customThumbnail artwork whose
+     * tooltip carries the tenure ("Member (1 year)").
+     */
+    private fun parseLiveChatBadges(badges: org.json.JSONArray?): List<LiveChatBadge> {
+        if (badges == null) return emptyList()
+        return (0 until badges.length()).mapNotNull { i ->
+            val r = badges.optJSONObject(i)?.optJSONObject("liveChatAuthorBadgeRenderer")
+                ?: return@mapNotNull null
+            val tooltip = r.optString("tooltip")
+            val custom = widestThumbnailUrl(
+                r.optJSONObject("customThumbnail")?.optJSONArray("thumbnails"),
+                "url"
+            )
+            if (custom != null) {
+                return@mapNotNull LiveChatBadge(LiveChatBadgeKind.MEMBER, tooltip, custom)
+            }
+            val kind = when (r.optJSONObject("icon")?.optString("iconType")) {
+                "OWNER" -> LiveChatBadgeKind.OWNER
+                "MODERATOR" -> LiveChatBadgeKind.MODERATOR
+                "VERIFIED" -> LiveChatBadgeKind.VERIFIED
+                else -> return@mapNotNull null
+            }
+            LiveChatBadge(kind, tooltip)
+        }
+    }
+
+    /**
+     * Split a chat message into text and emoji runs.
+     *
+     * Standard unicode emoji carry the character itself in emojiId and need no
+     * image; channel-custom emoji have an opaque id and must be drawn from the
+     * thumbnail, so the two cases are distinguished rather than flattened.
+     */
+    private fun parseLiveChatRuns(message: org.json.JSONObject?): List<LiveChatRun> {
+        if (message == null) return emptyList()
+        message.optString("simpleText").takeIf { it.isNotBlank() }?.let {
+            return listOf(LiveChatRun.Text(it))
+        }
+        val runs = message.optJSONArray("runs") ?: return emptyList()
+        return (0 until runs.length()).mapNotNull { i ->
+            val run = runs.optJSONObject(i) ?: return@mapNotNull null
+            val emoji = run.optJSONObject("emoji")
+            if (emoji != null) {
+                val emojiId = emoji.optString("emojiId")
+                val label = emoji.optJSONArray("shortcuts")?.optString(0)?.takeIf { it.isNotBlank() }
+                    ?: emojiId
+                // A unicode emoji's id is the character; anything longer is an
+                // opaque channel emoji key that must render as artwork.
+                val isUnicode = emojiId.isNotEmpty() && emojiId.codePointCount(0, emojiId.length) <= 2
+                LiveChatRun.Emoji(
+                    label = if (isUnicode) emojiId else label,
+                    imageUrl = if (isUnicode) null else widestThumbnailUrl(
+                        emoji.optJSONObject("image")?.optJSONArray("thumbnails"),
+                        "url"
+                    ),
+                )
+            } else {
+                run.optString("text").takeIf { it.isNotEmpty() }?.let { LiveChatRun.Text(it) }
+            }
+        }
+    }
+
+    /**
+     * The pinned card: either a message the creator pinned
+     * (liveChatTextMessageRenderer) or the auto-generated chat summary
+     * (liveChatBannerChatSummaryRenderer).
+     */
+    private fun parseLiveChatBanner(banner: org.json.JSONObject): LiveChatBanner? {
+        val contents = banner.optJSONObject("contents") ?: return null
+        contents.optJSONObject("liveChatBannerChatSummaryRenderer")?.let { summary ->
+            return LiveChatBanner(
+                id = summary.optString("liveChatSummaryId").takeIf { it.isNotBlank() }
+                    ?: banner.optString("actionId"),
+                author = null,
+                runs = parseLiveChatRuns(summary.optJSONObject("chatSummary")),
+                isSummary = true,
+            )
+        }
+        contents.optJSONObject("liveChatTextMessageRenderer")?.let { pinned ->
+            return LiveChatBanner(
+                id = pinned.optString("id").takeIf { it.isNotBlank() }
+                    ?: banner.optString("actionId"),
+                author = parseLiveChatAuthor(pinned),
+                runs = parseLiveChatRuns(pinned.optJSONObject("message")),
+                isSummary = false,
+            )
+        }
+        return null
+    }
+
+    /** Widest entry of a thumbnail/source array, which is the highest quality. */
+    private fun widestThumbnailUrl(array: org.json.JSONArray?, urlKey: String): String? {
+        if (array == null) return null
+        var best: String? = null
+        var bestWidth = -1
+        for (i in 0 until array.length()) {
+            val entry = array.optJSONObject(i) ?: continue
+            val url = entry.optString(urlKey).takeIf { it.isNotBlank() } ?: continue
+            val width = entry.optInt("width", 0)
+            if (width >= bestWidth) {
+                bestWidth = width
+                best = url
+            }
+        }
+        return best
     }
 
     /**

--- a/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
@@ -694,8 +694,11 @@ class YouTubeRepository(private val context: Context) {
             // the full TTL: adopt it instead of re-minting on every app
             // start, which put a network fetch on the first resolution of
             // each session.
+            // A negative age means the clock moved backwards since the mint
+            // (timezone/NTP correction, manual change). Treat that as expired
+            // rather than "forever fresh", which would pin a token for good.
             val persistedAt = visitorDataPrefs.getLong("visitor_data_at", 0L)
-            if (nowInner - persistedAt < VISITOR_DATA_TTL_MS) {
+            if (nowInner - persistedAt in 0 until VISITOR_DATA_TTL_MS) {
                 loadPersistedVisitorData()?.let {
                     cachedVisitorData = it
                     visitorDataFetchedAt = persistedAt
@@ -746,6 +749,32 @@ class YouTubeRepository(private val context: Context) {
                 null
             }
         }
+
+    /**
+     * Drop the current visitorData and mint a new one because *playback* failed,
+     * not resolution.
+     *
+     * [resolvePlayerStreamingData] only remints when the /player call itself
+     * shows the bot check (LOGIN_REQUIRED / missing streamingData). The other
+     * signature is a /player that answers 200 OK with URLs googlevideo then
+     * refuses with HTTP 403 — the token is flagged at the media layer only. The
+     * player sees that, resolution never does, so without this entry point the
+     * flagged token sits in prefs and is replayed on every launch for the whole
+     * 6h TTL: "restarting and clearing cache don't help, clearing data does".
+     *
+     * Safe to call speculatively; a no-op when there is no token to replace.
+     */
+    suspend fun refreshVisitorDataAfterPlaybackFailure() {
+        val flagged = cachedVisitorData ?: loadPersistedVisitorData() ?: return
+        try {
+            remintVisitorData(flagged)
+        } catch (e: Exception) {
+            android.util.Log.w(
+                "YouTubeRepository",
+                "visitorData remint after playback failure failed: ${e.message}",
+            )
+        }
+    }
 
     // Last successfully minted token, persisted per install so a cold start on
     // a flaky network still has a usable, install-unique token to fall back on.
@@ -4275,6 +4304,43 @@ class YouTubeRepository(private val context: Context) {
     private fun cacheCaptionTracks(videoId: String, tracks: List<CaptionTrack>) {
         if (tracks.isEmpty()) return
         captionCache[videoId] = CachedCaptions(tracks, System.currentTimeMillis())
+    }
+
+    /**
+     * Download and parse one caption track into cues the player overlay can
+     * render itself.
+     *
+     * Captions deliberately do not travel through ExoPlayer as a sideloaded
+     * text track: that made them part of the media source, so turning captions
+     * on or off rebuilt the source and discarded the entire video buffer. The
+     * timedtext endpoint lives on www.youtube.com rather than googlevideo, so a
+     * plain browser User-Agent is enough and no ranged chunking is needed - the
+     * payload is a few tens of KB.
+     *
+     * Returns an empty list on any failure; captions are best-effort and must
+     * never take playback down with them.
+     */
+    suspend fun getCaptionCues(track: CaptionTrack): List<VttCue> = withContext(Dispatchers.IO) {
+        try {
+            val request = okhttp3.Request.Builder()
+                .url(track.vttUrl)
+                .addHeader("User-Agent", BROWSER_USER_AGENT)
+                .build()
+            okHttpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    android.util.Log.w(
+                        "YouTubeRepo",
+                        "Caption fetch failed for ${track.languageCode}: HTTP ${response.code}"
+                    )
+                    return@withContext emptyList()
+                }
+                val body = response.body?.string().orEmpty()
+                WebVttParser.parse(body)
+            }
+        } catch (e: Exception) {
+            android.util.Log.e("YouTubeRepo", "getCaptionCues failed for ${track.languageCode}", e)
+            emptyList()
+        }
     }
 
     /**

--- a/app/src/main/java/com/ivor/ivormusic/ui/auth/YouTubeAuthDialog.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/auth/YouTubeAuthDialog.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.DialogProperties
 import com.ivor.ivormusic.data.SessionManager
+import com.ivor.ivormusic.data.YouTubeAuthUtils
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -95,12 +96,21 @@ fun YouTubeAuthDialog(
                                         // anonymous (no feed, no avatar, login loops).
                                         val cookies = CookieManager.getInstance()
                                             .getCookie("https://music.youtube.com")
+                                        // Exact cookie names, not substrings: "SID="
+                                        // also matches SAPISID=, APISID= and
+                                        // __Secure-3PSID=, so the old check passed on
+                                        // jars that had no SID session at all and saved
+                                        // a login that could never authenticate.
                                         if (cookies != null &&
-                                            cookies.contains("SAPISID") &&
-                                            cookies.contains("SID=")
+                                            YouTubeAuthUtils.missingRequiredCookies(cookies).isEmpty()
                                         ) {
                                             completed = true
-                                            sessionManager.saveCookies(cookies)
+                                            sessionManager.startSession(cookies)
+                                            // Without this the jar only reaches disk on
+                                            // WebView's own schedule, so a process death
+                                            // right after signing in left nothing to
+                                            // refresh the session from later.
+                                            CookieManager.getInstance().flush()
                                             onAuthSuccess()
                                         }
                                     }

--- a/app/src/main/java/com/ivor/ivormusic/ui/auth/YouTubeAuthViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/auth/YouTubeAuthViewModel.kt
@@ -3,6 +3,7 @@ package com.ivor.ivormusic.ui.auth
 import android.webkit.CookieManager
 import androidx.lifecycle.ViewModel
 import com.ivor.ivormusic.data.SessionManager
+import com.ivor.ivormusic.data.YouTubeAuthUtils
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
@@ -24,18 +25,23 @@ class YouTubeAuthViewModel(private val sessionManager: SessionManager) : ViewMod
     fun onUrlChanged(url: String) {
         val cookies = CookieManager.getInstance().getCookie(url)
         if (cookies != null && isLoginSuccessful(cookies)) {
-            sessionManager.saveCookies(cookies)
+            sessionManager.startSession(cookies)
+            CookieManager.getInstance().flush()
             _isLoggedIn.value = true
         }
     }
 
     /**
      * Helper to determine if the captured cookies indicate a successful login.
-     * Looks for key session cookies like "SID", "HSID", "SSID", or "SAPISID".
+     *
+     * Exact cookie names: `contains("SID=")` is also satisfied by SAPISID=,
+     * APISID= and __Secure-3PSID=, so a substring check accepted jars carrying
+     * no SID session and produced a login that authenticated nothing.
      */
     private fun isLoginSuccessful(cookies: String): Boolean {
-        // These cookies usually indicate an active session
-        return cookies.contains("SID=") && cookies.contains("HSID=") && cookies.contains("SSID=")
+        return YouTubeAuthUtils.missingRequiredCookies(cookies).isEmpty() &&
+            YouTubeAuthUtils.getCookieValue(cookies, "HSID") != null &&
+            YouTubeAuthUtils.getCookieValue(cookies, "SSID") != null
     }
 
     /**
@@ -51,7 +57,7 @@ class YouTubeAuthViewModel(private val sessionManager: SessionManager) : ViewMod
      * Save cookies directly and update login state.
      */
     fun saveCookies(cookies: String) {
-        sessionManager.saveCookies(cookies)
+        sessionManager.startSession(cookies)
         _isLoggedIn.value = true
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
@@ -15,6 +15,7 @@ import com.ivor.ivormusic.data.LikedSongsRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -42,7 +43,16 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
 
 
     private val _isYouTubeConnected = MutableStateFlow(false)
-    val isYouTubeConnected: StateFlow<Boolean> = _isYouTubeConnected.asStateFlow()
+
+    /**
+     * A YouTube session that actually authenticates. A session YouTube has
+     * rejected reads as disconnected, so account-only screens offer the sign-in
+     * wall instead of sitting on an empty list with no explanation.
+     */
+    val isYouTubeConnected: StateFlow<Boolean> =
+        combine(_isYouTubeConnected, SessionManager.sessionExpired) { connected, expired ->
+            connected && !expired
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()

--- a/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/home/HomeViewModel.kt
@@ -154,6 +154,14 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     private var tasteSeedOffset = 0
     private var videoFeedExhausted = false
 
+    // Videos already put in front of the user this session, so a refresh can
+    // skip them. FEwhat_to_watch barely moves between fetches - measured
+    // against the live feed (August 2026), re-requesting page 1 came back 22
+    // videos of which 16 had just been on screen - so a refresh that simply
+    // replaced the list looked like nothing had happened. Continuation pages,
+    // by contrast, were 100% new, which is what [refreshVideos] pulls from.
+    private val shownVideoIds = LinkedHashSet<String>()
+
     // Subscriptions tab state
     private val _subscribedChannels = MutableStateFlow<List<com.ivor.ivormusic.data.SubscribedChannel>>(emptyList())
     val subscribedChannels: StateFlow<List<com.ivor.ivormusic.data.SubscribedChannel>> = _subscribedChannels.asStateFlow()
@@ -579,12 +587,25 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
                     // entries; load-more continues from the 7th.
                     tasteSeedOffset = 6
                     videoFeedExhausted = false
+                    rememberShown(page.videos)
                 }
             } catch (e: Exception) {
                 // Handle error silently
             } finally {
                 _isVideoLoading.value = false
             }
+        }
+    }
+
+    /**
+     * Record videos as seen, keeping the newest [SHOWN_VIDEO_MEMORY] ids.
+     * Bounded because the set only exists to keep consecutive refreshes from
+     * repeating themselves, not to be a second watch history.
+     */
+    private fun rememberShown(videos: List<VideoItem>) {
+        videos.forEach { shownVideoIds.add(it.videoId) }
+        while (shownVideoIds.size > SHOWN_VIDEO_MEMORY) {
+            shownVideoIds.remove(shownVideoIds.first())
         }
     }
 
@@ -619,10 +640,11 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
                     }
                 }
 
-                val shownIds = _trendingVideos.value.mapTo(HashSet()) { it.videoId }
-                val fresh = newVideos.filterNot { it.videoId in shownIds }
+                val onScreen = _trendingVideos.value.mapTo(HashSet()) { it.videoId }
+                val fresh = newVideos.filterNot { it.videoId in onScreen }
                 if (fresh.isNotEmpty()) {
                     _trendingVideos.value = _trendingVideos.value + fresh
+                    rememberShown(fresh)
                 }
             } catch (e: Exception) {
                 // Handle error silently; the next scroll will retry
@@ -724,8 +746,81 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     /**
      * Refresh video mode content.
      */
+    /**
+     * Pull-to-refresh for the video home feed.
+     *
+     * Deliberately not a plain re-run of [loadTrendingVideos]. YouTube's
+     * FEwhat_to_watch page 1 is close to static between fetches, so replacing
+     * the list with it showed the user the videos they had just scrolled past
+     * and the refresh read as broken. Measured against the live feed in August
+     * 2026: a page-1 refetch returned 22 videos, 16 of them already on screen,
+     * while the continuation returned an entire page of new ones.
+     *
+     * So this takes whatever page 1 offers that is genuinely new, then walks
+     * forward through the feed until there is a screenful of unseen videos.
+     * When the feed really is exhausted it falls back to page 1 rather than
+     * emptying the screen.
+     */
     fun refreshVideos() {
-        loadTrendingVideos()
+        loadShortsFeed()
+        viewModelScope.launch {
+            _isVideoLoading.value = true
+            try {
+                val page = youtubeRepository.getTrendingVideos()
+                if (page.videos.isEmpty()) return@launch
+
+                val fresh = mutableListOf<VideoItem>()
+                val batchIds = HashSet<String>()
+                fun takeUnseen(videos: List<VideoItem>) {
+                    videos.forEach { video ->
+                        if (video.videoId !in shownVideoIds && batchIds.add(video.videoId)) {
+                            fresh += video
+                        }
+                    }
+                }
+                takeUnseen(page.videos)
+
+                var continuation = page.continuation
+                var pagesWalked = 0
+                while (fresh.size < MIN_FRESH_VIDEOS_ON_REFRESH &&
+                    pagesWalked < MAX_REFRESH_PAGES
+                ) {
+                    val token = continuation
+                    val more = if (token != null) {
+                        val next = youtubeRepository.getVideoFeedContinuation(token)
+                        continuation = next.continuation
+                        next.videos
+                    } else {
+                        // Logged out there is no token: page the taste-based
+                        // feed by seed window instead, wrapping back to the
+                        // newest history entries once the seeds run out.
+                        tasteSeedOffset += 6
+                        val seeded = youtubeRepository.getTasteBasedVideos(tasteSeedOffset)
+                        if (seeded.isEmpty()) {
+                            tasteSeedOffset = 0
+                            youtubeRepository.getTasteBasedVideos(0)
+                        } else {
+                            seeded
+                        }
+                    }
+                    pagesWalked++
+                    if (more.isEmpty()) break
+                    takeUnseen(more)
+                }
+
+                // Everything the feed has to offer is already seen. Showing
+                // page 1 again beats showing nothing.
+                val result = fresh.ifEmpty { page.videos }
+                _trendingVideos.value = result
+                videoFeedContinuation = continuation
+                videoFeedExhausted = false
+                rememberShown(result)
+            } catch (e: Exception) {
+                // Handle error silently; the list keeps its previous contents
+            } finally {
+                _isVideoLoading.value = false
+            }
+        }
     }
 
     // ============= PASTED YOUTUBE LINK RESOLUTION =============
@@ -888,5 +983,20 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     fun clearSearchHistory() {
         searchHistoryRepository.clearHistory()
         _searchHistory.value = emptyList()
+    }
+
+    private companion object {
+        /** Ids kept in [shownVideoIds] before the oldest are forgotten. */
+        const val SHOWN_VIDEO_MEMORY = 400
+
+        /** A refresh stops walking the feed once it has this many new videos. */
+        const val MIN_FRESH_VIDEOS_ON_REFRESH = 15
+
+        /**
+         * Cap on continuation fetches per refresh. The live feed ran out of
+         * continuation tokens after roughly 50 videos, so this bounds a refresh
+         * at about that depth instead of hammering the API.
+         */
+        const val MAX_REFRESH_PAGES = 3
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
@@ -1113,7 +1113,7 @@ fun SettingsScreen(
         CookiePasteSheet(
             onDismiss = { showCookiePasteSheet = false },
             onSave = { cookies ->
-                sessionManager.saveCookies(cookies)
+                sessionManager.startSession(cookies)
                 isLoggedIn = true
                 showCookiePasteSheet = false
                 coroutineScope.launch {

--- a/app/src/main/java/com/ivor/ivormusic/ui/share/SharedLinkHandler.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/share/SharedLinkHandler.kt
@@ -1,0 +1,152 @@
+package com.ivor.ivormusic.ui.share
+
+import android.content.Intent
+import android.widget.Toast
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import com.ivor.ivormusic.data.Song
+import com.ivor.ivormusic.data.VideoItem
+import com.ivor.ivormusic.data.YouTubeLinkParser
+import com.ivor.ivormusic.ui.home.HomeViewModel
+import com.ivor.ivormusic.ui.player.PlayerViewModel
+import com.ivor.ivormusic.ui.video.VideoPlayerViewModel
+
+/**
+ * A link handed to Koda from outside the app, waiting to be opened.
+ *
+ * [token] distinguishes two shares of the same URL, which are otherwise
+ * indistinguishable to the effect that acts on them - sharing the same video
+ * twice in a row must open it twice.
+ */
+data class PendingSharedLink(val text: String, val token: Long)
+
+/**
+ * The link carried by an incoming intent, if any: the shared text for a share
+ * sheet send, the URL itself for an "open with". Returns null for anything
+ * else, including the launcher intent.
+ */
+fun Intent.sharedLinkText(): String? = when (action) {
+    Intent.ACTION_SEND -> getStringExtra(Intent.EXTRA_TEXT)
+    Intent.ACTION_VIEW -> dataString
+    else -> null
+}?.takeIf { it.isNotBlank() }
+
+/**
+ * Opens a YouTube link shared into Koda, choosing the player from where the
+ * link points: music.youtube.com goes to the music player, everything else to
+ * the video player. Playlist links load the whole playlist; a watch link that
+ * also carries a list opens the playlist positioned on that track in music
+ * mode, and just the video in video mode (the video player has no queue, so
+ * loading the list would only cost a round trip).
+ *
+ * Video links skip metadata resolution entirely: [VideoPlayerViewModel.playVideo]
+ * only needs an id to start streaming, and its second phase fills in the title,
+ * channel and related videos. Music links have no such phase, so they resolve
+ * first and the player opens once there is something to show.
+ */
+@Composable
+fun SharedLinkHandler(
+    pendingLink: PendingSharedLink?,
+    enabled: Boolean,
+    localOnlyMode: Boolean,
+    homeViewModel: HomeViewModel,
+    playerViewModel: PlayerViewModel,
+    videoPlayerViewModel: VideoPlayerViewModel,
+    onNavigateHome: () -> Unit
+) {
+    val context = LocalContext.current
+
+    // Handled tokens are tracked here rather than cleared at the source: the
+    // effect suspends on a network call, and nulling the state it is keyed on
+    // would cancel the resolution half way through.
+    var lastHandledToken by remember { mutableStateOf<Long?>(null) }
+
+    LaunchedEffect(pendingLink?.token, enabled) {
+        val pending = pendingLink ?: return@LaunchedEffect
+        if (!enabled || lastHandledToken == pending.token) return@LaunchedEffect
+        lastHandledToken = pending.token
+
+        fun toast(message: String) =
+            Toast.makeText(context, message, Toast.LENGTH_LONG).show()
+
+        val link = YouTubeLinkParser.parseFromSharedText(pending.text)
+        if (link == null) {
+            toast("No YouTube link found in what you shared")
+            return@LaunchedEffect
+        }
+        if (localOnlyMode) {
+            toast("Local only mode is on. Turn it off in Settings to open YouTube links.")
+            return@LaunchedEffect
+        }
+
+        // The music player lives inside the Home screen, so it has nothing to
+        // draw on top of Settings or Downloads.
+        onNavigateHome()
+
+        val videoId = link.videoId
+        val playlistId = link.playlistId
+
+        when {
+            // Music playlist, opening on the shared track when the link names one
+            link.isMusicLink && playlistId != null -> {
+                val songs = homeViewModel.resolvePlaylistSongsFromLink(playlistId)
+                if (songs.isEmpty()) {
+                    toast("Couldn't open that playlist")
+                } else {
+                    val start = songs.firstOrNull { it.id == videoId } ?: songs.first()
+                    playerViewModel.playQueue(songs, start)
+                }
+            }
+
+            link.isMusicLink && videoId != null -> {
+                val video = homeViewModel.resolveVideoFromLink(videoId)
+                if (video == null) {
+                    toast("Couldn't open that link")
+                } else {
+                    playerViewModel.playSong(video.toSong())
+                }
+            }
+
+            videoId != null -> videoPlayerViewModel.playVideo(placeholderVideo(videoId))
+
+            playlistId != null -> {
+                val videos = homeViewModel.resolvePlaylistVideosFromLink(playlistId)
+                if (videos.isEmpty()) {
+                    toast("Couldn't open that playlist")
+                } else {
+                    videoPlayerViewModel.playVideo(videos.first())
+                }
+            }
+        }
+    }
+}
+
+/**
+ * The bare minimum [VideoItem] needed to start playback from an id alone. The
+ * thumbnail is derived rather than fetched so the player has a poster to show
+ * while the first frames buffer; the title and channel arrive with the
+ * watch-next phase a moment later.
+ */
+private fun placeholderVideo(videoId: String) = VideoItem(
+    videoId = videoId,
+    title = "",
+    channelName = "",
+    thumbnailUrl = "https://i.ytimg.com/vi/$videoId/hqdefault.jpg",
+    duration = 0L,
+    viewCount = ""
+)
+
+/** Music-mode representation of a video resolved from a shared link. */
+private fun VideoItem.toSong(): Song = Song.fromYouTube(
+    videoId = videoId,
+    title = title,
+    artist = channelName,
+    album = "",
+    duration = duration * 1000,
+    thumbnailUrl = thumbnailUrl
+)

--- a/app/src/main/java/com/ivor/ivormusic/ui/shorts/ShortsPlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/shorts/ShortsPlayerViewModel.kt
@@ -11,6 +11,7 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MergingMediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import com.ivor.ivormusic.data.CommentItem
@@ -209,6 +210,19 @@ class ShortsPlayerViewModel(application: android.app.Application) : AndroidViewM
     private val _isPostingComment = MutableStateFlow(false)
     val isPostingComment: StateFlow<Boolean> = _isPostingComment.asStateFlow()
 
+    /**
+     * Stream data source factory: ChunkedStreamDataSource fetches googlevideo
+     * media in bounded ranged chunks (open-ended requests are server-paced to
+     * the media bitrate) and picks the per-request User-Agent matching the
+     * URL's issuing client — googlevideo answers 403 on a UA mismatch.
+     *
+     * Declared before [init] on purpose: the ExoPlayer built there installs it
+     * as the player-wide MediaSource factory, so a lazy declared further down
+     * the class would still be an uninitialised delegate at that point.
+     */
+    private val streamDataSourceFactory =
+        DefaultDataSource.Factory(context, com.ivor.ivormusic.data.ChunkedStreamDataSource.Factory())
+
     init {
         // First frame after ~1s buffered, like the video player. Shorts are
         // under a minute, so the 60s max buffer already covers the whole clip
@@ -220,7 +234,13 @@ class ShortsPlayerViewModel(application: android.app.Application) : AndroidViewM
             .setPrioritizeTimeOverSizeThresholds(true)
             .build()
 
+        // Every media source this player builds must fetch through
+        // ChunkedStreamDataSource. loadQuality() passes it explicitly for the
+        // progressive/merged paths, but the adaptive branch hands the player a
+        // bare MediaItem, which would otherwise be served by Media3's stock
+        // DefaultDataSource - no per-URL User-Agent, so googlevideo answers 403.
         _exoPlayer = ExoPlayer.Builder(context)
+            .setMediaSourceFactory(DefaultMediaSourceFactory(streamDataSourceFactory))
             .setLoadControl(loadControl)
             .setWakeMode(C.WAKE_MODE_NETWORK)
             .setAudioAttributes(AudioAttributes.DEFAULT, true)
@@ -404,16 +424,6 @@ class ShortsPlayerViewModel(application: android.app.Application) : AndroidViewM
     // ---------------- Playback helpers (same conventions as the video player) ----------------
 
     /**
-     * Stream data source factory: ChunkedStreamDataSource fetches googlevideo
-     * media in bounded ranged chunks (open-ended requests are server-paced to
-     * the media bitrate) and picks the per-request User-Agent matching the
-     * URL's issuing client — googlevideo answers 403 on a UA mismatch.
-     */
-    private val streamDataSourceFactory by lazy {
-        DefaultDataSource.Factory(context, com.ivor.ivormusic.data.ChunkedStreamDataSource.Factory())
-    }
-
-    /**
      * Starting quality from the per-network video quality setting (fresh pref
      * read), like VideoPlayerViewModel.pickDefaultQuality. The list is sorted
      * highest-first, so the first label at or below the target height wins.
@@ -431,6 +441,21 @@ class ShortsPlayerViewModel(application: android.app.Application) : AndroidViewM
     }
 
     private fun loadQuality(quality: VideoQuality) {
+        // Adaptive manifests carry no progressive URL to wrap: hand the
+        // MediaItem to the player and let its MediaSource factory build the
+        // DASH/HLS source. Feeding a manifest to ProgressiveMediaSource (what
+        // this used to do for every quality) fails extraction outright.
+        if (quality.isDASH) {
+            _exoPlayer?.setMediaItem(
+                MediaItem.Builder()
+                    .setUri(quality.url)
+                    .setMimeType(adaptiveMimeType(quality))
+                    .build()
+            )
+            _exoPlayer?.prepare()
+            return
+        }
+
         val dataSourceFactory = streamDataSourceFactory
         val audioUrl = quality.audioUrl
         if (audioUrl != null) {
@@ -446,6 +471,19 @@ class ShortsPlayerViewModel(application: android.app.Application) : AndroidViewM
         }
         _exoPlayer?.prepare()
     }
+
+    /**
+     * MIME for an adaptive quality. Both DASH and HLS entries arrive with
+     * isDASH set and are told apart only by [VideoQuality.format], so pinning
+     * MPD unconditionally would make the factory build a DashMediaSource for an
+     * m3u8 playlist and fail the load.
+     */
+    private fun adaptiveMimeType(quality: VideoQuality): String =
+        if (quality.format.equals("HLS", ignoreCase = true)) {
+            androidx.media3.common.MimeTypes.APPLICATION_M3U8
+        } else {
+            androidx.media3.common.MimeTypes.APPLICATION_MPD
+        }
 
     // ---------------- Engagement actions (optimistic with rollback) ----------------
 

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/LiveChatPanel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/LiveChatPanel.kt
@@ -1,0 +1,999 @@
+package com.ivor.ivormusic.ui.video
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.DragInteraction
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.foundation.text.appendInlineContent
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.Send
+import androidx.compose.material.icons.rounded.ArrowDownward
+import androidx.compose.material.icons.rounded.CardGiftcard
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Info
+import androidx.compose.material.icons.rounded.Lock
+import androidx.compose.material.icons.rounded.PushPin
+import androidx.compose.material.icons.rounded.Shield
+import androidx.compose.material.icons.rounded.Verified
+import androidx.compose.material.icons.rounded.WorkspacePremium
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.ivor.ivormusic.data.LiveChatAuthor
+import com.ivor.ivormusic.data.LiveChatBadge
+import com.ivor.ivormusic.data.LiveChatBadgeKind
+import com.ivor.ivormusic.data.LiveChatBanner
+import com.ivor.ivormusic.data.LiveChatMessage
+import com.ivor.ivormusic.data.LiveChatRun
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
+
+/**
+ * Slack at the live edge. A settled scroll within this many pixels of the
+ * newest message still counts as following, so a stray flick does not pause
+ * chat.
+ */
+private const val LIVE_EDGE_TOLERANCE_PX = 120
+
+/** Characters left before the message-length counter is worth showing. */
+private const val COUNTER_VISIBLE_AT = 30
+
+/**
+ * Live chat, in two dresses.
+ *
+ * The portrait dress slides up over the info area the way [CommentsPanel]
+ * does - opaque surfaceContainer, rounded top, a composer pinned at the
+ * bottom. The [compact] dress is the landscape one: a narrow translucent
+ * column docked to the right of the video, so chat reads alongside the stream
+ * instead of covering it.
+ *
+ * The list runs reversed, which is what makes it behave like a chat rather
+ * than a feed: new messages enter at the visual bottom and the view stays
+ * pinned there on its own, while scrolling up to read back holds position and
+ * surfaces the jump-to-latest pill instead of yanking the user forward.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun LiveChatPanel(
+    messages: List<LiveChatMessage>,
+    banner: LiveChatBanner?,
+    isLoading: Boolean,
+    /** Null while the first poll is still in flight. */
+    isAvailable: Boolean?,
+    canSend: Boolean,
+    isSending: Boolean,
+    maxMessageLength: Int,
+    restriction: String?,
+    onSend: (String, (String) -> Unit) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    compact: Boolean = false,
+) {
+    val listState = rememberLazyListState()
+    val scope = rememberCoroutineScope()
+
+    /**
+     * Whether the view is riding the live edge.
+     *
+     * This cannot be derived from the scroll position alone. The list is
+     * reversed, so an arriving message is *prepended*, and Compose keeps the
+     * viewport anchored on the message the user was looking at - which pushes
+     * firstVisibleItemIndex off 0 without the user having scrolled at all. Read
+     * naively that looks identical to scrolling back, and the auto-follow
+     * switches itself off after the very first message.
+     *
+     * So a drag is the only thing that detaches it. Touching the list pauses
+     * chat immediately, and where it comes to rest - after any fling - decides
+     * whether following resumes. The follow-scrolls this screen performs itself
+     * are deliberately not consulted: one of them settling a row short while a
+     * message lands mid-animation would otherwise latch the pause on and freeze
+     * the panel behind a pill.
+     */
+    var followLatest by remember { mutableStateOf(true) }
+    LaunchedEffect(listState) {
+        var userDragged = false
+        launch {
+            listState.interactionSource.interactions.collect { interaction ->
+                if (interaction is DragInteraction.Start) {
+                    userDragged = true
+                    followLatest = false
+                }
+            }
+        }
+        snapshotFlow { listState.isScrollInProgress }
+            .filter { !it }
+            .collect {
+                if (!userDragged) return@collect
+                userDragged = false
+                followLatest = listState.firstVisibleItemIndex == 0 &&
+                    listState.firstVisibleItemScrollOffset < LIVE_EDGE_TOLERANCE_PX
+            }
+    }
+
+    // Index 0 is the newest message. Follow it while the user is at the live
+    // edge; a large jump (the opening backlog, or a flush) snaps rather than
+    // animating through hundreds of rows.
+    LaunchedEffect(messages.lastOrNull()?.id, followLatest) {
+        if (!followLatest || messages.isEmpty()) return@LaunchedEffect
+        if (listState.firstVisibleItemIndex > 4) {
+            listState.scrollToItem(0)
+        } else {
+            listState.animateScrollToItem(0)
+        }
+    }
+
+    // How much was missed while reading back, so the pill can say so rather
+    // than just offering a ride to the bottom.
+    var pausedAtId by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(followLatest) {
+        pausedAtId = if (followLatest) null else messages.lastOrNull()?.id
+    }
+    val missedCount = remember(messages, pausedAtId) {
+        val anchor = pausedAtId
+        if (anchor == null) {
+            0
+        } else {
+            val index = messages.indexOfLast { it.id == anchor }
+            // The anchor aging out of the capped buffer means everything on
+            // screen is newer than it.
+            if (index < 0) messages.size else messages.lastIndex - index
+        }
+    }
+
+    val containerColor = if (compact) {
+        MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.88f)
+    } else {
+        MaterialTheme.colorScheme.surfaceContainer
+    }
+
+    Surface(
+        shape = if (compact) {
+            RoundedCornerShape(28.dp)
+        } else {
+            RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp)
+        },
+        color = containerColor,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        modifier = modifier,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .imePadding(),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        start = if (compact) 16.dp else 24.dp,
+                        end = if (compact) 4.dp else 12.dp,
+                        top = if (compact) 8.dp else 12.dp,
+                        bottom = 4.dp,
+                    ),
+            ) {
+                LiveDot()
+                Spacer(Modifier.width(10.dp))
+                Text(
+                    text = "Live chat",
+                    style = if (compact) {
+                        MaterialTheme.typography.titleMedium
+                    } else {
+                        MaterialTheme.typography.headlineSmall
+                    },
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.weight(1f),
+                )
+                IconButton(onClick = onDismiss) {
+                    Icon(
+                        Icons.Rounded.Close,
+                        contentDescription = "Close live chat",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            banner?.let {
+                LiveChatBannerCard(
+                    banner = it,
+                    modifier = Modifier.padding(
+                        horizontal = if (compact) 12.dp else 20.dp,
+                        vertical = 4.dp,
+                    ),
+                )
+            }
+
+            Box(modifier = Modifier.weight(1f)) {
+                when {
+                    isLoading && messages.isEmpty() -> {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(48.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            LoadingIndicator(color = MaterialTheme.colorScheme.primary)
+                        }
+                    }
+
+                    isAvailable == false -> {
+                        LiveChatEmptyState(
+                            text = "Live chat is turned off for this stream",
+                        )
+                    }
+
+                    messages.isEmpty() -> {
+                        LiveChatEmptyState(text = "Waiting for messages")
+                    }
+
+                    else -> {
+                        LazyColumn(
+                            state = listState,
+                            reverseLayout = true,
+                            modifier = Modifier.fillMaxSize(),
+                            contentPadding = PaddingValues(
+                                start = if (compact) 12.dp else 20.dp,
+                                end = if (compact) 12.dp else 20.dp,
+                                top = 12.dp,
+                                bottom = 8.dp,
+                            ),
+                            verticalArrangement = Arrangement.spacedBy(if (compact) 10.dp else 14.dp),
+                        ) {
+                            val ordered = messages.asReversed()
+                            items(
+                                count = ordered.size,
+                                key = { ordered[it].id },
+                            ) { index ->
+                                LiveChatMessageRow(
+                                    message = ordered[index],
+                                    compact = compact,
+                                    modifier = Modifier.animateItem(),
+                                )
+                            }
+                        }
+                    }
+                }
+
+                // Reading back through chat should not be interrupted by the
+                // stream of new messages, so getting back to the bottom is an
+                // explicit tap rather than an automatic jump.
+                //
+                // Qualified: this Box is lexically inside a Column, whose
+                // scoped AnimatedVisibility would otherwise win overload
+                // resolution and fail to compile.
+                androidx.compose.animation.AnimatedVisibility(
+                    visible = !followLatest && messages.isNotEmpty(),
+                    enter = scaleIn(spring(dampingRatio = Spring.DampingRatioMediumBouncy)) + fadeIn(),
+                    exit = scaleOut() + fadeOut(),
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(bottom = 12.dp),
+                ) {
+                    JumpToLatestPill(
+                        missedCount = missedCount,
+                        onClick = {
+                            scope.launch {
+                                listState.animateScrollToItem(0)
+                                followLatest = true
+                            }
+                        },
+                    )
+                }
+            }
+
+            LiveChatComposer(
+                canSend = canSend,
+                isSending = isSending,
+                maxMessageLength = maxMessageLength,
+                restriction = restriction,
+                compact = compact,
+                onSend = onSend,
+            )
+        }
+    }
+}
+
+@Composable
+private fun LiveChatEmptyState(text: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+/**
+ * Chat is paused while reading back. Naming the number of missed messages is
+ * what makes it a status rather than just a button - it tells the user the
+ * stream is still running behind the scroll.
+ */
+@Composable
+private fun JumpToLatestPill(missedCount: Int, onClick: () -> Unit) {
+    Surface(
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.primary,
+        contentColor = MaterialTheme.colorScheme.onPrimary,
+        onClick = onClick,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+        ) {
+            Icon(
+                Icons.Rounded.ArrowDownward,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+            )
+            Text(
+                text = when {
+                    missedCount <= 0 -> "Latest"
+                    missedCount == 1 -> "1 new message"
+                    else -> "$missedCount new messages"
+                },
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+    }
+}
+
+/**
+ * One entry in the chat stream. Ordinary messages stay visually quiet - they
+ * are 95% of the traffic - while Super Chats, memberships and gifts get a
+ * container so they stand out the way they do on YouTube.
+ */
+@Composable
+private fun LiveChatMessageRow(
+    message: LiveChatMessage,
+    compact: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    when (message) {
+        is LiveChatMessage.Text -> LiveChatTextRow(message, compact, modifier)
+        is LiveChatMessage.Paid -> LiveChatPaidRow(message, compact, modifier)
+        is LiveChatMessage.Membership -> LiveChatEventRow(
+            author = message.author,
+            icon = Icons.Rounded.WorkspacePremium,
+            headline = message.headline,
+            detail = message.tierName,
+            modifier = modifier,
+        )
+
+        is LiveChatMessage.Gift -> LiveChatEventRow(
+            author = message.author,
+            icon = Icons.Rounded.CardGiftcard,
+            headline = "${message.author.name} ${message.text}".trim(),
+            detail = null,
+            modifier = modifier,
+        )
+
+        is LiveChatMessage.System -> LiveChatSystemRow(message, modifier)
+    }
+}
+
+@Composable
+private fun LiveChatTextRow(
+    message: LiveChatMessage.Text,
+    compact: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val avatarSize = if (compact) 20.dp else 24.dp
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        AuthorAvatar(message.author, avatarSize)
+        // Author name and message share one text flow so a short message wraps
+        // beside the name instead of claiming a line of its own, which is what
+        // keeps a busy chat readable in a narrow column.
+        LiveChatRunsText(
+            runs = message.runs,
+            prefix = message.author,
+            style = if (compact) {
+                MaterialTheme.typography.bodySmall
+            } else {
+                MaterialTheme.typography.bodyMedium
+            },
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun LiveChatPaidRow(
+    message: LiveChatMessage.Paid,
+    compact: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    // The only colors in the app that do not come from the ColorScheme: they
+    // are part of the Super Chat amount tier, sent by YouTube with the message.
+    val headerColor = Color(message.headerBackgroundColor.toInt())
+    val bodyColor = Color(message.bodyBackgroundColor.toInt())
+    val headerText = Color(message.headerTextColor.toInt())
+    val bodyText = Color(message.bodyTextColor.toInt())
+
+    Surface(
+        shape = RoundedCornerShape(16.dp),
+        color = bodyColor,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(headerColor)
+                    .padding(horizontal = 12.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                AuthorAvatar(message.author, 24.dp)
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        text = message.author.name,
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = headerText,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = message.amountText,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = headerText,
+                    )
+                }
+            }
+            message.stickerUrl?.let { sticker ->
+                AsyncImage(
+                    model = sticker,
+                    contentDescription = "Super Sticker",
+                    modifier = Modifier
+                        .padding(12.dp)
+                        .size(if (compact) 56.dp else 72.dp),
+                )
+            }
+            if (message.runs.isNotEmpty()) {
+                LiveChatRunsText(
+                    runs = message.runs,
+                    prefix = null,
+                    style = if (compact) {
+                        MaterialTheme.typography.bodySmall
+                    } else {
+                        MaterialTheme.typography.bodyMedium
+                    },
+                    color = bodyText,
+                    modifier = Modifier.padding(12.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LiveChatEventRow(
+    author: LiveChatAuthor,
+    icon: ImageVector,
+    headline: String,
+    detail: String?,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.tertiaryContainer,
+        contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Icon(icon, contentDescription = null, modifier = Modifier.size(20.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    text = headline,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                detail?.let {
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.bodySmall,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                if (author.name.isNotBlank() && !headline.startsWith(author.name)) {
+                    Text(
+                        text = author.name,
+                        style = MaterialTheme.typography.labelMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LiveChatSystemRow(
+    message: LiveChatMessage.System,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Icon(
+            Icons.Rounded.Info,
+            contentDescription = null,
+            modifier = Modifier.size(16.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        LiveChatRunsText(
+            runs = message.runs,
+            prefix = null,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun LiveChatBannerCard(banner: LiveChatBanner, modifier: Modifier = Modifier) {
+    Surface(
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Icon(
+                Icons.Rounded.PushPin,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+            )
+            LiveChatRunsText(
+                runs = banner.runs,
+                prefix = banner.author,
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 6,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun AuthorAvatar(author: LiveChatAuthor, size: Dp) {
+    if (!author.photoUrl.isNullOrBlank()) {
+        AsyncImage(
+            model = author.photoUrl,
+            contentDescription = null,
+            modifier = Modifier
+                .size(size)
+                .clip(CircleShape),
+            contentScale = ContentScale.Crop,
+        )
+    } else {
+        Box(
+            modifier = Modifier
+                .size(size)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primaryContainer),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = author.name.trimStart('@').take(1).uppercase(),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+    }
+}
+
+/**
+ * Render a chat message as one text flow: optional author name and badges,
+ * then the message runs.
+ *
+ * Custom channel emoji are images inside the text, so they ride as
+ * [InlineTextContent] rather than being dropped or replaced with their
+ * shortcut. Standard unicode emoji already carry the character and need no
+ * such treatment.
+ */
+@Composable
+private fun LiveChatRunsText(
+    runs: List<LiveChatRun>,
+    prefix: LiveChatAuthor?,
+    style: TextStyle,
+    modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.colorScheme.onSurface,
+    maxLines: Int = Int.MAX_VALUE,
+) {
+    val authorColor = when {
+        prefix?.isOwner == true -> MaterialTheme.colorScheme.tertiary
+        prefix?.isModerator == true -> MaterialTheme.colorScheme.primary
+        prefix?.isMember == true -> MaterialTheme.colorScheme.secondary
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    // Filled while the string is built, so it must not survive recomposition -
+    // a remembered map would keep entries for messages that are no longer here.
+    val inlineContent = mutableMapOf<String, InlineTextContent>()
+
+    val text = buildAnnotatedString {
+        prefix?.let { author ->
+            author.badges.forEachIndexed { index, badge ->
+                val id = "badge-$index-${badge.tooltip}"
+                appendInlineContent(id, badge.tooltip)
+                append(" ")
+                inlineContent[id] = InlineTextContent(
+                    Placeholder(
+                        width = style.fontSize,
+                        height = style.fontSize,
+                        placeholderVerticalAlign = PlaceholderVerticalAlign.TextCenter,
+                    )
+                ) { LiveChatBadgeIcon(badge) }
+            }
+            withStyle(SpanStyle(color = authorColor, fontWeight = FontWeight.Bold)) {
+                append(author.name.trimStart('@'))
+            }
+            append("  ")
+        }
+
+        runs.forEachIndexed { index, run ->
+            when (run) {
+                is LiveChatRun.Text -> append(run.text)
+                is LiveChatRun.Emoji -> {
+                    if (run.imageUrl == null) {
+                        append(run.label)
+                    } else {
+                        val id = "emoji-$index-${run.label}"
+                        appendInlineContent(id, run.label)
+                        inlineContent[id] = InlineTextContent(
+                            Placeholder(
+                                width = style.fontSize * 1.3f,
+                                height = style.fontSize * 1.3f,
+                                placeholderVerticalAlign = PlaceholderVerticalAlign.TextCenter,
+                            )
+                        ) {
+                            AsyncImage(
+                                model = run.imageUrl,
+                                contentDescription = run.label,
+                                modifier = Modifier.fillMaxSize(),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Text(
+        text = text,
+        style = style,
+        color = color,
+        inlineContent = inlineContent,
+        maxLines = maxLines,
+        overflow = TextOverflow.Ellipsis,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun LiveChatBadgeIcon(badge: LiveChatBadge) {
+    when (badge.kind) {
+        LiveChatBadgeKind.MEMBER -> {
+            if (!badge.imageUrl.isNullOrBlank()) {
+                AsyncImage(
+                    model = badge.imageUrl,
+                    contentDescription = badge.tooltip,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+        }
+
+        LiveChatBadgeKind.OWNER -> Icon(
+            Icons.Rounded.WorkspacePremium,
+            contentDescription = badge.tooltip,
+            modifier = Modifier.fillMaxSize(),
+            tint = MaterialTheme.colorScheme.tertiary,
+        )
+
+        LiveChatBadgeKind.MODERATOR -> Icon(
+            Icons.Rounded.Shield,
+            contentDescription = badge.tooltip,
+            modifier = Modifier.fillMaxSize(),
+            tint = MaterialTheme.colorScheme.primary,
+        )
+
+        LiveChatBadgeKind.VERIFIED -> Icon(
+            Icons.Rounded.Verified,
+            contentDescription = badge.tooltip,
+            modifier = Modifier.fillMaxSize(),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+/**
+ * The composer, in three states: open, closed by the creator ([restriction] -
+ * subscribers-only, slow mode, a ban), or signed out.
+ *
+ * A send clears the field immediately, because the message appears in the list
+ * in the same breath - the send response echoes it back. If the server rejects
+ * it instead, the text is put back and the reason shown, so a message is never
+ * silently swallowed.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun LiveChatComposer(
+    canSend: Boolean,
+    isSending: Boolean,
+    maxMessageLength: Int,
+    restriction: String?,
+    compact: Boolean,
+    onSend: (String, (String) -> Unit) -> Unit,
+) {
+    var text by remember { mutableStateOf("") }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    // Nothing to type into when chat is closed - say why instead of offering a
+    // field that cannot work.
+    if (restriction != null) {
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding(),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Icon(
+                    Icons.Rounded.Lock,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = restriction,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        return
+    }
+
+    val remaining = maxMessageLength - text.length
+
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        modifier = Modifier
+            .fillMaxWidth()
+            .navigationBarsPadding(),
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+            AnimatedVisibility(visible = error != null) {
+                Text(
+                    text = error.orEmpty(),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(start = 16.dp, bottom = 6.dp),
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedTextField(
+                    value = text,
+                    // YouTube hard-limits chat messages, so the field enforces it
+                    // rather than letting the send fail server-side.
+                    onValueChange = {
+                        if (it.length <= maxMessageLength) {
+                            text = it
+                            error = null
+                        }
+                    },
+                    modifier = Modifier.weight(1f),
+                    placeholder = {
+                        Text(if (canSend) "Chat..." else "Sign in to chat")
+                    },
+                    // Only worth the space once the limit is actually in reach.
+                    suffix = if (remaining <= COUNTER_VISIBLE_AT) {
+                        { Text("$remaining", style = MaterialTheme.typography.labelSmall) }
+                    } else {
+                        null
+                    },
+                    shape = CircleShape,
+                    maxLines = if (compact) 2 else 4,
+                    enabled = canSend && !isSending,
+                    textStyle = if (compact) {
+                        MaterialTheme.typography.bodySmall
+                    } else {
+                        MaterialTheme.typography.bodyMedium
+                    },
+                )
+                if (isSending) {
+                    LoadingIndicator(
+                        modifier = Modifier.size(32.dp),
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                } else {
+                    val enabled = canSend && text.isNotBlank()
+                    FilledIconButton(
+                        onClick = {
+                            val body = text
+                            if (body.isNotBlank()) {
+                                text = ""
+                                error = null
+                                onSend(body) { reason ->
+                                    // Rejected: hand the text back so it is not lost.
+                                    if (text.isBlank()) text = body
+                                    error = reason
+                                }
+                            }
+                        },
+                        enabled = enabled,
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Rounded.Send,
+                            contentDescription = "Send message",
+                            modifier = Modifier.size(20.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * The pulsing dot that marks anything live. Deliberately a slow, low-amplitude
+ * pulse: it has to read as "this is happening now" from the corner of the eye
+ * without competing with the video.
+ */
+@Composable
+fun LiveDot(modifier: Modifier = Modifier, size: Dp = 8.dp) {
+    val transition = rememberInfiniteTransition(label = "liveDot")
+    val alpha by transition.animateFloat(
+        initialValue = 1f,
+        targetValue = 0.35f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(900),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "liveDotAlpha",
+    )
+    Box(
+        modifier = modifier
+            .size(size)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.error.copy(alpha = alpha)),
+    )
+}
+
+/**
+ * "LIVE" pill plus the concurrent viewer count, for the metadata row and the
+ * player chrome.
+ */
+@Composable
+fun LiveBadge(
+    viewerCount: String?,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Surface(
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.errorContainer,
+            contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+            ) {
+                LiveDot(size = 7.dp)
+                Text(
+                    text = "LIVE",
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+        }
+        viewerCount?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/PipVideoSurface.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/PipVideoSurface.kt
@@ -1,0 +1,79 @@
+package com.ivor.ivormusic.ui.video
+
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.ui.AspectRatioFrameLayout
+import androidx.media3.ui.PlayerView
+
+/**
+ * Everything the app draws while it is in system Picture-in-Picture: the video
+ * and nothing else.
+ *
+ * This is rendered *instead of* the NavHost and the player overlays, not on top
+ * of them. Previously the whole app carried on composing behind a full-screen
+ * PlayerView, so home screens and animations kept running at PiP frame rate for
+ * no visible benefit, and any gap around the video showed app chrome rather
+ * than black.
+ *
+ * The window is already sized to the video's aspect ratio by
+ * PictureInPictureParams, so RESIZE_MODE_FIT lands flush and the surrounding
+ * black is only ever seen while the window is being resized.
+ */
+@androidx.annotation.OptIn(UnstableApi::class)
+@Composable
+fun PipVideoSurface(
+    viewModel: VideoPlayerViewModel,
+    modifier: Modifier = Modifier
+) {
+    val exoPlayer = viewModel.exoPlayer ?: return
+    val captionCues by viewModel.captionCues.collectAsState()
+
+    androidx.compose.foundation.layout.Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.Black)
+    ) {
+        AndroidView(
+            factory = { ctx ->
+                PlayerView(ctx).apply {
+                    player = exoPlayer
+                    useController = false
+                    resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
+                    // The PiP window is the video; a shutter over it during the
+                    // hand-off from the full player's surface just reads as a
+                    // black flash on entry.
+                    setShutterBackgroundColor(android.graphics.Color.TRANSPARENT)
+                    setKeepContentOnPlayerReset(true)
+                    layoutParams = FrameLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.MATCH_PARENT
+                    )
+                }
+            },
+            update = { playerView -> playerView.player = exoPlayer },
+            // Hand the surface back before this view is destroyed - the same
+            // ExoPlayer is rendered by the full and mini PlayerViews too.
+            onRelease = { playerView -> playerView.player = null },
+            modifier = Modifier.fillMaxSize()
+        )
+
+        // Captions used to come free with PlayerView's SubtitleView. They are
+        // drawn by the app now, so PiP has to ask for them explicitly.
+        CaptionOverlay(
+            cues = captionCues,
+            player = exoPlayer,
+            bottomPadding = 8.dp,
+            compact = true
+        )
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontWeight
@@ -84,6 +86,17 @@ fun VideoPlayerContent(
     val captionTracks by viewModel.captionTracks.collectAsState()
     val selectedCaption by viewModel.selectedCaption.collectAsState()
     val captionCues by viewModel.captionCues.collectAsState()
+    val videoAspectRatio by viewModel.videoAspectRatio.collectAsState()
+    val videoSurfaceBounds by viewModel.videoSurfaceBounds.collectAsState()
+
+    // PiP is a device capability, not a given: Android TV and a few OEM builds
+    // ship without it, and the button must not sit there doing nothing.
+    val pipSupported = remember(context) {
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+            context.packageManager.hasSystemFeature(
+                android.content.pm.PackageManager.FEATURE_PICTURE_IN_PICTURE
+            )
+    }
     val isCaptionsLoading by viewModel.isCaptionsLoading.collectAsState()
     val isLooping by viewModel.isLooping.collectAsState()
     val playbackSpeed by viewModel.playbackSpeed.collectAsState()
@@ -276,6 +289,20 @@ fun VideoPlayerContent(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(Color.Black) // Extra black background to prevent any bleed
+                    // Fullscreen reports its own bounds: the portrait video box
+                    // is not composed here, so without this the PiP source rect
+                    // would still describe the small inline player.
+                    .onGloballyPositioned { coords ->
+                        val rect = coords.boundsInWindow()
+                        viewModel.setVideoSurfaceBounds(
+                            android.graphics.Rect(
+                                rect.left.toInt(),
+                                rect.top.toInt(),
+                                rect.right.toInt(),
+                                rect.bottom.toInt()
+                            )
+                        )
+                    }
             ) {
                 FullscreenPlayerContent(
                 exoPlayer = exoPlayer,
@@ -337,6 +364,20 @@ fun VideoPlayerContent(
                         .fillMaxWidth()
                         .aspectRatio(16f / 9f)
                         .background(Color.Black)
+                        // Reported so PictureInPictureParams can animate the
+                        // window out of the video rect instead of the whole
+                        // screen. Window coordinates are what the system wants.
+                        .onGloballyPositioned { coords ->
+                            val rect = coords.boundsInWindow()
+                            viewModel.setVideoSurfaceBounds(
+                                android.graphics.Rect(
+                                    rect.left.toInt(),
+                                    rect.top.toInt(),
+                                    rect.right.toInt(),
+                                    rect.bottom.toInt()
+                                )
+                            )
+                        }
                 ) {
                     PortraitPlayerContent(
                         exoPlayer = exoPlayer,
@@ -372,6 +413,13 @@ fun VideoPlayerContent(
                             showCaptionsSheet = true
                         },
                         captionCues = captionCues,
+                        showPipButton = pipSupported,
+                        onPipClick = {
+                            val host = activity as? androidx.activity.ComponentActivity
+                            if (host != null) {
+                                enterPipMode(host, videoAspectRatio, videoSurfaceBounds)
+                            }
+                        },
                         minimizeDragEnabled = true,
                         onMinimizeDragDelta = onMinimizeDragDelta,
                         onMinimizeDragRelease = onMinimizeDragRelease,

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontWeight
@@ -115,12 +116,30 @@ fun VideoPlayerContent(
     val isVideoPlaylistsLoading by viewModel.isVideoPlaylistsLoading.collectAsState()
     val channelVideos by viewModel.channelVideos.collectAsState()
     val isChannelVideosLoading by viewModel.isChannelVideosLoading.collectAsState()
+    val isLive by viewModel.isLive.collectAsState()
+    val liveViewerCount by viewModel.liveViewerCount.collectAsState()
+    val liveChatMessages by viewModel.liveChatMessages.collectAsState()
+    val liveChatBanner by viewModel.liveChatBanner.collectAsState()
+    val isLiveChatAvailable by viewModel.isLiveChatAvailable.collectAsState()
+    val isLiveChatLoading by viewModel.isLiveChatLoading.collectAsState()
+    val canSendLiveChat by viewModel.canSendLiveChat.collectAsState()
+    val isSendingLiveChat by viewModel.isSendingLiveChat.collectAsState()
+    val liveChatMaxLength by viewModel.liveChatMaxLength.collectAsState()
+    val liveChatRestriction by viewModel.liveChatRestriction.collectAsState()
 
     // Local UI State
     var showControls by remember { mutableStateOf(false) }
     var isFullscreen by remember { mutableStateOf(false) }
     var showChaptersSheet by remember { mutableStateOf(false) }
     var showCaptionsSheet by remember { mutableStateOf(false) }
+    var showLiveChat by remember { mutableStateOf(false) }
+
+    // Landscape chat column: about a third of the screen, bounded so it stays
+    // readable on a small phone and does not eat a tablet.
+    val configuration = LocalConfiguration.current
+    val landscapeChatWidth = remember(configuration.screenWidthDp) {
+        (configuration.screenWidthDp * 0.34f).dp.coerceIn(260.dp, 360.dp)
+    }
     // Timed comments overlay toggle; persists across videos while the player is open
     var timedCommentsActive by remember { mutableStateOf(false) }
     
@@ -162,6 +181,13 @@ fun VideoPlayerContent(
             delay(4000)
             showControls = false
         }
+    }
+
+    // The chat stream only starts once the panel is actually opened, and a
+    // video that turns out not to be live must not leave the panel showing.
+    LaunchedEffect(showLiveChat, isLive) {
+        if (showLiveChat && isLive) viewModel.ensureLiveChatStarted() else viewModel.stopLiveChat()
+        if (!isLive) showLiveChat = false
     }
 
     // Fetch the first page of comments once the overlay is active and the
@@ -338,6 +364,10 @@ fun VideoPlayerContent(
                     showCaptionsSheet = true
                 },
                 captionCues = captionCues,
+                isLive = isLive,
+                liveChatActive = showLiveChat,
+                onLiveChatToggle = { showLiveChat = !showLiveChat },
+                onSeekToLive = { exoPlayer.seekToDefaultPosition() },
                 onRetry = { viewModel.retryPlayback() }
             )
 
@@ -348,6 +378,54 @@ fun VideoPlayerContent(
                         modifier = Modifier
                             .align(Alignment.BottomStart)
                             .padding(start = 24.dp, end = 24.dp, bottom = 104.dp)
+                    )
+                }
+
+                // Landscape chat: a column docked to the right of the video
+                // rather than a sheet over it, so the stream stays watchable
+                // while chat scrolls. Slides in from the edge it lives on.
+                androidx.compose.animation.AnimatedVisibility(
+                    visible = showLiveChat && isLive,
+                    enter = slideInHorizontally(
+                        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+                        initialOffsetX = { it }
+                    ) + fadeIn(),
+                    exit = slideOutHorizontally(targetOffsetX = { it }) + fadeOut(),
+                    modifier = Modifier
+                        .align(Alignment.CenterEnd)
+                        .fillMaxHeight()
+                ) {
+                    LiveChatPanel(
+                        messages = liveChatMessages,
+                        banner = liveChatBanner,
+                        isLoading = isLiveChatLoading,
+                        isAvailable = isLiveChatAvailable,
+                        canSend = canSendLiveChat,
+                        isSending = isSendingLiveChat,
+                        maxMessageLength = liveChatMaxLength,
+                        restriction = liveChatRestriction,
+                        onSend = { body, onFailure ->
+                            viewModel.sendLiveChatMessage(body, onFailure)
+                        },
+                        onDismiss = { showLiveChat = false },
+                        compact = true,
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .width(landscapeChatWidth)
+                            // Immersive fullscreen hides the system bars but
+                            // not the camera cutout, which is exactly where a
+                            // right-docked panel lands in landscape.
+                            .displayCutoutPadding()
+                            .padding(end = 8.dp, top = 8.dp, bottom = 8.dp)
+                            // Swallow taps: the gesture surface underneath
+                            // would otherwise toggle the player controls when
+                            // the user taps a gap between messages.
+                            .clickable(
+                                interactionSource = remember {
+                                    androidx.compose.foundation.interaction.MutableInteractionSource()
+                                },
+                                indication = null
+                            ) {}
                     )
                 }
             }
@@ -413,6 +491,8 @@ fun VideoPlayerContent(
                             showCaptionsSheet = true
                         },
                         captionCues = captionCues,
+                        isLive = isLive,
+                        onSeekToLive = { exoPlayer.seekToDefaultPosition() },
                         showPipButton = pipSupported,
                         onPipClick = {
                             val host = activity as? androidx.activity.ComponentActivity
@@ -480,7 +560,10 @@ fun VideoPlayerContent(
                                 viewModel.loadVideoPlaylists()
                                 saveTargetVideo = related
                             }
-                        }
+                        },
+                        isLive = isLive,
+                        liveViewerCount = liveViewerCount,
+                        onLiveChatClick = { showLiveChat = true }
                     )
 
                     // Qualified: inside this Box the outer Column's scoped
@@ -523,14 +606,46 @@ fun VideoPlayerContent(
                             }
                         )
                     }
+
+                    // Portrait chat: same slide-up treatment as comments, so
+                    // the video keeps playing above while chat scrolls.
+                    androidx.compose.animation.AnimatedVisibility(
+                        visible = showLiveChat && isLive,
+                        enter = slideInVertically(
+                            animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+                            initialOffsetY = { it }
+                        ) + fadeIn(),
+                        exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
+                        modifier = Modifier.fillMaxSize()
+                    ) {
+                        LiveChatPanel(
+                            messages = liveChatMessages,
+                            banner = liveChatBanner,
+                            isLoading = isLiveChatLoading,
+                            isAvailable = isLiveChatAvailable,
+                            canSend = canSendLiveChat,
+                            isSending = isSendingLiveChat,
+                            maxMessageLength = liveChatMaxLength,
+                            restriction = liveChatRestriction,
+                            onSend = { body, onFailure ->
+                                viewModel.sendLiveChatMessage(body, onFailure)
+                            },
+                            onDismiss = { showLiveChat = false },
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    }
                 }
             }
         }
     }
 
-    // Back closes the comments panel before collapsing the player
+    // Back closes an open panel before collapsing the player
     androidx.activity.compose.BackHandler(enabled = showCommentsSheet && !isFullscreen) {
         showCommentsSheet = false
+    }
+
+    androidx.activity.compose.BackHandler(enabled = showLiveChat) {
+        showLiveChat = false
     }
 
     // Save to Watch Later / playlist sheet
@@ -679,7 +794,7 @@ fun VideoPlayerContent(
                         PlayerSettingsSections(
                             isLoading = isLoading,
                             qualities = availableQualities,
-                            currentQualityUrl = currentQuality?.url,
+                            currentQuality = currentQuality,
                             onQualitySelected = { viewModel.setQuality(it) },
                             playbackSpeed = playbackSpeed,
                             onSpeedSelected = { viewModel.setPlaybackSpeed(it) }
@@ -710,7 +825,7 @@ fun VideoPlayerContent(
                 PlayerSettingsSections(
                     isLoading = isLoading,
                     qualities = availableQualities,
-                    currentQualityUrl = currentQuality?.url,
+                    currentQuality = currentQuality,
                     onQualitySelected = { viewModel.setQuality(it) },
                     playbackSpeed = playbackSpeed,
                     onSpeedSelected = { viewModel.setPlaybackSpeed(it) }
@@ -731,7 +846,7 @@ fun VideoPlayerContent(
 private fun PlayerSettingsSections(
     isLoading: Boolean,
     qualities: List<VideoQuality>,
-    currentQualityUrl: String?,
+    currentQuality: VideoQuality?,
     onQualitySelected: (VideoQuality) -> Unit,
     playbackSpeed: Float,
     onSpeedSelected: (Float) -> Unit
@@ -765,7 +880,12 @@ private fun PlayerSettingsSections(
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             qualities.forEach { quality ->
-                val selected = quality.url == currentQualityUrl
+                // Compared by label, not URL: every rendition of a live
+                // stream points at the same HLS manifest, so a URL comparison
+                // would light up the whole ladder at once.
+                val selected = currentQuality != null &&
+                    quality.resolution == currentQuality.resolution &&
+                    quality.url == currentQuality.url
                 ToggleButton(
                     checked = selected,
                     onCheckedChange = { if (!selected) onQualitySelected(quality) },

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
@@ -83,6 +83,7 @@ fun VideoPlayerContent(
     val chapters by viewModel.chapters.collectAsState()
     val captionTracks by viewModel.captionTracks.collectAsState()
     val selectedCaption by viewModel.selectedCaption.collectAsState()
+    val captionCues by viewModel.captionCues.collectAsState()
     val isCaptionsLoading by viewModel.isCaptionsLoading.collectAsState()
     val isLooping by viewModel.isLooping.collectAsState()
     val playbackSpeed by viewModel.playbackSpeed.collectAsState()
@@ -309,6 +310,7 @@ fun VideoPlayerContent(
                     viewModel.ensureCaptionsLoaded()
                     showCaptionsSheet = true
                 },
+                captionCues = captionCues,
                 onRetry = { viewModel.retryPlayback() }
             )
 
@@ -369,6 +371,7 @@ fun VideoPlayerContent(
                             viewModel.ensureCaptionsLoaded()
                             showCaptionsSheet = true
                         },
+                        captionCues = captionCues,
                         minimizeDragEnabled = true,
                         onMinimizeDragDelta = onMinimizeDragDelta,
                         onMinimizeDragRelease = onMinimizeDragRelease,

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerOverlay.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerOverlay.kt
@@ -47,6 +47,19 @@ private const val MIN_PIP_ASPECT = 1f / 2.39f
 private const val MAX_PIP_ASPECT = 2.39f
 
 /**
+ * Settle for the expand/minimize transition, shared by the state-driven
+ * animation and the release of a drag so both come to rest the same way.
+ *
+ * Softer and closer to critically damped than the house bouncy default: this
+ * one carries the whole player across the screen, where a visible overshoot
+ * reads as a snap rather than as character.
+ */
+private val MINIMIZE_SETTLE_SPRING = spring<Float>(
+    dampingRatio = 0.9f,
+    stiffness = 260f
+)
+
+/**
  * Put the app into system Picture-in-Picture now.
  *
  * Needed as an explicit call because [PictureInPictureParams.Builder.setAutoEnterEnabled]
@@ -260,7 +273,7 @@ fun VideoPlayerOverlay(
         LaunchedEffect(isExpanded) {
             expandProgress.animateTo(
                 if (isExpanded) 1f else 0f,
-                spring(stiffness = 300f, dampingRatio = 0.8f)
+                MINIMIZE_SETTLE_SPRING
             )
         }
 
@@ -273,12 +286,22 @@ fun VideoPlayerOverlay(
         // Accumulating in plain snapshot state applies every delta.
         var isDragging by remember { mutableStateOf(false) }
         var dragProgress by remember { mutableFloatStateOf(1f) }
+        // Where the finger picked the player up, so the commit test can measure
+        // real travel instead of an absolute position on the screen.
+        var dragStartProgress by remember { mutableFloatStateOf(1f) }
 
         // 1:1 with the finger: height interpolates over the full screen and the
         // player is bottom-anchored, so a range of one screen height moves the
         // player's top edge exactly as far as the finger travels. The old 0.8
         // range made it run ahead of the touch.
         val dragRangePx = fullHeightPx
+
+        // A short, unhurried pull is all it takes: ~40dp of travel commits the
+        // minimize, which is a little more than the touch slop the gesture
+        // spends arming itself. Expressed in dp so the feel is the same on
+        // every screen density - as a fraction of screen height it silently
+        // asked for a much longer pull on tall devices.
+        val minimizeTravel = with(density) { 40.dp.toPx() } / dragRangePx
 
         // Minimized resting position sits above the nav bar, and above the
         // music mini player too when both players are alive at the same time
@@ -312,6 +335,7 @@ fun VideoPlayerOverlay(
                          if (!isDragging) {
                              isDragging = true
                              dragProgress = expandProgress.value
+                             dragStartProgress = expandProgress.value
                          }
                          // Clamped short of the mini player so the expanded
                          // layout never squashes into an unreadable sliver.
@@ -319,17 +343,16 @@ fun VideoPlayerOverlay(
                              .coerceIn(0.25f, 1f)
                      },
                      onMinimizeDragRelease = { velocityY ->
-                         // Momentum first: any real downward flick commits, an
-                         // upward flick always restores; position only decides
-                         // for slow, deliberate drags. Both thresholds are
-                         // deliberately easy to reach - a flick is how most
-                         // people dismiss a player, and the old ones asked for
-                         // a long, committed pull before anything happened.
+                         // Momentum first: any downward drift commits, an
+                         // upward one always restores; travel only decides for
+                         // drags that end almost still. Both thresholds are
+                         // intentionally gentle - the gesture should answer a
+                         // calm nudge, not ask to be pulled or flicked hard.
                          val released = dragProgress
                          val minimize = when {
-                             velocityY > 350f -> true
-                             velocityY < -350f -> false
-                             else -> released < 0.9f
+                             velocityY > 120f -> true
+                             velocityY < -120f -> false
+                             else -> dragStartProgress - released > minimizeTravel
                          }
                          scope.launch {
                              // Hand the dragged position to the Animatable
@@ -341,10 +364,7 @@ fun VideoPlayerOverlay(
                              if (minimize) {
                                  viewModel.setExpanded(false)
                              } else {
-                                 expandProgress.animateTo(
-                                     1f,
-                                     spring(stiffness = 300f, dampingRatio = 0.8f)
-                                 )
+                                 expandProgress.animateTo(1f, MINIMIZE_SETTLE_SPRING)
                              }
                          }
                      }

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerOverlay.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerOverlay.kt
@@ -21,14 +21,65 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
-import androidx.compose.ui.viewinterop.AndroidView
 import kotlinx.coroutines.launch
-import androidx.core.util.Consumer
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
-import androidx.media3.ui.PlayerView
 import androidx.media3.common.util.UnstableApi
 import com.ivor.ivormusic.R
+
+/**
+ * Aspect ratio for the PiP window, from the video's own dimensions.
+ *
+ * A hardcoded 16:9 letterboxed everything that was not 16:9 - vertical clips
+ * worst of all. The system rejects anything outside roughly 1:2.39 to 2.39:1
+ * with an IllegalArgumentException, so the video's ratio is clamped into that
+ * range rather than passed through blind.
+ */
+private fun pipAspectRatio(videoAspectRatio: Float?): Rational {
+    val ratio = videoAspectRatio?.takeIf { it.isFinite() && it > 0f } ?: (16f / 9f)
+    val clamped = ratio.coerceIn(MIN_PIP_ASPECT, MAX_PIP_ASPECT)
+    // Scaled to integers: Rational(width, height) with 1000ths is precise
+    // enough for a window a few hundred pixels wide.
+    return Rational((clamped * 1000).toInt(), 1000)
+}
+
+private const val MIN_PIP_ASPECT = 1f / 2.39f
+private const val MAX_PIP_ASPECT = 2.39f
+
+/**
+ * Put the app into system Picture-in-Picture now.
+ *
+ * Needed as an explicit call because [PictureInPictureParams.Builder.setAutoEnterEnabled]
+ * only exists from API 31, and minSdk here is 30 - without this, PiP was simply
+ * unreachable on Android 11. It also backs the player's PiP button, which is
+ * the only discoverable way in on any version.
+ *
+ * Returns false when the system refuses (PiP disabled for the app, or the
+ * device does not support it), so callers can fall back to doing nothing
+ * rather than assuming they are now in PiP.
+ */
+fun enterPipMode(
+    activity: androidx.activity.ComponentActivity,
+    videoAspectRatio: Float?,
+    videoBounds: android.graphics.Rect?
+): Boolean {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return false
+    if (!activity.packageManager.hasSystemFeature(
+            android.content.pm.PackageManager.FEATURE_PICTURE_IN_PICTURE
+        )
+    ) return false
+
+    return try {
+        val params = PictureInPictureParams.Builder()
+            .setAspectRatio(pipAspectRatio(videoAspectRatio))
+            .apply { videoBounds?.takeIf { !it.isEmpty }?.let { setSourceRectHint(it) } }
+            .build()
+        activity.enterPictureInPictureMode(params)
+    } catch (e: Exception) {
+        android.util.Log.w("VideoPlayerOverlay", "enterPictureInPictureMode refused", e)
+        false
+    }
+}
 
 /**
  * Overlay component for persistent video playback across the app.
@@ -44,24 +95,12 @@ fun VideoPlayerOverlay(
     val isExpanded by viewModel.isExpanded.collectAsState()
     val currentVideo by viewModel.currentVideo.collectAsState()
     val isPlaying by viewModel.isPlaying.collectAsState()
-    
+    val videoAspectRatio by viewModel.videoAspectRatio.collectAsState()
+    val videoBounds by viewModel.videoSurfaceBounds.collectAsState()
+
     // Context and Activity
     val context = LocalContext.current
     val activity = context as? androidx.activity.ComponentActivity
-
-    // PiP State
-    var isInPipMode by remember { mutableStateOf(false) }
-
-    // Listen for PiP Mode changes
-    DisposableEffect(activity) {
-        val listener = Consumer<androidx.core.app.PictureInPictureModeChangedInfo> { info ->
-            isInPipMode = info.isInPictureInPictureMode
-            // Ensure expanded state is consistent/handled? 
-            // Usually if we go to PiP, we might want to ensure UI is ready for return?
-        }
-        activity?.addOnPictureInPictureModeChangedListener(listener)
-        onDispose { activity?.removeOnPictureInPictureModeChangedListener(listener) }
-    }
 
     if (currentVideo == null) return
 
@@ -84,11 +123,12 @@ fun VideoPlayerOverlay(
     }
 
     // Keep the screen awake while a video is actually playing (mini, full or
-    // fullscreen). Cleared when paused, when the player closes, or in system
-    // PiP (the PiP window should not block the lock screen timeout).
-    DisposableEffect(isPlaying, isInPipMode) {
+    // fullscreen). Cleared when paused and when the player closes. In system
+    // PiP this whole overlay leaves the composition, so onDispose clears the
+    // flag there too - a PiP window must not hold off the lock screen.
+    DisposableEffect(isPlaying) {
         val window = activity?.window
-        if (isPlaying && !isInPipMode) {
+        if (isPlaying) {
             window?.addFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         } else {
             window?.clearFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
@@ -103,7 +143,7 @@ fun VideoPlayerOverlay(
     val pipPlayAction = "$packageName.PIP_PLAY"
     val pipPauseAction = "$packageName.PIP_PAUSE"
     
-    LaunchedEffect(currentVideo, isPlaying, isExpanded) {
+    LaunchedEffect(currentVideo, isPlaying, isExpanded, videoAspectRatio, videoBounds) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && activity != null) {
              val videoId = currentVideo?.videoId ?: return@LaunchedEffect
              // Use collision-resistant request codes: masked hashcode OR'd with action bit
@@ -129,18 +169,28 @@ fun VideoPlayerOverlay(
              val pauseAction = RemoteAction(Icon.createWithResource(context, android.R.drawable.ic_media_pause), "Pause", "Pause", pauseIntent)
              
              val actions = if (isPlaying) listOf(pauseAction) else listOf(playAction)
-             
+
              val paramsBuilder = PictureInPictureParams.Builder()
-                .setAspectRatio(Rational(16, 9))
+                .setAspectRatio(pipAspectRatio(videoAspectRatio))
                 .setActions(actions)
-                
+
+             // Animate the PiP window out of the video rather than out of the
+             // whole activity window. Without a source rect the system scales
+             // the entire screen down - app chrome, nav bar and all - which is
+             // what made the transition look like the UI was being sucked into
+             // the window.
+             videoBounds?.takeIf { !it.isEmpty }?.let { paramsBuilder.setSourceRectHint(it) }
+
              if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                  // Only auto-enter PiP while the full player is on screen.
                  // Auto-entering from the mini player captures the whole app UI
                  // into the PiP window instead of just the video surface.
                  paramsBuilder.setAutoEnterEnabled(isExpanded)
+                 // The content is a video, not a layout that needs to reflow, so
+                 // let the system crossfade the resize instead of re-laying out.
+                 paramsBuilder.setSeamlessResizeEnabled(true)
              }
-             
+
              try {
                  activity.setPictureInPictureParams(paramsBuilder.build())
              } catch (e: Exception) {
@@ -174,29 +224,8 @@ fun VideoPlayerOverlay(
         }
     }
 
-    // If in System PiP Mode, show purely the player
-    if (isInPipMode) {
-        AndroidView(
-            factory = { ctx ->
-                PlayerView(ctx).apply {
-                    player = viewModel.exoPlayer
-                    useController = false
-                }
-            },
-            update = { pv ->
-                pv.player = viewModel.exoPlayer
-                pv.useController = false
-            },
-            // One ExoPlayer is shared by the PiP, full and mini PlayerViews.
-            // Detaching the player before the view (and its Surface) is
-            // destroyed hands the surface over cleanly on every swap; without
-            // it the outgoing view's surfaceDestroyed can pull the surface out
-            // from under the view that just took ownership.
-            onRelease = { pv -> pv.player = null },
-            modifier = Modifier.fillMaxSize()
-        )
-        return // Return early, don't show overlay UI
-    }
+    // Nothing here renders in system PiP: MainActivity swaps the whole app for
+    // PipVideoSurface, so the PiP window contains the video and nothing else.
 
     // ------------------------------------------------
     // Normal In-App Overlay UI
@@ -235,13 +264,25 @@ fun VideoPlayerOverlay(
             )
         }
 
-        // Dragging ~80% of the screen collapses fully; clamped so the full
-        // player layout never squashes into an unreadable sliver mid-drag.
-        val dragRangePx = fullHeightPx * 0.8f
+        // Live value while a finger is down. The drag deliberately does not go
+        // through the Animatable: Animatable.snapTo runs under a MutatorMutex,
+        // so each call cancels the one before it, and dispatching one per
+        // pointer event meant a fast drag had most of its deltas cancelled
+        // before they applied. The player fell behind the finger, which is why
+        // minimizing used to need a pull most of the way down the screen.
+        // Accumulating in plain snapshot state applies every delta.
+        var isDragging by remember { mutableStateOf(false) }
+        var dragProgress by remember { mutableFloatStateOf(1f) }
+
+        // 1:1 with the finger: height interpolates over the full screen and the
+        // player is bottom-anchored, so a range of one screen height moves the
+        // player's top edge exactly as far as the finger travels. The old 0.8
+        // range made it run ahead of the touch.
+        val dragRangePx = fullHeightPx
 
         // Minimized resting position sits above the nav bar, and above the
         // music mini player too when both players are alive at the same time
-        val p = expandProgress.value
+        val p = if (isDragging) dragProgress else expandProgress.value
         val height = lerp(88.dp, fullHeight, p)
         val widthPadding = lerp(16.dp, 0.dp, p)
         val bottomPadding = lerp(100.dp + bottomInset + miniPlayerExtraBottomPadding, 0.dp, p)
@@ -268,25 +309,38 @@ fun VideoPlayerOverlay(
                      },
                      timedCommentsFeatureEnabled = timedCommentsEnabled,
                      onMinimizeDragDelta = { dy ->
-                         scope.launch {
-                             expandProgress.snapTo(
-                                 (expandProgress.value - dy / dragRangePx).coerceIn(0.25f, 1f)
-                             )
+                         if (!isDragging) {
+                             isDragging = true
+                             dragProgress = expandProgress.value
                          }
+                         // Clamped short of the mini player so the expanded
+                         // layout never squashes into an unreadable sliver.
+                         dragProgress = (dragProgress - dy / dragRangePx)
+                             .coerceIn(0.25f, 1f)
                      },
                      onMinimizeDragRelease = { velocityY ->
                          // Momentum first: any real downward flick commits, an
                          // upward flick always restores; position only decides
-                         // for slow, deliberate drags.
+                         // for slow, deliberate drags. Both thresholds are
+                         // deliberately easy to reach - a flick is how most
+                         // people dismiss a player, and the old ones asked for
+                         // a long, committed pull before anything happened.
+                         val released = dragProgress
                          val minimize = when {
-                             velocityY > 600f -> true
-                             velocityY < -600f -> false
-                             else -> expandProgress.value < 0.85f
+                             velocityY > 350f -> true
+                             velocityY < -350f -> false
+                             else -> released < 0.9f
                          }
-                         if (minimize) {
-                             viewModel.setExpanded(false)
-                         } else {
-                             scope.launch {
+                         scope.launch {
+                             // Hand the dragged position to the Animatable
+                             // before dropping out of drag mode, so the settle
+                             // continues from where the finger let go instead
+                             // of snapping back to fully expanded first.
+                             expandProgress.snapTo(released)
+                             isDragging = false
+                             if (minimize) {
+                                 viewModel.setExpanded(false)
+                             } else {
                                  expandProgress.animateTo(
                                      1f,
                                      spring(stiffness = 300f, dampingRatio = 0.8f)

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.Chat
 import androidx.compose.material.icons.automirrored.rounded.Comment
 import androidx.compose.material.icons.automirrored.rounded.VolumeOff
 import androidx.compose.material.icons.automirrored.rounded.VolumeUp
@@ -263,6 +264,11 @@ fun FullscreenPlayerContent(
     captionsActive: Boolean = false,
     onCaptionsClick: () -> Unit = {},
     captionCues: List<VttCue> = emptyList(),
+    isLive: Boolean = false,
+    liveChatActive: Boolean = false,
+    onLiveChatToggle: () -> Unit = {},
+    /** Jump to the live edge of the DVR window. */
+    onSeekToLive: () -> Unit = {},
     onRetry: (() -> Unit)? = null
 ) {
     // Stable shapes to prevent "square flash"
@@ -415,6 +421,24 @@ fun FullscreenPlayerContent(
                         }
                     }
 
+                    // Landscape is where a side-by-side chat actually fits, so
+                    // the toggle only exists here.
+                    if (isLive) {
+                        FilledTonalIconButton(
+                            onClick = onLiveChatToggle,
+                            colors = IconButtonDefaults.filledTonalIconButtonColors(
+                                containerColor = if (liveChatActive) MaterialTheme.colorScheme.primary else Color.Black.copy(0.5f),
+                                contentColor = if (liveChatActive) MaterialTheme.colorScheme.onPrimary else Color.White
+                            ),
+                            shapes = stableShapes
+                        ) {
+                            Icon(
+                                Icons.AutoMirrored.Rounded.Chat,
+                                contentDescription = if (liveChatActive) "Hide live chat" else "Show live chat"
+                            )
+                        }
+                    }
+
                     FilledTonalIconButton(
                         onClick = onCaptionsClick,
                         colors = IconButtonDefaults.filledTonalIconButtonColors(
@@ -483,7 +507,12 @@ fun FullscreenPlayerContent(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(16.dp)
                     ) {
-                        Text(formatDuration(currentPosition), color = Color.White, style = MaterialTheme.typography.labelLarge)
+                        // A live stream's position is an offset into the DVR
+                        // window, not a place in a video, so the elapsed
+                        // readout means nothing to the viewer.
+                        if (!isLive) {
+                            Text(formatDuration(currentPosition), color = Color.White, style = MaterialTheme.typography.labelLarge)
+                        }
 
                         PlayerSeekBar(
                             progress = progress,
@@ -494,7 +523,16 @@ fun FullscreenPlayerContent(
                             durationMs = duration
                         )
 
-                        Text(formatDuration(duration), color = Color.White, style = MaterialTheme.typography.labelLarge)
+                        if (isLive) {
+                            LiveEdgeChip(
+                                // A stream without a DVR window reports no
+                                // duration, so there is nowhere to be behind.
+                                atLiveEdge = duration <= 0L || progress >= LIVE_EDGE_THRESHOLD,
+                                onClick = onSeekToLive
+                            )
+                        } else {
+                            Text(formatDuration(duration), color = Color.White, style = MaterialTheme.typography.labelLarge)
+                        }
                     }
                 }
             }
@@ -535,6 +573,9 @@ fun PortraitPlayerContent(
     captionsActive: Boolean = false,
     onCaptionsClick: () -> Unit = {},
     captionCues: List<VttCue> = emptyList(),
+    isLive: Boolean = false,
+    /** Jump to the live edge of the DVR window. */
+    onSeekToLive: () -> Unit = {},
     showPipButton: Boolean = false,
     onPipClick: () -> Unit = {},
     minimizeDragEnabled: Boolean = false,
@@ -742,7 +783,9 @@ fun PortraitPlayerContent(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
-                        Text(formatDuration(currentPosition), color = Color.White, style = MaterialTheme.typography.labelMedium)
+                        if (!isLive) {
+                            Text(formatDuration(currentPosition), color = Color.White, style = MaterialTheme.typography.labelMedium)
+                        }
 
                         PlayerSeekBar(
                             progress = progress,
@@ -753,10 +796,63 @@ fun PortraitPlayerContent(
                             durationMs = duration
                         )
 
-                        Text(formatDuration(duration), color = Color.White, style = MaterialTheme.typography.labelMedium)
+                        if (isLive) {
+                            LiveEdgeChip(
+                                // A stream without a DVR window reports no
+                                // duration, so there is nowhere to be behind.
+                                atLiveEdge = duration <= 0L || progress >= LIVE_EDGE_THRESHOLD,
+                                onClick = onSeekToLive
+                            )
+                        } else {
+                            Text(formatDuration(duration), color = Color.White, style = MaterialTheme.typography.labelMedium)
+                        }
                     }
                 }
             }
+        }
+    }
+}
+
+/**
+ * Fraction of the DVR window past which playback counts as "at the live edge".
+ * The window is hours long, so anything short of the last fraction of a percent
+ * is genuinely behind.
+ */
+private const val LIVE_EDGE_THRESHOLD = 0.995f
+
+/**
+ * The "LIVE" marker where a normal video shows its duration. Red and tappable
+ * while the viewer is behind, so getting back to the edge is one tap; muted
+ * once they are already there.
+ */
+@Composable
+private fun LiveEdgeChip(atLiveEdge: Boolean, onClick: () -> Unit) {
+    Surface(
+        shape = CircleShape,
+        color = Color.Transparent,
+        onClick = onClick,
+        enabled = !atLiveEdge
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            modifier = Modifier.padding(horizontal = 6.dp, vertical = 4.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .clip(CircleShape)
+                    .background(
+                        if (atLiveEdge) MaterialTheme.colorScheme.error
+                        else Color.White.copy(alpha = 0.6f)
+                    )
+            )
+            Text(
+                text = "LIVE",
+                color = if (atLiveEdge) Color.White else Color.White.copy(alpha = 0.6f),
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Bold
+            )
         }
     }
 }
@@ -1314,7 +1410,11 @@ fun VideoInfoSection(
     onChannelClick: () -> Unit = {},
     onRelatedLongPress: ((VideoItem) -> Unit)? = null,
     /** Seek the player, in seconds. Enables timestamp links in the description. */
-    onSeekTo: ((seconds: Long) -> Unit)? = null
+    onSeekTo: ((seconds: Long) -> Unit)? = null,
+    isLive: Boolean = false,
+    /** Concurrent viewers, refreshed while the stream is open. */
+    liveViewerCount: String? = null,
+    onLiveChatClick: () -> Unit = {}
 ) {
     Column(
         modifier = modifier
@@ -1333,14 +1433,23 @@ fun VideoInfoSection(
                 modifier = Modifier.fillMaxWidth()
             )
 
-            Text(
-                text = buildString {
-                    if (video.viewCount.isNotEmpty()) append(video.viewCount)
-                    if (!video.uploadedDate.isNullOrEmpty()) append(" • ${video.uploadedDate}")
-                },
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+            // A live stream's "view count" is a concurrent-viewer number that
+            // moves, and its upload date is meaningless, so the badge replaces
+            // the static line rather than sitting next to it.
+            if (isLive) {
+                LiveBadge(
+                    viewerCount = liveViewerCount ?: video.viewCount.takeIf { it.isNotEmpty() }
+                )
+            } else {
+                Text(
+                    text = buildString {
+                        if (video.viewCount.isNotEmpty()) append(video.viewCount)
+                        if (!video.uploadedDate.isNullOrEmpty()) append(" • ${video.uploadedDate}")
+                    },
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
         }
 
         // Like / Dislike + Save + Share Actions (scrolls like YouTube's chip
@@ -1427,6 +1536,43 @@ fun VideoInfoSection(
                     containerColor = Color.Transparent
                 )
             )
+        }
+
+        // Live chat entry. Sits above comments because on a live stream it is
+        // the conversation - the comment section is usually empty or off.
+        if (isLive) {
+            Surface(
+                shape = RoundedCornerShape(16.dp),
+                color = MaterialTheme.colorScheme.surfaceContainer,
+                modifier = Modifier.fillMaxWidth(),
+                onClick = onLiveChatClick
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Icon(
+                        Icons.AutoMirrored.Rounded.Chat,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                    Text(
+                        text = "Live chat",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.weight(1f)
+                    )
+                    LiveDot()
+                    Icon(
+                        Icons.Rounded.ExpandMore,
+                        contentDescription = "Open live chat",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
         }
 
         // Comments Entry

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -65,6 +65,7 @@ import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.ClosedCaption
 import androidx.compose.material.icons.rounded.ClosedCaptionOff
+import androidx.compose.material.icons.rounded.PictureInPictureAlt
 import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.Error
 import androidx.compose.material.icons.rounded.ExpandMore
@@ -172,7 +173,7 @@ import java.util.Locale
  * player controls above them.
  */
 @Composable
-private fun CaptionOverlay(
+internal fun CaptionOverlay(
     cues: List<VttCue>,
     player: ExoPlayer,
     bottomPadding: Dp,
@@ -534,6 +535,8 @@ fun PortraitPlayerContent(
     captionsActive: Boolean = false,
     onCaptionsClick: () -> Unit = {},
     captionCues: List<VttCue> = emptyList(),
+    showPipButton: Boolean = false,
+    onPipClick: () -> Unit = {},
     minimizeDragEnabled: Boolean = false,
     onMinimizeDragDelta: (Float) -> Unit = {},
     onMinimizeDragRelease: (Float) -> Unit = {},
@@ -670,6 +673,25 @@ fun PortraitPlayerContent(
                                 if (captionsActive) Icons.Rounded.ClosedCaption else Icons.Rounded.ClosedCaptionOff,
                                 contentDescription = "Captions"
                             )
+                        }
+                        // The only discoverable way into PiP. Auto-enter covers
+                        // leaving the app on API 31+, but nothing advertised
+                        // that PiP existed, and on Android 11 there was no way
+                        // in at all.
+                        if (showPipButton) {
+                            FilledTonalIconButton(
+                                onClick = onPipClick,
+                                colors = IconButtonDefaults.filledTonalIconButtonColors(
+                                    containerColor = Color.Black.copy(0.5f),
+                                    contentColor = Color.White
+                                ),
+                                shapes = stableShapes
+                            ) {
+                                Icon(
+                                    Icons.Rounded.PictureInPictureAlt,
+                                    contentDescription = "Picture in picture"
+                                )
+                            }
                         }
                         FilledIconButton(
                             onClick = onSettings,

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -8,9 +8,11 @@ import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.FrameLayout
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Canvas
@@ -118,7 +120,6 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChanged
 import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
@@ -127,6 +128,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.util.UnstableApi
@@ -141,7 +143,10 @@ import com.ivor.ivormusic.data.ThemePreferences
 import com.ivor.ivormusic.data.VideoChapter
 import com.ivor.ivormusic.data.VideoEngagement
 import com.ivor.ivormusic.data.VideoItem
+import com.ivor.ivormusic.data.VttCue
+import com.ivor.ivormusic.data.WebVttParser
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import java.util.Locale
 
@@ -152,40 +157,75 @@ import java.util.Locale
 // ---------------- Sub-Composables ----------------
 
 /**
- * Reparents the SubtitleView from exo_content_frame to the PlayerView root.
+ * Draws the active caption cue over the video.
  *
- * Media3 nests captions inside the content frame, and RESIZE_MODE_ZOOM (our
- * pinch-to-fill) works by over-measuring that frame so the video overflows the
- * PlayerView and gets clipped. The SubtitleView rides along: cues slide off the
- * bottom edge and their text - sized as a fraction of the view height - blows up
- * with the frame. Hoisted to the root, captions keep screen size and screen
- * position no matter what the video surface does.
+ * Captions are rendered here rather than by PlayerView's built-in SubtitleView
+ * because they are no longer part of the media source - sideloading them as a
+ * text track meant every CC toggle rebuilt the source and dropped the whole
+ * video buffer. Drawing them in Compose also sidesteps two problems the
+ * SubtitleView had: cues no longer scale or slide off-screen with
+ * RESIZE_MODE_ZOOM, and their distance from the bottom edge is a plain padding
+ * value instead of a fight with per-cue positioning.
+ *
+ * Black-on-white here rather than ColorScheme: captions sit on video frames, so
+ * they have to stay legible whatever the app theme is. Same reasoning as the
+ * player controls above them.
  */
-@UnstableApi
-private fun PlayerView.hoistSubtitleViewAboveVideo() {
-    val subtitles = subtitleView ?: return
-    if (subtitles.parent === this) return
-    (subtitles.parent as? ViewGroup)?.removeView(subtitles)
-    addView(
-        subtitles,
-        FrameLayout.LayoutParams(
-            ViewGroup.LayoutParams.MATCH_PARENT,
-            ViewGroup.LayoutParams.MATCH_PARENT
-        )
-    )
-}
+@Composable
+private fun CaptionOverlay(
+    cues: List<VttCue>,
+    player: ExoPlayer,
+    bottomPadding: Dp,
+    compact: Boolean,
+    modifier: Modifier = Modifier
+) {
+    if (cues.isEmpty()) return
 
-/**
- * Pads the bottom of the PlayerView's SubtitleView so captions never sit on the
- * screen edge. Media3 lays every cue out inside the SubtitleView's padding box -
- * cues carrying their own line/position included - so padding is the one knob that
- * moves all of them (setBottomPaddingFraction only affects unpositioned cues, and
- * YouTube's timedtext VTT is mostly positioned).
- */
-@UnstableApi
-private fun PlayerView.setCaptionBottomInset(paddingPx: Int) {
-    subtitleView?.let { view ->
-        if (view.paddingBottom != paddingPx) view.setPadding(0, 0, 0, paddingPx)
+    // Polled off the player rather than the surrounding 500ms progress ticker:
+    // at that rate a cue visibly lands after the words it belongs to.
+    var text by remember(cues) { mutableStateOf<String?>(null) }
+    LaunchedEffect(cues, player) {
+        while (isActive) {
+            text = WebVttParser.cueAt(cues, player.currentPosition)?.text
+            delay(100)
+        }
+    }
+
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.BottomCenter
+    ) {
+        Crossfade(
+            targetState = text,
+            animationSpec = tween(150),
+            label = "captionCue",
+            modifier = Modifier.padding(horizontal = 16.dp)
+        ) { cue ->
+            if (cue != null) {
+                Box(
+                    modifier = Modifier.padding(bottom = bottomPadding),
+                    contentAlignment = Alignment.BottomCenter
+                ) {
+                    Text(
+                        text = cue,
+                        color = Color.White,
+                        style = if (compact) {
+                            MaterialTheme.typography.bodyMedium
+                        } else {
+                            MaterialTheme.typography.titleMedium
+                        },
+                        fontWeight = FontWeight.Medium,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .background(
+                                color = Color.Black.copy(alpha = 0.75f),
+                                shape = RoundedCornerShape(8.dp)
+                            )
+                            .padding(horizontal = 12.dp, vertical = 6.dp)
+                    )
+                }
+            }
+        }
     }
 }
 
@@ -221,6 +261,7 @@ fun FullscreenPlayerContent(
     onOpenChapters: () -> Unit = {},
     captionsActive: Boolean = false,
     onCaptionsClick: () -> Unit = {},
+    captionCues: List<VttCue> = emptyList(),
     onRetry: (() -> Unit)? = null
 ) {
     // Stable shapes to prevent "square flash"
@@ -232,10 +273,8 @@ fun FullscreenPlayerContent(
     // Speed captured when a hold-to-2x begins, restored when the finger lifts
     var speedBeforeBoost by remember { mutableFloatStateOf(1f) }
 
-    // Captions sit flush with the bottom of the PlayerView by default, which in
-    // fullscreen means the gesture bar / bottom bezel. Hold them off the edge, and
-    // lift them over the bottom bar while the controls are up.
-    val density = LocalDensity.current
+    // Hold captions off the gesture bar / bottom bezel, and lift them over the
+    // bottom bar while the controls are up.
     val navBarInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
     val captionLift = animateDpAsState(
         targetValue = if (showControls) maxOf(112.dp, navBarInset + 24.dp) else navBarInset + 24.dp,
@@ -265,7 +304,6 @@ fun FullscreenPlayerContent(
                         ViewGroup.LayoutParams.MATCH_PARENT,
                         ViewGroup.LayoutParams.MATCH_PARENT
                     )
-                    hoistSubtitleViewAboveVideo()
                 }
             },
             update = { playerView ->
@@ -275,15 +313,20 @@ fun FullscreenPlayerContent(
                 } else {
                     AspectRatioFrameLayout.RESIZE_MODE_FIT
                 }
-                // Read the animated value here so only this node recomposes while it runs
-                playerView.setCaptionBottomInset(with(density) { captionLift.value.roundToPx() })
             },
             // Hand the surface back before this view is destroyed - the same
             // ExoPlayer is also rendered by the mini and PiP PlayerViews.
             onRelease = { playerView -> playerView.player = null },
             modifier = Modifier.fillMaxSize()
         )
-        
+
+        CaptionOverlay(
+            cues = captionCues,
+            player = exoPlayer,
+            bottomPadding = captionLift.value,
+            compact = false
+        )
+
         // Overlays
         if (hasError) {
             ErrorOverlay(errorMessage, onRetry)
@@ -490,6 +533,7 @@ fun PortraitPlayerContent(
     onOpenChapters: () -> Unit = {},
     captionsActive: Boolean = false,
     onCaptionsClick: () -> Unit = {},
+    captionCues: List<VttCue> = emptyList(),
     minimizeDragEnabled: Boolean = false,
     onMinimizeDragDelta: (Float) -> Unit = {},
     onMinimizeDragRelease: (Float) -> Unit = {},
@@ -502,7 +546,6 @@ fun PortraitPlayerContent(
     var speedBeforeBoost by remember { mutableFloatStateOf(1f) }
 
     // Same caption lift as fullscreen, scaled to the smaller inline video box
-    val density = LocalDensity.current
     val captionLift = animateDpAsState(
         targetValue = if (showControls) 64.dp else 12.dp,
         animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
@@ -531,17 +574,22 @@ fun PortraitPlayerContent(
                         ViewGroup.LayoutParams.MATCH_PARENT,
                         ViewGroup.LayoutParams.MATCH_PARENT
                     )
-                    hoistSubtitleViewAboveVideo()
                 }
             },
             update = { playerView ->
                 playerView.player = exoPlayer
-                playerView.setCaptionBottomInset(with(density) { captionLift.value.roundToPx() })
             },
             // Hand the surface back before this view is destroyed - the same
             // ExoPlayer is also rendered by the mini and PiP PlayerViews.
             onRelease = { playerView -> playerView.player = null },
             modifier = Modifier.fillMaxSize()
+        )
+
+        CaptionOverlay(
+            cues = captionCues,
+            player = exoPlayer,
+            bottomPadding = captionLift.value,
+            compact = true
         )
 
         if (hasError) ErrorOverlay(errorMessage, onRetry)

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
@@ -100,6 +100,25 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
 
     private var captionCuesJob: Job? = null
 
+    // ---------------- Picture-in-Picture ----------------
+
+    // Width/height of the video being played, so the PiP window takes the
+    // shape of the video instead of a hardcoded 16:9 that letterboxes
+    // everything else. Null until the first frame is decoded.
+    private val _videoAspectRatio = MutableStateFlow<Float?>(null)
+    val videoAspectRatio: StateFlow<Float?> = _videoAspectRatio.asStateFlow()
+
+    // Where the video surface sits on screen, in window coordinates. Handed to
+    // PictureInPictureParams as the source rect hint so the system animates the
+    // PiP window out of the video itself; without it the transition scales down
+    // the entire activity window, app chrome and all.
+    private val _videoSurfaceBounds = MutableStateFlow<android.graphics.Rect?>(null)
+    val videoSurfaceBounds: StateFlow<android.graphics.Rect?> = _videoSurfaceBounds.asStateFlow()
+
+    fun setVideoSurfaceBounds(bounds: android.graphics.Rect?) {
+        _videoSurfaceBounds.value = bounds
+    }
+
     // Repeat sticks across videos and app restarts, so seed it from prefs
     // rather than defaulting to off on every player creation.
     private val _isLooping = MutableStateFlow(themePreferences.isVideoRepeatEnabled())
@@ -259,6 +278,16 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
             addListener(object : Player.Listener {
                 override fun onIsPlayingChanged(isPlaying: Boolean) {
                     _isPlaying.value = isPlaying
+                }
+
+                override fun onVideoSizeChanged(videoSize: androidx.media3.common.VideoSize) {
+                    // Drives the PiP window's shape. Ignore the 0x0 the player
+                    // reports between media items, which would otherwise
+                    // collapse the aspect ratio mid-switch.
+                    if (videoSize.width > 0 && videoSize.height > 0) {
+                        _videoAspectRatio.value =
+                            videoSize.width * videoSize.pixelWidthHeightRatio / videoSize.height
+                    }
                 }
 
                 override fun onPlaybackStateChanged(playbackState: Int) {

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
@@ -1,6 +1,7 @@
 package com.ivor.ivormusic.ui.video
 
 import android.content.Context
+import android.os.SystemClock
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.media3.common.AudioAttributes
@@ -21,6 +22,9 @@ import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import com.ivor.ivormusic.data.CaptionTrack
 import com.ivor.ivormusic.data.CommentItem
 import com.ivor.ivormusic.data.LikeStatus
+import com.ivor.ivormusic.data.LiveChatBanner
+import com.ivor.ivormusic.data.LiveChatMessage
+import com.ivor.ivormusic.data.LiveChatPage
 import com.ivor.ivormusic.data.TimedComment
 import com.ivor.ivormusic.data.VideoEngagement
 import com.ivor.ivormusic.data.VideoItem
@@ -35,7 +39,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 
 @UnstableApi
@@ -119,6 +125,16 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         _videoSurfaceBounds.value = bounds
     }
 
+    // True while the app is in system Picture-in-Picture. Set by the
+    // composition so the STATE_ENDED auto-play can stand down: advancing
+    // to the next video while in PiP means the user returns to a video
+    // they did not put there.
+    private var _isInPipMode = false
+
+    fun setInPipMode(inPip: Boolean) {
+        _isInPipMode = inPip
+    }
+
     // Repeat sticks across videos and app restarts, so seed it from prefs
     // rather than defaulting to off on every player creation.
     private val _isLooping = MutableStateFlow(themePreferences.isVideoRepeatEnabled())
@@ -158,6 +174,86 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
 
     private val _isLoggedIn = MutableStateFlow(youtubeRepository.isLoggedIn())
     val isLoggedIn: StateFlow<Boolean> = _isLoggedIn.asStateFlow()
+
+    // ---------------- Live broadcast ----------------
+
+    /**
+     * Whether the current video is a live broadcast. Resolved in Phase 1 from
+     * the quality list: a live stream only ever produces a single adaptive HLS
+     * entry (see YouTubeRepository.parseQualitiesFromStreamingData), so the
+     * flag rides along with the streams instead of costing a separate call.
+     */
+    private val _isLive = MutableStateFlow(false)
+    val isLive: StateFlow<Boolean> = _isLive.asStateFlow()
+
+    /** Concurrent viewers, e.g. "14,618 watching now". Live videos only. */
+    private val _liveViewerCount = MutableStateFlow<String?>(null)
+    val liveViewerCount: StateFlow<String?> = _liveViewerCount.asStateFlow()
+
+    /** Null until the first chat poll answers; false when chat is unavailable. */
+    private val _isLiveChatAvailable = MutableStateFlow<Boolean?>(null)
+    val isLiveChatAvailable: StateFlow<Boolean?> = _isLiveChatAvailable.asStateFlow()
+
+    private val _liveChatMessages = MutableStateFlow<List<LiveChatMessage>>(emptyList())
+    val liveChatMessages: StateFlow<List<LiveChatMessage>> = _liveChatMessages.asStateFlow()
+
+    private val _liveChatBanner = MutableStateFlow<LiveChatBanner?>(null)
+    val liveChatBanner: StateFlow<LiveChatBanner?> = _liveChatBanner.asStateFlow()
+
+    private val _isLiveChatLoading = MutableStateFlow(false)
+    val isLiveChatLoading: StateFlow<Boolean> = _isLiveChatLoading.asStateFlow()
+
+    private val _isSendingLiveChat = MutableStateFlow(false)
+    val isSendingLiveChat: StateFlow<Boolean> = _isSendingLiveChat.asStateFlow()
+
+    private val _liveChatSendParams = MutableStateFlow<String?>(null)
+
+    /**
+     * Posting needs both an account and a chat that accepts messages. The send
+     * token is present in the poll response even when signed out, so it is not
+     * on its own permission to post.
+     */
+    val canSendLiveChat: StateFlow<Boolean> = kotlinx.coroutines.flow.combine(
+        _isLoggedIn, _liveChatSendParams
+    ) { loggedIn, params -> loggedIn && params != null }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    private val _liveChatMaxLength = MutableStateFlow(200)
+    val liveChatMaxLength: StateFlow<Int> = _liveChatMaxLength.asStateFlow()
+
+    /**
+     * Why the composer is closed - subscribers-only, members-only, slow mode, a
+     * ban. Null when the viewer may post. Distinct from [canSendLiveChat], which
+     * is about having an account at all.
+     */
+    private val _liveChatRestriction = MutableStateFlow<String?>(null)
+    val liveChatRestriction: StateFlow<String?> = _liveChatRestriction.asStateFlow()
+
+    private var liveChatJob: Job? = null
+    private var liveMetadataJob: Job? = null
+    private var liveChatStartedForVideoId: String? = null
+
+    /**
+     * Chat start token lifted from Phase 2's watch-next response, so opening the
+     * panel does not re-fetch and re-parse that multi-megabyte tree.
+     */
+    private var liveChatContinuation: String? = null
+
+    /**
+     * Messages that have arrived from the server but are not on screen yet.
+     *
+     * A poll returns ten seconds of chat in one lump; releasing it in one frame
+     * is what made the panel feel like a stuttering wall rather than a live
+     * conversation. Both the poll loop and the drain loop run on viewModelScope's
+     * main dispatcher, so this needs no synchronization.
+     */
+    private val pendingLiveChat = ArrayDeque<LiveChatMessage>()
+
+    /** Ids already queued or displayed, so a re-delivered message is dropped. */
+    private val seenLiveChatIds = LinkedHashSet<String>()
+
+    /** Elapsed-realtime mark when the next batch is expected, for pacing. */
+    private var liveChatBatchDueAt = 0L
 
     private val _comments = MutableStateFlow<List<CommentItem>>(emptyList())
     val comments: StateFlow<List<CommentItem>> = _comments.asStateFlow()
@@ -301,8 +397,9 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
                     if (playbackState == Player.STATE_ENDED) {
                         // Repeat and auto-play are mutually exclusive: looping
                         // repeats the current video, otherwise auto-play moves
-                        // to the next related one.
-                        if (!_isLooping.value) {
+                        // to the next related one. Suppressed during PiP so
+                        // the user returns to the video they put there.
+                        if (!_isLooping.value && !_isInPipMode) {
                             val nextVideo = _relatedVideos.value.firstOrNull()
                             // Guard: ensure ViewModel/player is still valid before launching
                             if (nextVideo != null && _exoPlayer != null) {
@@ -593,6 +690,31 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         _isChannelVideosLoading.value = false
         channelVideosLoadedForChannelId = null
 
+        // Live state belongs to the previous video; the polls must stop before
+        // their next tick can write into the new video's chat.
+        stopLivePolling()
+        // Track selection outlives media items, so a height cap picked on a
+        // live stream would silently limit the next video too - and on a VOD,
+        // where quality is a source swap, that cap is invisible in the UI.
+        _exoPlayer?.let { player ->
+            player.trackSelectionParameters = player.trackSelectionParameters.buildUpon()
+                .clearVideoSizeConstraints()
+                .setForceHighestSupportedBitrate(false)
+                .build()
+        }
+        _isLive.value = false
+        _liveViewerCount.value = null
+        _isLiveChatAvailable.value = null
+        _liveChatMessages.value = emptyList()
+        _liveChatBanner.value = null
+        _liveChatSendParams.value = null
+        _liveChatRestriction.value = null
+        _isLiveChatLoading.value = false
+        liveChatStartedForVideoId = null
+        liveChatContinuation = null
+        pendingLiveChat.clear()
+        seenLiveChatIds.clear()
+
         // Speed is per-video, like YouTube
         _playbackSpeed.value = 1f
         _exoPlayer?.setPlaybackSpeed(1f)
@@ -609,7 +731,9 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
                     // FAST: Get stream URLs only (no metadata, no related, no channel avatar)
                     val qualities = youtubeRepository.getVideoStreamQualities(video.videoId)
                     _availableQualities.value = qualities
-                    
+                    _isLive.value = qualities.any { it.isLive }
+                    if (_isLive.value) startLiveMetadataPolling(video.videoId)
+
                     if (qualities.isNotEmpty()) {
                         loadQuality(pickDefaultQuality(qualities))
                         // FORCE PLAY: Ensure we override any previous paused state
@@ -664,6 +788,9 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
                     _relatedVideos.value = watchNext.relatedVideos
                 }
                 _chapters.value = watchNext.chapters
+                // Opening the chat panel now costs one poll instead of a second
+                // watch-next round trip plus its parse.
+                liveChatContinuation = watchNext.liveChatContinuation
             } catch (e: Exception) {
                 // Phase 2 errors are non-critical - playback already started
                 android.util.Log.w("VideoPlayerVM", "Failed to load watch-next data", e)
@@ -708,6 +835,18 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
     private fun pickDefaultQuality(qualities: List<VideoQuality>): VideoQuality {
         fun height(label: String): Int = label.takeWhile { it.isDigit() }.toIntOrNull() ?: 0
         val preferred = themePreferences.getDefaultVideoQuality()
+
+        // The live ladder leads with an "Auto" entry (height 0) that the VOD
+        // branches below would skip over, so it picks its own entry: Auto when
+        // the setting says auto, otherwise the best rendition at or below the
+        // target, falling back to Auto rather than to the lowest available.
+        if (qualities.firstOrNull()?.isLive == true) {
+            if (preferred == ThemePreferences.VIDEO_QUALITY_AUTO) return qualities.first()
+            val targetHeight = height(preferred)
+            return qualities.firstOrNull { height(it.resolution) in 1..targetHeight }
+                ?: qualities.first()
+        }
+
         if (preferred == ThemePreferences.VIDEO_QUALITY_AUTO) {
             return qualities.firstOrNull { height(it.resolution) > 0 } ?: qualities.first()
         }
@@ -728,6 +867,13 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
      */
     private fun loadQuality(quality: VideoQuality) {
         _currentQuality.value = quality
+
+        if (quality.isLive) {
+            // The whole ladder is one manifest, so the cap has to be applied
+            // alongside preparing it - loadQuality is the only entry point that
+            // runs for the initial pick.
+            applyLiveQualityCap(quality)
+        }
 
         if (quality.isDASH) {
             // Adaptive manifest - hand it to the player and let its MediaSource
@@ -771,7 +917,42 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         else MimeTypes.APPLICATION_MPD
 
     fun setQuality(quality: VideoQuality) {
+        // Live renditions all live in the manifest that is already playing, so
+        // switching is a track-selector cap rather than a new media source: no
+        // re-prepare, no rebuffer, and ABR keeps adapting underneath the cap.
+        // Rebuilding the source here would also drop the viewer back to the
+        // live edge and throw away the DVR buffer.
+        if (quality.isLive) {
+            _currentQuality.value = quality
+            applyLiveQualityCap(quality)
+            return
+        }
         reloadPreservingPosition(quality)
+    }
+
+    /**
+     * Constrain the video track to [quality]'s height, or lift the constraint
+     * for the "Auto" entry.
+     *
+     * The height cap alone is only a ceiling - ABR would still be free to sit
+     * two rungs below it, so picking "1080p60" could visibly play 480p. Pairing
+     * it with forceHighestSupportedBitrate makes an explicit pick behave like a
+     * pin (always the best track that fits the cap) while Auto stays adaptive,
+     * which is the split users expect from the menu.
+     *
+     * buildUpon() so this composes with the video-track suspend/restore in
+     * [onEnterBackground] / [onEnterForeground] instead of overwriting it.
+     */
+    private fun applyLiveQualityCap(quality: VideoQuality) {
+        val player = _exoPlayer ?: return
+        val height = quality.resolution.takeWhile { it.isDigit() }.toIntOrNull() ?: 0
+        player.trackSelectionParameters = player.trackSelectionParameters.buildUpon()
+            .apply {
+                if (height > 0) setMaxVideoSize(Int.MAX_VALUE, height)
+                else clearVideoSizeConstraints()
+                setForceHighestSupportedBitrate(height > 0)
+            }
+            .build()
     }
 
     /**
@@ -870,6 +1051,8 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         // Track selection outlives media items: a player closed while the video
         // track is suspended would come back audio-only on the next video.
         onEnterForeground()
+        stopLivePolling()
+        liveChatStartedForVideoId = null
         _currentVideo.value = null
         _isExpanded.value = false
     }
@@ -885,6 +1068,290 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
     /** Pause without closing the player (music or Shorts playback started). */
     fun pause() {
         _exoPlayer?.pause()
+    }
+
+    // ---------------- Live chat ----------------
+
+    /**
+     * Start the chat stream. Called when the chat panel opens rather than when
+     * the video loads: a live stream watched without the panel open should not
+     * pay for a poll every 10 seconds.
+     */
+    fun ensureLiveChatStarted() {
+        val videoId = _currentVideo.value?.videoId ?: return
+        if (!_isLive.value) return
+        if (liveChatStartedForVideoId == videoId && liveChatJob?.isActive == true) return
+        liveChatStartedForVideoId = videoId
+        startLiveChatPolling(videoId)
+    }
+
+    /**
+     * Stop polling when the panel closes. Messages are kept so reopening shows
+     * the conversation immediately while the fresh backlog loads behind it -
+     * the poll dedupes by id, so the overlap costs nothing.
+     */
+    fun stopLiveChat() {
+        liveChatJob?.cancel()
+        liveChatJob = null
+        liveChatStartedForVideoId = null
+        _isLiveChatLoading.value = false
+    }
+
+    /**
+     * Run the chat: one coroutine polling the server, one releasing what it
+     * fetched onto the screen.
+     *
+     * They are separate because their rhythms are: the server hands over ten
+     * seconds of chat in a single response, and rendering that in one frame is
+     * what made the panel feel broken. The drain loop spreads a batch across the
+     * interval until the next one is due, so messages arrive at roughly the rate
+     * people actually typed them.
+     */
+    private fun startLiveChatPolling(videoId: String) {
+        liveChatJob?.cancel()
+        pendingLiveChat.clear()
+        seenLiveChatIds.clear()
+        _liveChatMessages.value.forEach { seenLiveChatIds.add(it.id) }
+
+        liveChatJob = viewModelScope.launch {
+            _isLiveChatLoading.value = true
+
+            // Phase 2 usually has the token already; only a chat opened before
+            // watch-next lands pays for a fetch.
+            val start = liveChatContinuation
+                ?: youtubeRepository.getLiveChatSession(videoId)?.continuation
+            if (_currentVideo.value?.videoId != videoId) return@launch
+            if (start == null) {
+                // No conversationBar in the watch-next response: chat is
+                // disabled or unavailable for this broadcast, which is a state
+                // to render, not an error.
+                _isLiveChatAvailable.value = false
+                _isLiveChatLoading.value = false
+                return@launch
+            }
+            liveChatContinuation = start
+
+            coroutineScope {
+                val drain = launch { drainLiveChatQueue() }
+                try {
+                    pollLiveChatLoop(videoId, start)
+                } finally {
+                    drain.cancel()
+                    // Anything still queued was already fetched; drop it on
+                    // screen rather than losing it on the way out.
+                    flushPendingLiveChat()
+                    _isLiveChatLoading.value = false
+                }
+            }
+        }
+    }
+
+    /**
+     * Fetch pages on the cadence the server dictates.
+     *
+     * Every response hands back the next token and the delay before it should be
+     * used (10s on every stream sampled). The wait subtracts the time the request
+     * itself took, so the cycle stays a true 10s instead of drifting further
+     * behind live by one round trip per poll.
+     *
+     * The first response carries the visible backlog - that is history, not new
+     * chat, so it goes straight to the screen; only later pages are paced.
+     */
+    private suspend fun pollLiveChatLoop(videoId: String, firstContinuation: String) {
+        var continuation: String? = firstContinuation
+        var consecutiveFailures = 0
+        var isFirstPage = true
+
+        while (true) {
+            val token = continuation ?: break
+            val startedAt = SystemClock.elapsedRealtime()
+            val page = youtubeRepository.pollLiveChat(token)
+            if (_currentVideo.value?.videoId != videoId) return
+
+            if (page == null) {
+                // A failed poll is usually transient (the stream is still
+                // there), so back off and retry the same token a few times
+                // before declaring the chat gone.
+                consecutiveFailures++
+                if (consecutiveFailures > MAX_LIVE_CHAT_POLL_FAILURES) {
+                    if (_isLiveChatAvailable.value == null) _isLiveChatAvailable.value = false
+                    return
+                }
+                kotlinx.coroutines.delay(LIVE_CHAT_RETRY_DELAY_MS)
+                continue
+            }
+            consecutiveFailures = 0
+
+            _isLiveChatAvailable.value = true
+            _isLiveChatLoading.value = false
+            page.sendParams?.let { _liveChatSendParams.value = it }
+            _liveChatMaxLength.value = page.maxMessageLength
+            _liveChatRestriction.value = page.restrictionMessage
+            if (page.bannerCleared) _liveChatBanner.value = null
+            page.banner?.let { _liveChatBanner.value = it }
+
+            applyLiveChatModeration(page)
+
+            val fresh = page.messages.filter { seenLiveChatIds.add(it.id) }
+            if (isFirstPage) {
+                appendLiveChatMessages(fresh)
+                isFirstPage = false
+            } else {
+                pendingLiveChat.addAll(fresh)
+            }
+            trimSeenLiveChatIds()
+
+            continuation = page.nextContinuation
+            val window = page.timeoutMs.coerceIn(LIVE_CHAT_MIN_WINDOW_MS, LIVE_CHAT_MAX_WINDOW_MS)
+            val wait = (window - (SystemClock.elapsedRealtime() - startedAt))
+                .coerceAtLeast(LIVE_CHAT_MIN_WINDOW_MS)
+            liveChatBatchDueAt = SystemClock.elapsedRealtime() + wait
+            kotlinx.coroutines.delay(wait)
+        }
+    }
+
+    /**
+     * Release queued messages one at a time, spread over the time remaining
+     * until the next batch lands, so the queue empties just as it arrives.
+     *
+     * The first message of a batch shows immediately - the pacing only applies
+     * to the ones behind it - so a quiet chat has no added latency while a busy
+     * one flows instead of arriving in slabs. Falling behind (a burst larger
+     * than the window can pace) collapses the gap to the floor and catches up.
+     */
+    private suspend fun drainLiveChatQueue() {
+        while (true) {
+            val next = pendingLiveChat.removeFirstOrNull()
+            if (next == null) {
+                kotlinx.coroutines.delay(LIVE_CHAT_DRAIN_IDLE_MS)
+                continue
+            }
+            appendLiveChatMessages(listOf(next))
+
+            val remaining = pendingLiveChat.size
+            if (remaining == 0) {
+                kotlinx.coroutines.delay(LIVE_CHAT_DRAIN_IDLE_MS)
+                continue
+            }
+            val budget = liveChatBatchDueAt - SystemClock.elapsedRealtime()
+            kotlinx.coroutines.delay(
+                (budget / (remaining + 1))
+                    .coerceIn(LIVE_CHAT_MIN_GAP_MS, LIVE_CHAT_MAX_GAP_MS)
+            )
+        }
+    }
+
+    /** Put everything still queued on screen at once. */
+    private fun flushPendingLiveChat() {
+        if (pendingLiveChat.isEmpty()) return
+        val rest = pendingLiveChat.toList()
+        pendingLiveChat.clear()
+        appendLiveChatMessages(rest)
+    }
+
+    /**
+     * Append to the visible list, capped at [MAX_LIVE_CHAT_MESSAGES] - the same
+     * cap YouTube declares in the response - so a stream left open overnight
+     * cannot grow the list without bound.
+     */
+    private fun appendLiveChatMessages(new: List<LiveChatMessage>) {
+        if (new.isEmpty()) return
+        _liveChatMessages.update { current -> (current + new).takeLast(MAX_LIVE_CHAT_MESSAGES) }
+    }
+
+    /**
+     * Apply deletions and edits to both the visible list and the queue - a
+     * message deleted while still waiting to be shown must never reach the
+     * screen.
+     */
+    private fun applyLiveChatModeration(page: LiveChatPage) {
+        if (page.removedIds.isEmpty() &&
+            page.removedAuthorIds.isEmpty() &&
+            page.replacements.isEmpty()
+        ) return
+
+        fun survives(message: LiveChatMessage): Boolean =
+            message.id !in page.removedIds &&
+                message.author?.channelId?.let { it !in page.removedAuthorIds } != false
+
+        pendingLiveChat.retainAll { survives(it) }
+        _liveChatMessages.update { current ->
+            current.mapNotNull { message ->
+                if (!survives(message)) null else page.replacements[message.id] ?: message
+            }
+        }
+    }
+
+    /**
+     * Keep the dedupe set from growing for the lifetime of a long stream. Only
+     * ids that are still visible or queued can be re-delivered in a way that
+     * matters.
+     */
+    private fun trimSeenLiveChatIds() {
+        if (seenLiveChatIds.size <= MAX_LIVE_CHAT_MESSAGES * 3) return
+        val live = HashSet<String>(_liveChatMessages.value.size + pendingLiveChat.size)
+        _liveChatMessages.value.forEach { live.add(it.id) }
+        pendingLiveChat.forEach { live.add(it.id) }
+        seenLiveChatIds.retainAll(live)
+    }
+
+    /**
+     * Keep the concurrent viewer count fresh. The endpoint asks for a 5s tick,
+     * which is far more often than a phone needs, so this runs on
+     * [LIVE_METADATA_POLL_MS] instead.
+     */
+    private fun startLiveMetadataPolling(videoId: String) {
+        liveMetadataJob?.cancel()
+        liveMetadataJob = viewModelScope.launch {
+            while (true) {
+                val metadata = youtubeRepository.getLiveMetadata(videoId)
+                if (_currentVideo.value?.videoId != videoId) return@launch
+                metadata?.viewerCountText?.let { _liveViewerCount.value = it }
+                kotlinx.coroutines.delay(LIVE_METADATA_POLL_MS)
+            }
+        }
+    }
+
+    /** Stop both live polls. Safe to call when nothing is live. */
+    fun stopLivePolling() {
+        liveChatJob?.cancel()
+        liveChatJob = null
+        liveMetadataJob?.cancel()
+        liveMetadataJob = null
+    }
+
+    /**
+     * Post a message to the live chat.
+     *
+     * The response echoes the accepted message back, so it goes on screen at
+     * once instead of waiting up to a poll interval to come round - it is marked
+     * seen, so the poll that eventually redelivers it is a no-op.
+     *
+     * [onFailure] reports a rejection (slow mode, a word filter, a ban) so the
+     * composer can put the text back rather than silently swallowing it.
+     */
+    fun sendLiveChatMessage(text: String, onFailure: (String) -> Unit = {}) {
+        val body = text.trim()
+        if (body.isEmpty() || _isSendingLiveChat.value) return
+        val params = _liveChatSendParams.value ?: return
+        viewModelScope.launch {
+            _isSendingLiveChat.value = true
+            try {
+                val result = youtubeRepository.sendLiveChatMessage(params, body)
+                if (result.success) {
+                    result.echo?.let { echo ->
+                        if (seenLiveChatIds.add(echo.id)) appendLiveChatMessages(listOf(echo))
+                    }
+                } else {
+                    onFailure(result.error ?: "Message not sent")
+                }
+            } catch (e: Exception) {
+                android.util.Log.w("VideoPlayerVM", "Failed to send live chat message", e)
+                onFailure("Message not sent")
+            } finally {
+                _isSendingLiveChat.value = false
+            }
+        }
     }
 
     // ---------------- Save to playlist / Watch Later ----------------
@@ -1192,6 +1659,42 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
          * unplayable and the user should get the overlay instead of a spinner.
          */
         private const val MAX_SOURCE_RETRIES = 1
+
+        /**
+         * Chat backlog kept in memory. Matches the cap YouTube declares in the
+         * response itself (itemList.liveChatItemListRenderer.maxItemsToDisplay),
+         * so a stream left open for hours cannot grow the list without bound.
+         */
+        private const val MAX_LIVE_CHAT_MESSAGES = 250
+
+        /** Consecutive failed polls tolerated before the chat is given up on. */
+        private const val MAX_LIVE_CHAT_POLL_FAILURES = 3
+        private const val LIVE_CHAT_RETRY_DELAY_MS = 5_000L
+
+        /**
+         * Bounds on the server's requested poll interval. Live streams ask for
+         * 10s; a replay can ask for much less, and a misparse must not turn into
+         * a hot loop.
+         */
+        private const val LIVE_CHAT_MIN_WINDOW_MS = 2_000L
+        private const val LIVE_CHAT_MAX_WINDOW_MS = 30_000L
+
+        /**
+         * Pacing bounds for releasing a batch. The floor keeps a burst from
+         * animating one message per frame; the ceiling stops a sparse batch from
+         * sitting in the queue for seconds when there is nothing behind it.
+         */
+        private const val LIVE_CHAT_MIN_GAP_MS = 45L
+        private const val LIVE_CHAT_MAX_GAP_MS = 700L
+
+        /** Poll interval of the drain loop while the queue is empty. */
+        private const val LIVE_CHAT_DRAIN_IDLE_MS = 120L
+
+        /**
+         * Viewer-count refresh. The endpoint asks for 5s; a phone showing one
+         * number does not need it that often.
+         */
+        private const val LIVE_METADATA_POLL_MS = 25_000L
     }
 
     override fun onCleared() {
@@ -1201,6 +1704,7 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         qualityChangeListener = null
         sourceRecoveryJob?.cancel()
         sourceRecoveryJob = null
+        stopLivePolling()
         _exoPlayer?.release()
         _exoPlayer = null
     }

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
@@ -11,14 +11,13 @@ import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
-import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.datasource.HttpDataSource
 import androidx.media3.exoplayer.DefaultLoadControl
-import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlaybackException
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MergingMediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
-import androidx.media3.exoplayer.source.SingleSampleMediaSource
 import com.ivor.ivormusic.data.CaptionTrack
 import com.ivor.ivormusic.data.CommentItem
 import com.ivor.ivormusic.data.LikeStatus
@@ -26,8 +25,10 @@ import com.ivor.ivormusic.data.TimedComment
 import com.ivor.ivormusic.data.VideoEngagement
 import com.ivor.ivormusic.data.VideoItem
 import com.ivor.ivormusic.data.VideoQuality
+import com.ivor.ivormusic.data.VttCue
 import com.ivor.ivormusic.data.YouTubeRepository
 import com.ivor.ivormusic.data.ThemePreferences
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -92,11 +93,12 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
 
     private var captionsLoadedForVideoId: String? = null
 
-    // Guards the drop-the-caption-and-retry recovery in onPlayerError so it
-    // fires at most once per caption selection: without it, an unrelated
-    // playback failure (expired stream URL, network blip) would be blamed on
-    // the subtitle and silently switch captions off for good.
-    private var captionRecoveryUsed = false
+    // Cues of the selected track, rendered by the player overlay. Captions are
+    // deliberately kept out of the media source - see [setCaptionTrack].
+    private val _captionCues = MutableStateFlow<List<VttCue>>(emptyList())
+    val captionCues: StateFlow<List<VttCue>> = _captionCues.asStateFlow()
+
+    private var captionCuesJob: Job? = null
 
     // Repeat sticks across videos and app restarts, so seed it from prefs
     // rather than defaulting to off on every player creation.
@@ -122,6 +124,13 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
     // reclaimed by another app). Retry in place a couple of times before the
     // error reaches the UI; reset on every successful playback start.
     private var rendererRetryCount = 0
+
+    // Source failures (googlevideo 403 on a flagged token, an expired URL, a
+    // network blip) are recovered by re-resolving the stream rather than by
+    // replaying the dead URL. Bounded so a genuinely unplayable video still
+    // reaches the error overlay; reset on every successful playback start.
+    private var sourceRetryCount = 0
+    private var sourceRecoveryJob: kotlinx.coroutines.Job? = null
 
     // ---------------- Engagement (likes / subscribe / comments) ----------------
 
@@ -190,6 +199,19 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
 
     private var channelVideosLoadedForChannelId: String? = null
 
+    /**
+     * Stream data source factory: ChunkedStreamDataSource fetches googlevideo
+     * media in bounded ranged chunks (open-ended requests are server-paced to
+     * the media bitrate) and picks the per-request User-Agent matching the
+     * URL's issuing client (`?c=` param; a UA mismatch means a 403).
+     *
+     * Declared before [init] on purpose: the ExoPlayer built there installs it
+     * as the player-wide MediaSource factory, so a lazy declared further down
+     * the class would still be an uninitialised delegate at that point.
+     */
+    private val streamDataSourceFactory =
+        DefaultDataSource.Factory(context, com.ivor.ivormusic.data.ChunkedStreamDataSource.Factory())
+
     init {
         // Near-instant first frame (~1s buffered) plus an aggressive
         // read-ahead: up to 5 minutes (min == max: continuous top-up),
@@ -215,27 +237,15 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         // buffer drains and playback dies in a stuck-buffering state.
         // Audio focus + becoming-noisy mirror MusicService, so video playback
         // pauses the music player (and vice versa) instead of playing over it.
-        // Media3 1.4+ parses subtitles at extraction time and disables the
-        // render-time text path by default, so a sideloaded text/vtt sample
-        // throws "Legacy decoding is disabled". Our captions are sideloaded as
-        // SingleSampleMediaSource, so re-enable legacy decoding on the text
-        // renderer. DefaultRenderersFactory only exposes a toggle for this from
-        // Media3 1.6; on 1.5 we flip it on the TextRenderer directly.
-        val renderersFactory = object : DefaultRenderersFactory(context) {
-            override fun buildTextRenderers(
-                context: Context,
-                output: androidx.media3.exoplayer.text.TextOutput,
-                outputLooper: android.os.Looper,
-                extensionRendererMode: Int,
-                out: ArrayList<androidx.media3.exoplayer.Renderer>
-            ) {
-                super.buildTextRenderers(context, output, outputLooper, extensionRendererMode, out)
-                out.filterIsInstance<androidx.media3.exoplayer.text.TextRenderer>()
-                    .forEach { it.experimentalSetLegacyDecodingEnabled(true) }
-            }
-        }
-
-        _exoPlayer = ExoPlayer.Builder(context, renderersFactory)
+        // Every media source this player builds must fetch through
+        // ChunkedStreamDataSource. loadQuality() passes it explicitly for the
+        // progressive/merged paths, but the DASH branch hands the player a bare
+        // MediaItem, which would otherwise be served by Media3's stock
+        // DefaultDataSource - no per-URL User-Agent, so googlevideo answers 403
+        // and the video dead-ends on "Source error". Setting it here covers the
+        // manifest, its segments, and any future setMediaItem call.
+        _exoPlayer = ExoPlayer.Builder(context)
+            .setMediaSourceFactory(DefaultMediaSourceFactory(streamDataSourceFactory))
             .setLoadControl(loadControl)
             .setWakeMode(C.WAKE_MODE_NETWORK)
             .setAudioAttributes(AudioAttributes.DEFAULT, true)
@@ -257,6 +267,7 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
                         // Playback recovered (or started cleanly): allow the
                         // retry budget to be spent again on a later failure.
                         rendererRetryCount = 0
+                        sourceRetryCount = 0
                     }
                     if (playbackState == Player.STATE_ENDED) {
                         // Repeat and auto-play are mutually exclusive: looping
@@ -273,33 +284,6 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
                 }
 
                 override fun onPlayerError(error: PlaybackException) {
-                    // Captions are best-effort: a failing sideloaded subtitle
-                    // source fails the whole MergingMediaSource, which would
-                    // otherwise leave the player stuck buffering. If a caption is
-                    // active when playback errors, drop it and reload the video so
-                    // it recovers instead of hanging.
-                    if (!captionRecoveryUsed &&
-                        _selectedCaption.value != null &&
-                        _currentQuality.value != null
-                    ) {
-                        android.util.Log.w(
-                            "VideoPlayerVM",
-                            "Playback error with captions on; retrying without captions",
-                            error
-                        )
-                        val quality = _currentQuality.value ?: return
-                        captionRecoveryUsed = true
-                        _selectedCaption.value = null
-                        _exoPlayer?.let { p ->
-                            p.trackSelectionParameters = p.trackSelectionParameters.buildUpon()
-                                .setPreferredTextLanguage(null)
-                                .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, true)
-                                .build()
-                        }
-                        reloadPreservingPosition(quality, null)
-                        return
-                    }
-
                     // A renderer/decoder failure is not a broken stream: the
                     // codec lost its surface or was reclaimed. Re-prepare in
                     // place (position is kept) instead of dead-ending the
@@ -312,6 +296,20 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
                             error
                         )
                         _exoPlayer?.prepare()
+                        return
+                    }
+
+                    // A source failure means the URL is dead, not the video:
+                    // re-resolving is the only thing that can help, and
+                    // re-preparing the same URL never will.
+                    if (isRecoverableSourceError(error) && sourceRetryCount < MAX_SOURCE_RETRIES) {
+                        sourceRetryCount++
+                        android.util.Log.w(
+                            "VideoPlayerVM",
+                            "Source error (attempt $sourceRetryCount/$MAX_SOURCE_RETRIES); re-resolving stream",
+                            error
+                        )
+                        recoverFromSourceError(error)
                         return
                     }
 
@@ -361,21 +359,130 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
     }
 
     /**
-     * Retry after playback failed, from the error overlay. Rebuilds the media
-     * source for the current quality when there is one (keeping the position),
-     * otherwise re-runs the whole load for the current video - a failure before
-     * any quality resolved means there is nothing to preserve.
+     * Retry after playback failed, from the error overlay. Re-resolves the
+     * stream and rebuilds the media source at the current position; falls back
+     * to re-running the whole load when there is no player to reload into.
      */
     fun retryPlayback() {
         rendererRetryCount = 0
+        sourceRetryCount = 0
         _playbackError.value = null
-        val quality = _currentQuality.value
-        if (quality != null && _exoPlayer != null) {
-            reloadPreservingPosition(quality, _selectedCaption.value)
-            _exoPlayer?.play()
-        } else {
-            _currentVideo.value?.let { playVideo(it, forceRestart = true) }
+        val video = _currentVideo.value ?: return
+        if (_exoPlayer == null) {
+            playVideo(video, forceRestart = true)
+            return
         }
+        // Always re-resolve rather than replaying _currentQuality: its URL is
+        // what just failed, and googlevideo URLs are short-lived, so handing
+        // the same one back to the player fails identically every time.
+        _isLoading.value = true
+        sourceRecoveryJob?.cancel()
+        sourceRecoveryJob = viewModelScope.launch {
+            if (!reresolveAndReload(video)) {
+                _playbackError.value = Exception("Unable to load video stream")
+                _isLoading.value = false
+            }
+        }
+    }
+
+    /**
+     * Rescue a source failure without bothering the user: mint a fresh
+     * visitorData when googlevideo refused us outright (403 means the token or
+     * the request's client signature was rejected at the media layer - stream
+     * resolution itself answered 200 and never sees this), then re-resolve and
+     * reload. Falls back to surfacing [original] so the error overlay and its
+     * Retry button still appear when recovery cannot help.
+     */
+    private fun recoverFromSourceError(original: PlaybackException) {
+        val video = _currentVideo.value
+        if (video == null) {
+            _playbackError.value = original
+            _isBuffering.value = false
+            return
+        }
+        // _isLoading, not _isBuffering: a fatal error drives the player to
+        // STATE_IDLE, whose onPlaybackStateChanged sets _isBuffering back to
+        // false and would leave the re-resolve showing a frozen frame with no
+        // spinner. Nothing else writes _isLoading, and "resolving a stream" is
+        // exactly what it already means during the initial load.
+        _isLoading.value = true
+        sourceRecoveryJob?.cancel()
+        sourceRecoveryJob = viewModelScope.launch {
+            if (httpResponseCode(original) == 403) {
+                youtubeRepository.refreshVisitorDataAfterPlaybackFailure()
+            }
+            if (!reresolveAndReload(video)) {
+                _playbackError.value = original
+                _isLoading.value = false
+            }
+        }
+    }
+
+    /**
+     * Re-resolve [video]'s stream URLs and rebuild the media source at the
+     * current position, keeping the quality the user was watching when it is
+     * still on offer. Returns false when resolution yielded nothing usable, so
+     * the caller can surface an error; true also covers "the user moved on
+     * mid-flight", where there is nothing left to recover.
+     */
+    private suspend fun reresolveAndReload(video: VideoItem): Boolean {
+        if (_exoPlayer == null) return false
+        val qualities = try {
+            kotlinx.coroutines.withTimeout(15000L) {
+                youtubeRepository.getVideoStreamQualities(video.videoId)
+            }
+        } catch (e: kotlinx.coroutines.TimeoutCancellationException) {
+            // Caught before CancellationException below, which it subclasses:
+            // a timed-out resolution is a real failure the caller must surface,
+            // not a cancellation to propagate.
+            android.util.Log.w("VideoPlayerVM", "Re-resolve timed out for ${video.videoId}", e)
+            emptyList()
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            // playVideo() cancels this job when the user moves on. Swallowing
+            // that would let a dead recovery keep writing loading/error state
+            // over the video that replaced it.
+            throw e
+        } catch (e: Exception) {
+            android.util.Log.w("VideoPlayerVM", "Re-resolve failed for ${video.videoId}", e)
+            emptyList()
+        }
+        if (_currentVideo.value?.videoId != video.videoId) {
+            _isLoading.value = false
+            return true
+        }
+        if (qualities.isEmpty()) return false
+
+        _availableQualities.value = qualities
+        val previousLabel = _currentQuality.value?.resolution
+        val quality = qualities.firstOrNull { it.resolution == previousLabel }
+            ?: pickDefaultQuality(qualities)
+        reloadPreservingPosition(quality)
+        _exoPlayer?.play()
+        _playbackError.value = null
+        _isLoading.value = false
+        return true
+    }
+
+    /**
+     * Source-level failures - dead URL, 403, malformed container - are worth
+     * re-resolving for. Renderer failures are not: [isTransientRendererError]
+     * already re-prepares those in place, and this runs after it.
+     */
+    private fun isRecoverableSourceError(error: PlaybackException): Boolean {
+        if (error is ExoPlaybackException && error.type == ExoPlaybackException.TYPE_SOURCE) {
+            return true
+        }
+        return error.errorCode == PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS
+    }
+
+    /** HTTP status behind a source error, or null when it was not an HTTP failure. */
+    private fun httpResponseCode(error: PlaybackException): Int? {
+        var cause: Throwable? = error.cause
+        while (cause != null) {
+            if (cause is HttpDataSource.InvalidResponseCodeException) return cause.responseCode
+            cause = cause.cause
+        }
+        return null
     }
 
     /**
@@ -432,9 +539,14 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         _selectedCaption.value = null // Captions default off per video
         _isCaptionsLoading.value = false
         captionsLoadedForVideoId = null
-        captionRecoveryUsed = false
+        captionCuesJob?.cancel()
+        _captionCues.value = emptyList()
         _playbackError.value = null // Clear previous error
         rendererRetryCount = 0
+        sourceRetryCount = 0
+        // A recovery still in flight belongs to the previous video
+        sourceRecoveryJob?.cancel()
+        sourceRecoveryJob = null
 
         // Reset engagement + comments state for the new video
         _engagement.value = null
@@ -556,16 +668,6 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
     }
 
     /**
-     * Stream data source factory: ChunkedStreamDataSource fetches googlevideo
-     * media in bounded ranged chunks (open-ended requests are server-paced to
-     * the media bitrate) and picks the per-request User-Agent matching the
-     * URL's issuing client (`?c=` param; a UA mismatch means a 403).
-     */
-    private val streamDataSourceFactory by lazy {
-        DefaultDataSource.Factory(context, com.ivor.ivormusic.data.ChunkedStreamDataSource.Factory())
-    }
-
-    /**
      * Pick the starting quality based on the Settings preference for the
      * current network (Wi-Fi vs mobile data). Fresh pref read because Settings
      * toggles through its own ThemePreferences instance.
@@ -587,33 +689,26 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
     }
 
     /**
-     * Build the media source for [quality], optionally sideloading [caption] as
-     * a WebVTT subtitle track. DASH carries the subtitle via a MediaItem
-     * SubtitleConfiguration (the player's default source factory sideloads it);
-     * the progressive/merged paths wrap a SingleSampleMediaSource into the
-     * MergingMediaSource. PlayerView renders the selected text cues in its
-     * built-in SubtitleView, so no extra UI is needed.
+     * Build the media source for [quality].
+     *
+     * Captions are not part of it. They used to be sideloaded here as a text
+     * track, which made every CC toggle a media-source rebuild: the video and
+     * audio were torn down and refetched from the network just to add or drop a
+     * subtitle. Koda renders cues itself instead - see [setCaptionTrack] - so
+     * this only ever deals with video and audio.
      */
-    private fun loadQuality(quality: VideoQuality, caption: CaptionTrack? = _selectedCaption.value) {
+    private fun loadQuality(quality: VideoQuality) {
         _currentQuality.value = quality
 
-        val subtitleConfig = caption?.let {
-            MediaItem.SubtitleConfiguration.Builder(android.net.Uri.parse(it.vttUrl))
-                .setMimeType(MimeTypes.TEXT_VTT)
-                .setLanguage(it.languageCode)
-                .setSelectionFlags(C.SELECTION_FLAG_DEFAULT)
-                .build()
-        }
-
         if (quality.isDASH) {
-            // DASH streams are adaptive - use directly without merging
-            val builder = MediaItem.Builder()
-                .setUri(quality.url)
-                .setMimeType(MimeTypes.APPLICATION_MPD)
-            if (subtitleConfig != null) {
-                builder.setSubtitleConfigurations(listOf(subtitleConfig))
-            }
-            _exoPlayer?.setMediaItem(builder.build())
+            // Adaptive manifest - hand it to the player and let its MediaSource
+            // factory build the DASH/HLS source, no merging needed.
+            _exoPlayer?.setMediaItem(
+                MediaItem.Builder()
+                    .setUri(quality.url)
+                    .setMimeType(adaptiveMimeType(quality))
+                    .build()
+            )
         } else {
             val dataSourceFactory = streamDataSourceFactory
             val audioUrl = quality.audioUrl
@@ -631,50 +726,38 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
                     .createMediaSource(MediaItem.fromUri(quality.url))
             }
 
-            if (subtitleConfig != null) {
-                val subtitleSource = SingleSampleMediaSource.Factory(subtitleDataSourceFactory())
-                    .createMediaSource(subtitleConfig, C.TIME_UNSET)
-                // Documented sideloading pattern: merge the subtitle as an extra
-                // source. The default MergingMediaSource ignores the subtitle's
-                // unknown (TIME_UNSET) duration when clipping, so it does not
-                // truncate the video/audio timeline.
-                _exoPlayer?.setMediaSource(MergingMediaSource(primarySource, subtitleSource))
-            } else {
-                _exoPlayer?.setMediaSource(primarySource)
-            }
+            _exoPlayer?.setMediaSource(primarySource)
         }
         _exoPlayer?.prepare()
     }
 
     /**
-     * HTTP factory for the timedtext subtitle request. The endpoint is on
-     * www.youtube.com (not googlevideo), so a plain browser User-Agent works.
+     * MIME for an adaptive quality. Both DASH and HLS entries arrive with
+     * isDASH set and are told apart only by [VideoQuality.format], so pinning
+     * MPD unconditionally would make the factory build a DashMediaSource for an
+     * m3u8 playlist and fail the load - which is what every live stream gets.
      */
-    private fun subtitleDataSourceFactory(): DefaultHttpDataSource.Factory =
-        DefaultHttpDataSource.Factory()
-            .setUserAgent(
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
-                    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-            )
-            .setAllowCrossProtocolRedirects(true)
+    private fun adaptiveMimeType(quality: VideoQuality): String =
+        if (quality.format.equals("HLS", ignoreCase = true)) MimeTypes.APPLICATION_M3U8
+        else MimeTypes.APPLICATION_MPD
 
     fun setQuality(quality: VideoQuality) {
-        reloadPreservingPosition(quality, _selectedCaption.value)
+        reloadPreservingPosition(quality)
     }
 
     /**
-     * Rebuild the media source for a new quality and/or caption selection while
-     * keeping the current playback position. Used by both quality switches and
-     * caption toggles.
+     * Rebuild the media source for a new quality while keeping the current
+     * playback position. Only quality switches need this - caption changes no
+     * longer touch the media source at all.
      */
-    private fun reloadPreservingPosition(quality: VideoQuality, caption: CaptionTrack?) {
+    private fun reloadPreservingPosition(quality: VideoQuality) {
         val player = _exoPlayer ?: return
         val position = player.currentPosition
 
         // Remove any existing quality change listener to prevent leaks
         qualityChangeListener?.let { player.removeListener(it) }
 
-        loadQuality(quality, caption)
+        loadQuality(quality)
 
         // Wait for player to be ready before seeking to preserved position
         val listener = object : Player.Listener {
@@ -712,22 +795,38 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
     }
 
     /**
-     * Select a caption track (or null to turn captions off). Rebuilds the media
-     * source to add/remove the sideloaded subtitle, preserving position, and
-     * updates the player's preferred text language so the track is auto-shown.
+     * Select a caption track, or null to turn captions off.
+     *
+     * The playback pipeline is deliberately untouched here. Captions used to be
+     * a text track merged into the media source, so switching them rebuilt that
+     * source: playback re-prepared, the buffer was discarded, and - because
+     * video has no disk cache - everything already downloaded was fetched
+     * again. Cues are fetched and parsed on their own instead, and the overlay
+     * draws them over the video surface, which makes the CC toggle instant and
+     * free no matter how many times it is pressed.
      */
     fun setCaptionTrack(track: CaptionTrack?) {
         if (_selectedCaption.value == track) return
         _selectedCaption.value = track
-        // A deliberate (re)selection earns a fresh recovery attempt.
-        captionRecoveryUsed = false
-        val player = _exoPlayer ?: return
-        player.trackSelectionParameters = player.trackSelectionParameters.buildUpon()
-            .setPreferredTextLanguage(track?.languageCode)
-            .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, track == null)
-            .build()
-        val quality = _currentQuality.value ?: return
-        reloadPreservingPosition(quality, track)
+
+        captionCuesJob?.cancel()
+        if (track == null) {
+            _captionCues.value = emptyList()
+            return
+        }
+        captionCuesJob = viewModelScope.launch {
+            val cues = youtubeRepository.getCaptionCues(track)
+            // Ignore a load the user has already switched away from
+            if (_selectedCaption.value == track) {
+                _captionCues.value = cues
+                if (cues.isEmpty()) {
+                    android.util.Log.w(
+                        "VideoPlayerVM",
+                        "Caption track ${track.languageCode} produced no cues"
+                    )
+                }
+            }
+        }
     }
 
     fun setExpanded(expanded: Boolean) {
@@ -1056,6 +1155,14 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
 
         /** Silent re-prepare attempts before a renderer error reaches the UI. */
         private const val MAX_RENDERER_RETRIES = 2
+
+        /**
+         * Silent re-resolve attempts before a source error reaches the UI. One
+         * is enough: the first pass already remints a rejected visitorData and
+         * fetches brand-new URLs, so a second failure means the video really is
+         * unplayable and the user should get the overlay instead of a spinner.
+         */
+        private const val MAX_SOURCE_RETRIES = 1
     }
 
     override fun onCleared() {
@@ -1063,6 +1170,8 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         // Remove quality change listener to prevent leaks
         qualityChangeListener?.let { _exoPlayer?.removeListener(it) }
         qualityChangeListener = null
+        sourceRecoveryJob?.cancel()
+        sourceRecoveryJob = null
         _exoPlayer?.release()
         _exoPlayer = null
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,8 @@ androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 androidx-media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3" }
+androidx-media3-exoplayer-dash = { group = "androidx.media3", name = "media3-exoplayer-dash", version.ref = "media3" }
+androidx-media3-exoplayer-hls = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3" }
 androidx-media3-ui = { group = "androidx.media3", name = "media3-ui", version.ref = "media3" }
 androidx-media3-session = { group = "androidx.media3", name = "media3-session", version.ref = "media3" }
 accompanist-permissions = { group = "com.google.accompanist", name = "accompanist-permissions", version.ref = "accompanist" }


### PR DESCRIPTION
Three video-mode changes, plus DASH/HLS module loading from a concurrent session.

## Share sheet and link intents

`MainActivity` had one `MAIN`/`LAUNCHER` intent filter, so Koda never showed up when a YouTube link was shared or opened from another app.

- `ACTION_SEND` (`text/plain`) for the share sheet, `ACTION_VIEW` for "open with". VIEW paths are constrained to `/watch`, `/playlist`, `/shorts/`, `/live/`, `/embed/`, `/v/` and all of `youtu.be`, so Koda is not offered for channel or account URLs it cannot play.
- The link's origin picks the mode: `music.youtube.com` → music player, everything else → video player. A music playlist link opens the playlist positioned on the shared track.
- Video links skip metadata resolution — `playVideo` only needs an id to start streaming, and its second phase fills in title, channel and related videos. A derived thumbnail gives the player a poster while the first frames buffer.
- `singleTop` + `onNewIntent` so a link shared into a running app does not stack a second activity over the live players. The intent is neutralised once read, so an activity recreation (theme change) cannot replay it.
- `parseFromSharedText` finds the URL inside the prose share sheets attach ("Video title\nhttps://youtu.be/id").

Held back until onboarding completes, and guarded on local-only mode with an explanatory toast.

## Captions no longer reload the video

Captions were a `SingleSampleMediaSource` merged into the media source, so `setCaptionTrack` rebuilt that source: playback re-prepared and the entire buffer was thrown away. Video has no disk cache, so everything already downloaded was refetched — on every CC tap.

Cues are now fetched and parsed independently (`WebVttParser`) and drawn by a Compose overlay driven by the playhead. Toggling captions no longer touches the playback pipeline at all, and captions survive a quality switch, which they previously did not.

Three workarounds retired with it:
- the `DefaultRenderersFactory` subclass calling `experimentalSetLegacyDecodingEnabled`
- the drop-the-caption-and-retry recovery in `onPlayerError`
- `hoistSubtitleViewAboveVideo` and `setCaptionBottomInset`

**Known regression:** the mini player and PiP window no longer show captions, since they relied on the built-in `SubtitleView`. Cheap to restore, and that surface is being rebuilt for the PiP work next.

## Feed refresh actually returns new videos

Pull-to-refresh re-fetched `FEwhat_to_watch` page 1 and replaced the list, but that page is near-static server-side. Probed against the live feed:

| | result |
|---|---|
| page 1 | 23 videos |
| page 2 (continuation) | 23 videos, 100% new |
| page 3 | 4 videos, then the token dies (~50 total) |
| **page-1 refetch** | 22 videos, **16 already on screen** |

Refresh now walks forward through the feed, keeping a session-scoped set of shown ids, until it has a screenful of unseen videos or the token runs out — falling back to page 1 rather than emptying the screen. Logged out there is no token, so it rotates the taste-based seed window instead.

A stale `visitorData` looked like the culprit (YouTube mints a fresh visitor session on every request), but pinning it measured *worse* — 77% identical vs 63% — so that change was not adopted.

Limits: the seen-set is in-memory, so a cold start can still show familiar videos, and YouTube's pool is only ~50 deep per session.

## Note on commit structure

This branch was cut from a working tree shared with a concurrent session. The first commit isolates that session's DASH/HLS work (the `media3-exoplayer-dash` / `-hls` artifacts and the Shorts data-source factory). `YouTubeRepository.kt` and `VideoPlayerViewModel.kt` carry both sets of changes and could not be split by file — the visitorData clock-skew fix and `refreshVisitorDataAfterPlaybackFailure` are from that session, not this one.

## Testing

Share sheet and captions verified on device. Feed refresh verified. Not yet built or run in CI from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqFo1AKYYTHrEvdv3mjFCX
