### PR TITLE
Fix dead PiP controls, add PiP seek buttons, publish video to system media

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -115,6 +115,22 @@
         </service>
 
         <!--
+            Puts video playback on the lock screen, in the shade's media area
+            and on Bluetooth/headset transport buttons. The ExoPlayer itself
+            stays owned by VideoPlayerViewModel; this service only wraps it in
+            a MediaSession, which is also what makes background video audio a
+            legitimate foreground service rather than an unannounced one.
+        -->
+        <service
+            android:name=".service.VideoPlaybackService"
+            android:foregroundServiceType="mediaPlayback"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="androidx.media3.session.MediaSessionService"/>
+            </intent-filter>
+        </service>
+
+        <!--
             Keeps the process alive while downloads run. dataSync is the correct
             type for user-initiated file transfers; the matching
             FOREGROUND_SERVICE_DATA_SYNC permission is declared above.

--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -434,6 +434,12 @@ fun MusicApp(
         }
     )
 
+    // Drives the PiP window's shape and its transport controls. Composed above
+    // the early return on purpose: everything below it is torn out of the
+    // composition the moment PiP starts, which is what used to unregister the
+    // receiver behind the PiP play/pause button and leave it inert.
+    com.ivor.ivormusic.ui.video.VideoPipController(viewModel = videoPlayerViewModel)
+
     // In system PiP the app is just a video surface. Returning here keeps the
     // NavHost, both players and every overlay out of the composition entirely,
     // rather than letting them draw and animate behind a window nobody can see

--- a/app/src/main/java/com/ivor/ivormusic/service/MusicService.kt
+++ b/app/src/main/java/com/ivor/ivormusic/service/MusicService.kt
@@ -3,6 +3,8 @@ package com.ivor.ivormusic.service
 import android.app.PendingIntent
 import android.content.Intent
 import android.net.Uri
+import android.os.Bundle
+import android.os.SystemClock
 import android.util.Log
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
@@ -22,6 +24,8 @@ import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.session.LibraryResult
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
+import androidx.media3.session.SessionCommand
+import androidx.media3.session.SessionResult
 import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
@@ -133,6 +137,31 @@ class MusicService : MediaLibraryService() {
         // Stream head pre-cached for upcoming songs: ~30s of opus audio, enough
         // to cover the 0.5s start buffer plus the first ranged chunk's RTT.
         private const val WARM_CACHE_BYTES = 512L * 1024
+
+        // --- Sleep timer: the contract with PlayerViewModel ---
+
+        /** Arm the timer. Carries [ARG_SLEEP_TIMER_MINUTES]; 0 = end of track. */
+        const val CMD_SLEEP_TIMER_SET = "com.ivor.ivormusic.SLEEP_TIMER_SET"
+        const val CMD_SLEEP_TIMER_CANCEL = "com.ivor.ivormusic.SLEEP_TIMER_CANCEL"
+        const val ARG_SLEEP_TIMER_MINUTES = "sleep_timer_minutes"
+
+        /** Session-extras keys the timer state is published under. */
+        const val EXTRA_SLEEP_TIMER_ENDS_AT = "sleep_timer_ends_at"
+        const val EXTRA_SLEEP_TIMER_END_OF_TRACK = "sleep_timer_end_of_track"
+
+        /**
+         * How long the fade before the timer's pause takes. Long enough to read
+         * as drifting off rather than as a glitch, short enough that the last
+         * thing heard is not a minute of near-silence.
+         */
+        private const val SLEEP_TIMER_FADE_MS = 5_000L
+
+        /**
+         * Longest a single slice of the countdown sleeps for. Bounded so the
+         * job re-checks the real deadline regularly instead of trusting one
+         * long delay that deep sleep can stretch.
+         */
+        private const val SLEEP_TIMER_TICK_MS = 30_000L
     }
 
     /**
@@ -209,6 +238,7 @@ class MusicService : MediaLibraryService() {
         Log.i(TAG, "MusicService Destroying...")
         fadeVolumeJob?.cancel()
         progressJob?.cancel()
+        sleepTimerJob?.cancel()
         // Cancel the scopes themselves — they host the preference collectors and
         // any in-flight resolutions, which would otherwise outlive the service.
         serviceScope.cancel()
@@ -434,6 +464,22 @@ class MusicService : MediaLibraryService() {
             if (playbackState == Player.STATE_ENDED || playbackState == Player.STATE_IDLE) {
                 progressJob?.cancel()
                 musicProgressLiveUpdate?.hide()
+            }
+        }
+
+        /**
+         * The end-of-track sleep timer firing. Media3 drops playWhenReady with
+         * this exact reason when [ExoPlayer.setPauseAtEndOfMediaItems] stops the
+         * player on an item boundary, so it is the one unambiguous signal that
+         * the timer - rather than the user or audio focus - paused playback.
+         */
+        override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
+            super.onPlayWhenReadyChanged(playWhenReady, reason)
+            if (!playWhenReady &&
+                reason == Player.PLAY_WHEN_READY_CHANGE_REASON_END_OF_MEDIA_ITEM &&
+                sleepTimerEndOfTrack
+            ) {
+                clearSleepTimer()
             }
         }
 
@@ -757,11 +803,44 @@ class MusicService : MediaLibraryService() {
                 .add(Player.COMMAND_SET_SHUFFLE_MODE)
                 .add(Player.COMMAND_SET_REPEAT_MODE)
                 .build()
-                
+
+            val availableSessionCommands =
+                MediaSession.ConnectionResult.DEFAULT_SESSION_COMMANDS.buildUpon()
+                    .add(SessionCommand(CMD_SLEEP_TIMER_SET, Bundle.EMPTY))
+                    .add(SessionCommand(CMD_SLEEP_TIMER_CANCEL, Bundle.EMPTY))
+                    .build()
+
             return MediaSession.ConnectionResult.accept(
-                MediaSession.ConnectionResult.DEFAULT_SESSION_COMMANDS,
+                availableSessionCommands,
                 availablePlayerCommands
             )
+        }
+
+        /**
+         * A controller that connects mid-session has no idea a timer is
+         * running - the UI is routinely destroyed and rebuilt underneath a
+         * playing service - so hand it the current state on arrival.
+         */
+        override fun onPostConnect(session: MediaSession, controller: MediaSession.ControllerInfo) {
+            super.onPostConnect(session, controller)
+            publishSleepTimerState()
+        }
+
+        override fun onCustomCommand(
+            session: MediaSession,
+            controller: MediaSession.ControllerInfo,
+            customCommand: SessionCommand,
+            args: Bundle
+        ): ListenableFuture<SessionResult> = when (customCommand.customAction) {
+            CMD_SLEEP_TIMER_SET -> {
+                startSleepTimer(args.getInt(ARG_SLEEP_TIMER_MINUTES, 0))
+                Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
+            }
+            CMD_SLEEP_TIMER_CANCEL -> {
+                clearSleepTimer()
+                Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
+            }
+            else -> super.onCustomCommand(session, controller, customCommand, args)
         }
 
         override fun onAddMediaItems(
@@ -979,6 +1058,117 @@ class MusicService : MediaLibraryService() {
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to pre-warm cache", e)
             }
+        }
+    }
+
+    // --- Sleep timer ---
+    //
+    // This lives in the service, not in PlayerViewModel where it used to. The
+    // ViewModel is scoped to MainActivity, so its viewModelScope - and with it
+    // the timer's delay() - was cancelled the moment the activity went away.
+    // Backing out of the app while music kept playing (the whole point of a
+    // foreground media service, and exactly what someone setting a sleep timer
+    // does next) silently killed the timer, and playback ran all night. There
+    // was no persistence either, so reopening the app showed no timer running
+    // and gave the user no way to tell it had died.
+    //
+    // The player outlives the UI, so the thing that stops the player has to as
+    // well. State is published back through the session's extras, which is how
+    // every connected controller - the UI, and anything else - learns about it.
+
+    private var sleepTimerJob: Job? = null
+
+    /** Wall-clock ms when the timer fires, or 0 when no duration timer is set. */
+    private var sleepTimerEndsAt: Long = 0L
+
+    /** True while the player is set to stop when the current track finishes. */
+    private var sleepTimerEndOfTrack: Boolean = false
+
+    /**
+     * Arm the sleep timer. [minutes] of 0 or less means "at the end of the
+     * current track" instead of a duration.
+     */
+    private fun startSleepTimer(minutes: Int) {
+        clearSleepTimer(publish = false)
+
+        if (minutes <= 0) {
+            // Media3 has exactly this behaviour built in, and it is more precise
+            // than watching for the track to end ourselves: the player stops on
+            // the item boundary rather than a callback or two later, and a
+            // later play() still moves on to the next track normally.
+            sleepTimerEndOfTrack = true
+            player.pauseAtEndOfMediaItems = true
+        } else {
+            val durationMs = minutes * 60_000L
+            sleepTimerEndsAt = System.currentTimeMillis() + durationMs
+            val deadline = SystemClock.elapsedRealtime() + durationMs
+            sleepTimerJob = serviceScope.launch {
+                // Sliced against elapsedRealtime rather than one long delay:
+                // coroutine delays on the main dispatcher are driven by
+                // uptimeMillis, which stops counting while the device is in
+                // deep sleep. A timer set and then paused would come due long
+                // after the wall clock said it should.
+                while (true) {
+                    val remaining = deadline - SystemClock.elapsedRealtime()
+                    if (remaining <= 0L) break
+                    delay(remaining.coerceAtMost(SLEEP_TIMER_TICK_MS))
+                }
+                fadeOutAndPause()
+                clearSleepTimer()
+            }
+        }
+        publishSleepTimerState()
+    }
+
+    /**
+     * Ease the volume down before pausing.
+     *
+     * A sleep timer that cuts the audio dead is worse than one that does not
+     * fire: the silence is what wakes people. Runs on [fadeVolumeJob] so it and
+     * the crossfade fade-in can never drive the volume at the same time.
+     */
+    private fun fadeOutAndPause() {
+        fadeVolumeJob?.cancel()
+        fadeVolumeJob = serviceScope.launch {
+            val steps = 20
+            for (i in steps - 1 downTo 0) {
+                player.volume = i / steps.toFloat()
+                delay(SLEEP_TIMER_FADE_MS / steps)
+            }
+            player.pause()
+            // Back to full straight away, or pressing play would be silent.
+            player.volume = 1f
+        }
+    }
+
+    /** Disarm, whether it fired or the user cancelled it. */
+    private fun clearSleepTimer(publish: Boolean = true) {
+        sleepTimerJob?.cancel()
+        sleepTimerJob = null
+        sleepTimerEndsAt = 0L
+        if (sleepTimerEndOfTrack) {
+            sleepTimerEndOfTrack = false
+            // Leaving this set would silently pause at the end of every
+            // subsequent track too.
+            player.pauseAtEndOfMediaItems = false
+        }
+        if (publish) publishSleepTimerState()
+    }
+
+    /**
+     * Push the timer state to every connected controller. Session extras are
+     * the right channel: they survive the UI being destroyed and rebuilt, so a
+     * player reopened ten minutes later still shows the running countdown.
+     */
+    private fun publishSleepTimerState() {
+        val session = mediaLibrarySession ?: return
+        runCatching {
+            session.setSessionExtras(
+                Bundle().apply {
+                    putLong(EXTRA_SLEEP_TIMER_ENDS_AT, sleepTimerEndsAt)
+                    putBoolean(EXTRA_SLEEP_TIMER_END_OF_TRACK, sleepTimerEndOfTrack)
+                }
+            )
         }
     }
 

--- a/app/src/main/java/com/ivor/ivormusic/service/VideoPlaybackService.kt
+++ b/app/src/main/java/com/ivor/ivormusic/service/VideoPlaybackService.kt
@@ -1,0 +1,284 @@
+package com.ivor.ivormusic.service
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.CommandButton
+import androidx.media3.session.DefaultMediaNotificationProvider
+import androidx.media3.session.MediaSession
+import androidx.media3.session.MediaSessionService
+import androidx.media3.session.SessionCommand
+import androidx.media3.session.SessionResult
+import com.google.common.collect.ImmutableList
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+import com.ivor.ivormusic.MainActivity
+import com.ivor.ivormusic.R
+
+/**
+ * Publishes the video player to the rest of Android.
+ *
+ * Music has always had this through [MusicService]: a MediaSession is what puts
+ * a track on the lock screen, in the notification shade's media area and in the
+ * output switcher, and what makes headset and Bluetooth transport buttons work.
+ * Video had none of it - it was an ExoPlayer owned by a ViewModel and nothing
+ * else - so a video kept playing with the screen off with no way to pause it
+ * short of reopening the app, and the system had no idea Koda was playing
+ * anything at all. It was also playing audio in the background with no
+ * foreground service, which is exactly the state Android kills processes for.
+ *
+ * The player deliberately stays owned by `VideoPlayerViewModel` (see CLAUDE.md:
+ * the video pipeline is a plain ExoPlayer, not a service, so the surface, PiP
+ * and quality switching stay in one place). This service borrows it: it wraps
+ * the ViewModel's player in a session and owns nothing but that session, and it
+ * never releases the player.
+ *
+ * Lifecycle is driven from the ViewModel - [start] when a video loads, [stop]
+ * when the player is closed or the ViewModel dies. [stop] tears the session
+ * down synchronously on the caller's thread (which is the player's application
+ * thread) so the session is always gone before the player it wraps is released.
+ */
+@UnstableApi
+class VideoPlaybackService : MediaSessionService() {
+
+    private var session: MediaSession? = null
+
+    override fun onCreate() {
+        super.onCreate()
+
+        // Its own notification id and channel: the default provider uses one
+        // fixed id, so sharing it with MusicService would mean whichever
+        // pipeline posted last erased the other's notification.
+        setMediaNotificationProvider(
+            DefaultMediaNotificationProvider.Builder(this)
+                .setNotificationId(NOTIFICATION_ID)
+                .setChannelId(CHANNEL_ID)
+                .setChannelName(R.string.video_playback_channel_name)
+                .build()
+                .apply { setSmallIcon(R.drawable.ic_playback_notification) }
+        )
+
+        instance = this
+
+        val player = pendingPlayer
+        if (player == null) {
+            // Nothing to publish - the ViewModel went away between the start
+            // request and the service actually being created, or the system
+            // restarted us stickily after the process died.
+            Log.w(TAG, "Started without a player; stopping")
+            stopSelf()
+            return
+        }
+        ensureSession(player)
+    }
+
+    /**
+     * Make sure a session is publishing [player], building one if there is not
+     * one already.
+     *
+     * Needed because `stopService` is asynchronous: closing a video and opening
+     * another one quickly enough finds the service still alive with its session
+     * already gone, and `onCreate` will not run a second time to rebuild it.
+     * Without this the second video would play with nothing on the lock screen.
+     */
+    private fun ensureSession(player: Player) {
+        session?.let { existing ->
+            if (existing.player === player) return
+            releaseSession()
+        }
+
+        val sessionIntent = PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, MainActivity::class.java),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
+        val built = try {
+            MediaSession.Builder(this, player)
+                // A process may not hold two sessions with the same id, and
+                // MusicService already owns the default (empty) one.
+                .setId(SESSION_ID)
+                .setSessionActivity(sessionIntent)
+                .setCallback(VideoSessionCallback())
+                .setCustomLayout(seekLayout())
+                .build()
+        } catch (e: Exception) {
+            Log.e(TAG, "Could not build the video media session", e)
+            stopSelf()
+            return
+        }
+        session = built
+        // Explicit, not incidental: Media3 registers a session automatically
+        // only when a MediaController binds and onGetSession answers. Nothing in
+        // Koda binds to this service - the ViewModel already has the player - so
+        // without this the session would exist and the notification would never
+        // be posted.
+        addSession(built)
+    }
+
+    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? = session
+
+    /**
+     * Swiped out of recents. The player belongs to the ViewModel, which is
+     * being torn down with the task, so pause and go away rather than leaving
+     * an undismissable foreground notification behind.
+     */
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        pauseAllPlayersAndStopSelf()
+    }
+
+    override fun onDestroy() {
+        releaseSession()
+        if (instance === this) instance = null
+        super.onDestroy()
+    }
+
+    /** Drop the session without touching the player - the ViewModel owns that. */
+    private fun releaseSession() {
+        val current = session ?: return
+        session = null
+        runCatching { removeSession(current) }
+        current.release()
+    }
+
+    /**
+     * Back 10 / forward 10 in the media notification, matching the double-tap
+     * seek on the player and the PiP controls.
+     *
+     * These have to be custom session commands rather than
+     * [Player.COMMAND_SEEK_BACK] buttons: Media3's notification provider only
+     * promotes custom-layout entries that carry a [SessionCommand], and its
+     * built-in row is previous/play/next - which on a single-item video player
+     * means one button that seeks to zero and one that is permanently dead.
+     */
+    private fun seekLayout(): ImmutableList<CommandButton> = ImmutableList.of(
+        CommandButton.Builder()
+            .setDisplayName("Back 10 seconds")
+            .setIconResId(R.drawable.ic_media_replay_10)
+            .setSessionCommand(SessionCommand(ACTION_REWIND, Bundle.EMPTY))
+            .build(),
+        CommandButton.Builder()
+            .setDisplayName("Forward 10 seconds")
+            .setIconResId(R.drawable.ic_media_forward_10)
+            .setSessionCommand(SessionCommand(ACTION_FORWARD, Bundle.EMPTY))
+            .build()
+    )
+
+    private inner class VideoSessionCallback : MediaSession.Callback {
+
+        override fun onConnect(
+            session: MediaSession,
+            controller: MediaSession.ControllerInfo
+        ): MediaSession.ConnectionResult {
+            return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
+                .setAvailableSessionCommands(
+                    MediaSession.ConnectionResult.DEFAULT_SESSION_COMMANDS.buildUpon()
+                        .add(SessionCommand(ACTION_REWIND, Bundle.EMPTY))
+                        .add(SessionCommand(ACTION_FORWARD, Bundle.EMPTY))
+                        .build()
+                )
+                // The video player holds exactly one item, so "previous" only
+                // ever seeks to zero and "next" is permanently dead. Withdrawing
+                // both is what leaves room for the skip pair below, and stops a
+                // car head unit from offering a track-change that does nothing.
+                .setAvailablePlayerCommands(
+                    MediaSession.ConnectionResult.DEFAULT_PLAYER_COMMANDS.buildUpon()
+                        .remove(Player.COMMAND_SEEK_TO_PREVIOUS)
+                        .remove(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
+                        .remove(Player.COMMAND_SEEK_TO_NEXT)
+                        .remove(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
+                        .build()
+                )
+                .build()
+        }
+
+        override fun onCustomCommand(
+            session: MediaSession,
+            controller: MediaSession.ControllerInfo,
+            customCommand: SessionCommand,
+            args: Bundle
+        ): ListenableFuture<SessionResult> {
+            when (customCommand.customAction) {
+                // seekBack/seekForward, not a raw seekTo: the player is built
+                // with 10s increments, so these agree with the UI by
+                // construction and clamp at the ends of the media for free.
+                ACTION_REWIND -> session.player.seekBack()
+                ACTION_FORWARD -> session.player.seekForward()
+                else -> return Futures.immediateFuture(
+                    SessionResult(SessionResult.RESULT_ERROR_NOT_SUPPORTED)
+                )
+            }
+            return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
+        }
+    }
+
+    companion object {
+        private const val TAG = "VideoPlaybackService"
+        private const val SESSION_ID = "koda_video"
+        private const val CHANNEL_ID = "video_playback"
+
+        // Must differ from DefaultMediaNotificationProvider's default (which is
+        // what MusicService posts under) and from MusicProgressLiveUpdate's.
+        private const val NOTIFICATION_ID = 1002
+
+        const val ACTION_REWIND = "com.ivor.ivormusic.VIDEO_REWIND"
+        const val ACTION_FORWARD = "com.ivor.ivormusic.VIDEO_FORWARD"
+
+        @Volatile
+        private var instance: VideoPlaybackService? = null
+
+        /**
+         * The player the session will wrap, handed over before the service is
+         * created. Held statically because there is no DI here and a Service
+         * cannot be given constructor arguments.
+         */
+        @Volatile
+        internal var pendingPlayer: Player? = null
+            private set
+
+        /**
+         * Publish [player] to the system. Safe to call repeatedly - once the
+         * service is up this is just a no-op start command.
+         *
+         * Must be called from the foreground (it is, from `playVideo`): a
+         * background service start is refused from Android 12 onwards.
+         */
+        fun start(context: Context, player: Player) {
+            pendingPlayer = player
+            // A start request cancels a pending stop, but it does not re-run
+            // onCreate on a service that is still alive, so an already-running
+            // instance is asked to rebuild its session directly.
+            instance?.ensureSession(player)
+            try {
+                context.startService(Intent(context, VideoPlaybackService::class.java))
+            } catch (e: Exception) {
+                // A refused start costs the notification, never playback.
+                Log.w(TAG, "Could not start the video playback service", e)
+            }
+        }
+
+        /**
+         * Take the video off the system's media controls.
+         *
+         * The session is released here rather than being left to `onDestroy`
+         * because `stopService` is asynchronous: callers release the player
+         * immediately afterwards, and a session outliving its player is a
+         * crash. This runs on the caller's thread, which is the player's
+         * application thread, so the teardown is ordered correctly.
+         */
+        fun stop(context: Context) {
+            instance?.releaseSession()
+            pendingPlayer = null
+            try {
+                context.stopService(Intent(context, VideoPlaybackService::class.java))
+            } catch (e: Exception) {
+                Log.w(TAG, "Could not stop the video playback service", e)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/components/SleepTimerDialog.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/components/SleepTimerDialog.kt
@@ -1,17 +1,30 @@
 package com.ivor.ivormusic.ui.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Bedtime
-import androidx.compose.material3.AlertDialog
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -20,84 +33,226 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import java.util.Locale
 
+/** Durations offered, laid out three to a row. */
+private val PRESET_MINUTES = listOf(listOf(5, 10, 15), listOf(30, 45, 60))
+
 /**
- * 😴 Sleep timer picker / status dialog.
+ * Sleep timer picker and status.
  *
- * Inactive: preset duration buttons. Active: live countdown + stop button.
- * Playback pauses when the timer fires (see PlayerViewModel.startSleepTimer).
+ * One sheet shared by all eight player styles rather than eight bespoke ones -
+ * but it takes its colours from the caller, so it lands inside each style's own
+ * palette instead of ignoring it. The styles that compute their own two-tone
+ * pairs (Editorial's accent/field, Canvas's glyph/scrim, Bento's tiles) pass
+ * those straight in; the rest fall through to the theme, which is already
+ * artwork-tinted where the user has asked for that.
+ *
+ * A sheet rather than the AlertDialog this used to be: it is a picker, the
+ * players already host sheets, and a centred dialog over the full-bleed styles
+ * read as something bolted on from another app.
+ *
+ * The timer itself lives in MusicService - see the note there for why - so what
+ * this shows is the service's state, not this screen's.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SleepTimerDialog(
+fun SleepTimerSheet(
     endsAt: Long?,
-    onStart: (minutes: Int) -> Unit,
-    onStop: () -> Unit,
-    onDismiss: () -> Unit
+    endOfTrack: Boolean,
+    onStartMinutes: (Int) -> Unit,
+    onStartEndOfTrack: () -> Unit,
+    onCancel: () -> Unit,
+    onDismiss: () -> Unit,
+    accent: Color = MaterialTheme.colorScheme.primary,
+    onAccent: Color = MaterialTheme.colorScheme.onPrimary,
+    container: Color = MaterialTheme.colorScheme.surfaceContainerHigh,
+    onContainer: Color = MaterialTheme.colorScheme.onSurface
 ) {
-    AlertDialog(
+    ModalBottomSheet(
         onDismissRequest = onDismiss,
-        icon = { Icon(Icons.Rounded.Bedtime, contentDescription = null) },
-        title = { Text(if (endsAt != null) "Sleep timer running" else "Sleep timer") },
-        text = {
-            if (endsAt != null) {
+        sheetState = rememberModalBottomSheetState(),
+        containerColor = container,
+        contentColor = onContainer
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .navigationBarsPadding()
+                .padding(bottom = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(64.dp)
+                    .clip(RoundedCornerShape(20.dp))
+                    .background(accent.copy(alpha = 0.16f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Bedtime,
+                    contentDescription = null,
+                    tint = accent,
+                    modifier = Modifier.size(30.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = "Sleep timer",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = onContainer
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            if (endOfTrack) {
+                SleepTimerStatus(
+                    headline = "This track",
+                    detail = "Playback stops when the song playing now finishes",
+                    accent = accent,
+                    onContainer = onContainer
+                )
+                Spacer(modifier = Modifier.height(20.dp))
+                TurnOffButton(onCancel, accent, onAccent)
+            } else if (endsAt != null) {
+                // Ticks against the wall clock the service published, so the
+                // countdown stays honest across a screen-off stretch instead of
+                // drifting away from when playback will actually stop.
                 var remainingMs by remember(endsAt) {
                     mutableLongStateOf(endsAt - System.currentTimeMillis())
                 }
                 LaunchedEffect(endsAt) {
                     while (true) {
                         remainingMs = endsAt - System.currentTimeMillis()
-                        if (remainingMs <= 0) break
+                        if (remainingMs <= 0L) break
                         delay(1_000)
                     }
                 }
+                SleepTimerStatus(
+                    headline = formatRemaining(remainingMs),
+                    detail = "Playback fades out and pauses when the timer ends",
+                    accent = accent,
+                    onContainer = onContainer
+                )
+                Spacer(modifier = Modifier.height(20.dp))
+                TurnOffButton(onCancel, accent, onAccent)
+            } else {
                 Column(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalAlignment = Alignment.CenterHorizontally
+                    verticalArrangement = Arrangement.spacedBy(10.dp)
                 ) {
-                    val totalSeconds = (remainingMs / 1000).coerceAtLeast(0)
-                    Text(
-                        String.format(Locale.US, "%d:%02d", totalSeconds / 60, totalSeconds % 60),
-                        style = MaterialTheme.typography.displaySmall,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                    Text(
-                        "Playback will pause when the timer ends",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            } else {
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    listOf(listOf(5, 10, 15), listOf(30, 45, 60)).forEach { presetRow ->
+                    PRESET_MINUTES.forEach { presetRow ->
                         Row(
                             modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            horizontalArrangement = Arrangement.spacedBy(10.dp)
                         ) {
                             presetRow.forEach { minutes ->
                                 FilledTonalButton(
-                                    onClick = { onStart(minutes) },
-                                    modifier = Modifier.weight(1f)
+                                    onClick = { onStartMinutes(minutes) },
+                                    modifier = Modifier.weight(1f),
+                                    colors = ButtonDefaults.filledTonalButtonColors(
+                                        containerColor = accent.copy(alpha = 0.16f),
+                                        contentColor = onContainer
+                                    )
                                 ) {
                                     Text("$minutes min")
                                 }
                             }
                         }
                     }
+
+                    // The option the presets cannot express, and usually the
+                    // one people actually want: finish this song, then stop.
+                    Surface(
+                        onClick = onStartEndOfTrack,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(56.dp),
+                        shape = RoundedCornerShape(18.dp),
+                        color = accent,
+                        contentColor = onAccent
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 20.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Rounded.MusicNote,
+                                contentDescription = null,
+                                modifier = Modifier.size(20.dp)
+                            )
+                            Text(
+                                text = "End of this track",
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                        }
+                    }
                 }
             }
-        },
-        confirmButton = {
-            if (endsAt != null) {
-                TextButton(onClick = onStop) { Text("Stop timer") }
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Close") }
         }
+    }
+}
+
+@Composable
+private fun SleepTimerStatus(
+    headline: String,
+    detail: String,
+    accent: Color,
+    onContainer: Color
+) {
+    Text(
+        text = headline,
+        style = MaterialTheme.typography.displaySmall,
+        fontWeight = FontWeight.Bold,
+        color = accent
     )
+    Spacer(modifier = Modifier.height(6.dp))
+    Text(
+        text = detail,
+        style = MaterialTheme.typography.bodyMedium,
+        color = onContainer.copy(alpha = 0.7f),
+        textAlign = TextAlign.Center
+    )
+}
+
+@Composable
+private fun TurnOffButton(onCancel: () -> Unit, accent: Color, onAccent: Color) {
+    Button(
+        onClick = onCancel,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(56.dp),
+        shape = RoundedCornerShape(18.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = accent,
+            contentColor = onAccent
+        )
+    ) {
+        Text("Turn off", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+    }
+}
+
+/** m:ss under an hour, h:mm:ss over it. */
+private fun formatRemaining(remainingMs: Long): String {
+    val totalSeconds = (remainingMs / 1000).coerceAtLeast(0)
+    val hours = totalSeconds / 3600
+    val minutes = (totalSeconds % 3600) / 60
+    val seconds = totalSeconds % 60
+    return if (hours > 0) {
+        String.format(Locale.US, "%d:%02d:%02d", hours, minutes, seconds)
+    } else {
+        String.format(Locale.US, "%d:%02d", minutes, seconds)
+    }
 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/BentoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/BentoPlayerContent.kt
@@ -42,6 +42,7 @@ import androidx.compose.material.icons.filled.RepeatOne
 import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material.icons.rounded.Bedtime
 import androidx.compose.material.icons.rounded.Lyrics
 import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material.icons.rounded.PlaylistAdd
@@ -127,6 +128,13 @@ fun BentoPlayerSheetContent(
     val boardColor = MaterialTheme.colorScheme.surfaceContainerLowest
     val tileColor = MaterialTheme.colorScheme.surfaceContainerHigh
     val onTile = MaterialTheme.colorScheme.onSurface
+
+    // Bento's own emphasis colour, the one BentoToggleTile lights up with.
+    val sleepTimer = rememberSleepTimerControl(
+        viewModel = viewModel,
+        accent = MaterialTheme.colorScheme.tertiaryContainer,
+        onAccent = MaterialTheme.colorScheme.onTertiaryContainer
+    )
     val onTileVariant = MaterialTheme.colorScheme.onSurfaceVariant
 
     Box(
@@ -188,9 +196,28 @@ fun BentoPlayerSheetContent(
                             Box(contentAlignment = Alignment.Center) {
                                 Text(
                                     text = "NOW PLAYING",
-                                    style = MaterialTheme.typography.labelLarge.copy(letterSpacing = 3.sp)
+                                    style = MaterialTheme.typography.labelLarge.copy(letterSpacing = 3.sp),
+                                    maxLines = 1,
+                                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
                                 )
                             }
+                        }
+                        BentoTile(
+                            onClick = sleepTimer.open,
+                            color = if (sleepTimer.active) {
+                                MaterialTheme.colorScheme.tertiaryContainer
+                            } else tileColor,
+                            contentColor = if (sleepTimer.active) {
+                                MaterialTheme.colorScheme.onTertiaryContainer
+                            } else onTile,
+                            modifier = Modifier
+                                .width(56.dp)
+                                .fillMaxHeight()
+                        ) {
+                            Icon(
+                                Icons.Rounded.Bedtime, "Sleep timer",
+                                modifier = Modifier.size(24.dp)
+                            )
                         }
                         BentoTile(
                             onClick = { showAddToPlaylist = true },

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/DialPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/DialPlayerContent.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.filled.RepeatOne
 import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material.icons.rounded.Bedtime
 import androidx.compose.material.icons.rounded.Lyrics
 import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material.icons.rounded.PlaylistAdd
@@ -126,6 +127,9 @@ fun DialPlayerSheetContent(
     val accent = MaterialTheme.colorScheme.primary
     val chipColor = MaterialTheme.colorScheme.surfaceContainerHigh
 
+    // The dial's instrument accent carries into the picker.
+    val sleepTimer = rememberSleepTimerControl(viewModel = viewModel, accent = accent)
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -169,6 +173,17 @@ fun DialPlayerSheetContent(
                             )
                         }
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            EditorialCircleButton(
+                                onClick = sleepTimer.open,
+                                accent = if (sleepTimer.active) accent else chipColor,
+                                field = if (sleepTimer.active) MaterialTheme.colorScheme.onPrimary else ink,
+                                size = 44.dp
+                            ) {
+                                Icon(
+                                    Icons.Rounded.Bedtime, "Sleep timer",
+                                    modifier = Modifier.size(22.dp)
+                                )
+                            }
                             EditorialCircleButton(
                                 onClick = { showAddToPlaylist = true },
                                 accent = chipColor,

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/EditorialPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/EditorialPlayerContent.kt
@@ -42,6 +42,7 @@ import androidx.compose.material.icons.filled.RepeatOne
 import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material.icons.rounded.Bedtime
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.GraphicEq
@@ -158,6 +159,16 @@ fun EditorialPlayerSheetContent(
     val field = MaterialTheme.colorScheme.primaryContainer
     val accent = MaterialTheme.colorScheme.onPrimaryContainer
 
+    // The picker follows the same two tones, so it reads as another page of
+    // this player rather than a sheet borrowed from somewhere else.
+    val sleepTimer = rememberSleepTimerControl(
+        viewModel = viewModel,
+        accent = accent,
+        onAccent = field,
+        container = field,
+        onContainer = accent
+    )
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -208,6 +219,8 @@ fun EditorialPlayerSheetContent(
                     onCollapse = onCollapse,
                     onShowQueue = { showQueue = true },
                     onShowAddToPlaylist = { showAddToPlaylist = true },
+                    onShowSleepTimer = sleepTimer.open,
+                    sleepTimerActive = sleepTimer.active,
                     onArtistClick = onArtistClick,
                     field = field,
                     accent = accent
@@ -261,6 +274,8 @@ private fun EditorialNowPlayingView(
     onCollapse: () -> Unit,
     onShowQueue: () -> Unit,
     onShowAddToPlaylist: () -> Unit,
+    onShowSleepTimer: () -> Unit,
+    sleepTimerActive: Boolean,
     onArtistClick: (String) -> Unit,
     field: Color,
     accent: Color
@@ -285,6 +300,16 @@ private fun EditorialNowPlayingView(
                 Icon(Icons.Default.KeyboardArrowDown, "Collapse", modifier = Modifier.size(26.dp))
             }
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                // Inverted while a timer runs - in a two-tone player, swapping
+                // the fill is the only emphasis there is.
+                EditorialCircleButton(
+                    onClick = onShowSleepTimer,
+                    accent = if (sleepTimerActive) accent else field,
+                    field = if (sleepTimerActive) field else accent,
+                    size = 44.dp
+                ) {
+                    Icon(Icons.Rounded.Bedtime, "Sleep timer", modifier = Modifier.size(22.dp))
+                }
                 EditorialCircleButton(
                     onClick = onShowAddToPlaylist,
                     accent = accent,

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/GesturePlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/GesturePlayerContent.kt
@@ -104,8 +104,7 @@ fun GesturePlayerSheetContent(
     val addToPlaylistItems by viewModel.addToPlaylistItems.collectAsState()
 
     // Sleep timer
-    val sleepTimerEndsAt by viewModel.sleepTimerEndsAt.collectAsState()
-    var showSleepTimerDialog by remember { mutableStateOf(false) }
+    val sleepTimer = rememberSleepTimerControl(viewModel = viewModel)
 
     val surfaceColor = MaterialTheme.colorScheme.background
     val primaryColor = MaterialTheme.colorScheme.primary
@@ -167,8 +166,8 @@ fun GesturePlayerSheetContent(
                     onToggleRepeat = { viewModel.toggleRepeat() },
                     onToggleFavorite = { viewModel.toggleCurrentSongLike() },
                     onToggleDownload = { currentSong?.let { viewModel.toggleDownload(it) } },
-                    sleepTimerActive = sleepTimerEndsAt != null,
-                    onSleepTimerClick = { showSleepTimerDialog = true },
+                    sleepTimerActive = sleepTimer.active,
+                    onSleepTimerClick = sleepTimer.open,
                     onPlayPauseToggle = {
                         playerHaptics.playPause(!viewModel.isPlaying.value)
                         viewModel.togglePlayPause()
@@ -186,14 +185,6 @@ fun GesturePlayerSheetContent(
         }
     }
 
-    if (showSleepTimerDialog) {
-        com.ivor.ivormusic.ui.components.SleepTimerDialog(
-            endsAt = sleepTimerEndsAt,
-            onStart = { minutes -> viewModel.startSleepTimer(minutes) },
-            onStop = { viewModel.cancelSleepTimer() },
-            onDismiss = { showSleepTimerDialog = false }
-        )
-    }
 
     if (showAddToPlaylist) {
         AddToPlaylistSheet(

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/MorphPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/MorphPlayerContent.kt
@@ -45,6 +45,7 @@ import androidx.compose.material.icons.filled.RepeatOne
 import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material.icons.rounded.Bedtime
 import androidx.compose.material.icons.rounded.Lyrics
 import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material.icons.rounded.PlaylistAdd
@@ -141,6 +142,9 @@ fun MorphPlayerSheetContent(
     var showQueue by remember { mutableStateOf(false) }
     var showLyrics by remember { mutableStateOf(false) }
     var showAddToPlaylist by remember { mutableStateOf(false) }
+
+    // Morph runs on the theme's own roles, so the picker needs no overrides.
+    val sleepTimer = rememberSleepTimerControl(viewModel = viewModel)
     var controlsVisible by remember { mutableStateOf(true) }
 
     val surfaceColor = MaterialTheme.colorScheme.background
@@ -208,6 +212,15 @@ fun MorphPlayerSheetContent(
                             )
                         }
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            MorphUtilityButton(
+                                onClick = sleepTimer.open,
+                                active = sleepTimer.active
+                            ) {
+                                Icon(
+                                    Icons.Rounded.Bedtime, "Sleep timer",
+                                    modifier = Modifier.size(22.dp)
+                                )
+                            }
                             MorphUtilityButton(onClick = { showLyrics = !showLyrics }) {
                                 Icon(
                                     Icons.Rounded.Lyrics, "Lyrics",
@@ -448,14 +461,19 @@ fun MorphPlayerSheetContent(
 @Composable
 private fun MorphUtilityButton(
     onClick: () -> Unit,
+    active: Boolean = false,
     content: @Composable () -> Unit
 ) {
     FilledIconButton(
         onClick = onClick,
         shape = CircleShape,
         colors = IconButtonDefaults.filledIconButtonColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-            contentColor = MaterialTheme.colorScheme.onSurface
+            containerColor = if (active) {
+                MaterialTheme.colorScheme.primary
+            } else MaterialTheme.colorScheme.surfaceContainerHigh,
+            contentColor = if (active) {
+                MaterialTheme.colorScheme.onPrimary
+            } else MaterialTheme.colorScheme.onSurface
         ),
         modifier = Modifier.size(44.dp)
     ) {

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerSheetContent.kt
@@ -710,9 +710,8 @@ private fun ExpressiveNowPlayingView(
             Spacer(modifier = Modifier.height(24.dp))
             
             // 🌟 Favorite / Download / Sleep Timer - connected button group
-            val sleepTimerEndsAt by viewModel.sleepTimerEndsAt.collectAsState()
-            var showSleepTimerDialog by remember { mutableStateOf(false) }
-            val sleepTimerActive = sleepTimerEndsAt != null
+            val sleepTimer = rememberSleepTimerControl(viewModel = viewModel)
+            val sleepTimerActive = sleepTimer.active
             val groupButtonColors = ToggleButtonDefaults.toggleButtonColors(
                 containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
                 contentColor = onSurfaceVariantColor
@@ -773,7 +772,7 @@ private fun ExpressiveNowPlayingView(
                 // Sleep timer (checked while a timer is running; tap opens the dialog)
                 ToggleButton(
                     checked = sleepTimerActive,
-                    onCheckedChange = { showSleepTimerDialog = true },
+                    onCheckedChange = { sleepTimer.open() },
                     modifier = Modifier
                         .weight(1f)
                         .fillMaxHeight(),
@@ -788,14 +787,6 @@ private fun ExpressiveNowPlayingView(
                 }
             }
 
-            if (showSleepTimerDialog) {
-                com.ivor.ivormusic.ui.components.SleepTimerDialog(
-                    endsAt = sleepTimerEndsAt,
-                    onStart = { minutes -> viewModel.startSleepTimer(minutes) },
-                    onStop = { viewModel.cancelSleepTimer() },
-                    onDismiss = { showSleepTimerDialog = false }
-                )
-            }
         }
         }
     } // End Box wrapper

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
@@ -274,7 +274,19 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
 
     private fun initializeController() {
         val sessionToken = SessionToken(context, ComponentName(context, MusicService::class.java))
-        val future = MediaController.Builder(context, sessionToken).buildAsync()
+        val future = MediaController.Builder(context, sessionToken)
+            // The sleep timer runs in the service and reports back through the
+            // session's extras, which arrive on MediaController.Listener rather
+            // than on the Player.Listener installed below.
+            .setListener(object : MediaController.Listener {
+                override fun onExtrasChanged(
+                    controller: MediaController,
+                    extras: android.os.Bundle
+                ) {
+                    applySleepTimerExtras(extras)
+                }
+            })
+            .buildAsync()
         controllerFuture = future
 
         future.addListener({
@@ -893,27 +905,58 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
     }
 
     // --- Sleep timer ---
+    //
+    // Owned by MusicService, not by this ViewModel. The timer used to be a
+    // viewModelScope.launch { delay(...) } here, which meant it was cancelled
+    // the moment MainActivity was destroyed - backing out of the app while the
+    // music kept playing, which is exactly what someone who has just set a
+    // sleep timer does. It died silently and playback ran on. Everything below
+    // is a remote control for the service's copy.
 
     /** Wall-clock time when the sleep timer fires, or null when inactive. */
     private val _sleepTimerEndsAt = MutableStateFlow<Long?>(null)
     val sleepTimerEndsAt: StateFlow<Long?> = _sleepTimerEndsAt.asStateFlow()
-    private var sleepTimerJob: kotlinx.coroutines.Job? = null
 
+    /** True while playback is set to stop at the end of the current track. */
+    private val _sleepTimerEndOfTrack = MutableStateFlow(false)
+    val sleepTimerEndOfTrack: StateFlow<Boolean> = _sleepTimerEndOfTrack.asStateFlow()
+
+    /** Stop playback after [minutes]; playback fades out rather than cutting. */
     fun startSleepTimer(minutes: Int) {
-        sleepTimerJob?.cancel()
-        val durationMs = minutes * 60_000L
-        _sleepTimerEndsAt.value = System.currentTimeMillis() + durationMs
-        sleepTimerJob = viewModelScope.launch {
-            kotlinx.coroutines.delay(durationMs)
-            controller?.pause()
-            _sleepTimerEndsAt.value = null
-        }
+        sendSleepTimerCommand(MusicService.CMD_SLEEP_TIMER_SET, minutes)
+    }
+
+    /** Stop playback when the track that is playing now finishes. */
+    fun startSleepTimerEndOfTrack() {
+        sendSleepTimerCommand(MusicService.CMD_SLEEP_TIMER_SET, 0)
     }
 
     fun cancelSleepTimer() {
-        sleepTimerJob?.cancel()
-        sleepTimerJob = null
-        _sleepTimerEndsAt.value = null
+        sendSleepTimerCommand(MusicService.CMD_SLEEP_TIMER_CANCEL, 0)
+    }
+
+    private fun sendSleepTimerCommand(action: String, minutes: Int) {
+        val ctrl = controller ?: return
+        val args = android.os.Bundle().apply {
+            putInt(MusicService.ARG_SLEEP_TIMER_MINUTES, minutes)
+        }
+        ctrl.sendCustomCommand(
+            androidx.media3.session.SessionCommand(action, android.os.Bundle.EMPTY),
+            args
+        )
+    }
+
+    /**
+     * Adopt the timer state the service published. Also called on connect, so
+     * a player reopened after the activity was destroyed picks the running
+     * countdown back up instead of showing nothing.
+     */
+    private fun applySleepTimerExtras(extras: android.os.Bundle) {
+        if (!extras.containsKey(MusicService.EXTRA_SLEEP_TIMER_ENDS_AT)) return
+        val endsAt = extras.getLong(MusicService.EXTRA_SLEEP_TIMER_ENDS_AT, 0L)
+        _sleepTimerEndsAt.value = endsAt.takeIf { it > 0L }
+        _sleepTimerEndOfTrack.value =
+            extras.getBoolean(MusicService.EXTRA_SLEEP_TIMER_END_OF_TRACK, false)
     }
 
     fun skipToNext() {

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PosterPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PosterPlayerContent.kt
@@ -41,6 +41,7 @@ import androidx.compose.material.icons.filled.RepeatOne
 import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material.icons.rounded.Bedtime
 import androidx.compose.material.icons.rounded.Lyrics
 import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material.icons.rounded.Pause
@@ -154,6 +155,17 @@ fun PosterPlayerSheetContent(
     // any cover without fighting the artwork's own palette.
     val glyph = Color.White
     val scrim = Color.Black
+
+    // Canvas is white type on black over the artwork, and the picker keeps
+    // that: a light themed sheet under a full-bleed cover reads as a different
+    // app opening on top of this one.
+    val sleepTimer = rememberSleepTimerControl(
+        viewModel = viewModel,
+        accent = glyph,
+        onAccent = scrim,
+        container = scrim,
+        onContainer = glyph
+    )
 
     Box(
         modifier = Modifier
@@ -335,6 +347,19 @@ fun PosterPlayerSheetContent(
                                 )
                             }
                             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                // Solid fill while armed - the only contrast
+                                // available over artwork is the scrim's alpha.
+                                EditorialCircleButton(
+                                    onClick = sleepTimer.open,
+                                    accent = if (sleepTimer.active) glyph else scrim.copy(alpha = 0.35f),
+                                    field = if (sleepTimer.active) scrim else glyph,
+                                    size = 44.dp
+                                ) {
+                                    Icon(
+                                        Icons.Rounded.Bedtime, "Sleep timer",
+                                        modifier = Modifier.size(22.dp)
+                                    )
+                                }
                                 EditorialCircleButton(
                                     onClick = { showAddToPlaylist = true },
                                     accent = scrim.copy(alpha = 0.35f),

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/SleepTimerControl.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/SleepTimerControl.kt
@@ -1,0 +1,70 @@
+package com.ivor.ivormusic.ui.player
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
+import com.ivor.ivormusic.ui.components.SleepTimerSheet
+
+/**
+ * What a player style needs to show a sleep timer control: whether one is
+ * armed, and a way to open the picker.
+ */
+@Immutable
+internal class SleepTimerControl(
+    /** True while a duration or end-of-track timer is running. */
+    val active: Boolean,
+    val open: () -> Unit
+)
+
+/**
+ * Wire a player style to the sleep timer.
+ *
+ * Also *emits* the picker sheet, which is why every style needs only this call
+ * plus one button. Placement is the part that belongs to each style - the
+ * button goes in that style's own top bar, in that style's own idiom - so the
+ * shared piece here is deliberately only the state and the sheet.
+ *
+ * The colour pair defaults to the theme, which is already artwork-tinted when
+ * the user has that on. Styles that run their own two-tone palette (Editorial's
+ * paper and ink, Canvas's white-on-black over the artwork) pass theirs in so
+ * the sheet does not arrive looking like it came from a different app. Pass
+ * matched pairs only: they are used as fill and content together.
+ */
+@Composable
+internal fun rememberSleepTimerControl(
+    viewModel: PlayerViewModel,
+    accent: Color = MaterialTheme.colorScheme.primary,
+    onAccent: Color = MaterialTheme.colorScheme.onPrimary,
+    container: Color = MaterialTheme.colorScheme.surfaceContainerHigh,
+    onContainer: Color = MaterialTheme.colorScheme.onSurface
+): SleepTimerControl {
+    val endsAt by viewModel.sleepTimerEndsAt.collectAsState()
+    val endOfTrack by viewModel.sleepTimerEndOfTrack.collectAsState()
+    var showSheet by remember { mutableStateOf(false) }
+
+    if (showSheet) {
+        SleepTimerSheet(
+            endsAt = endsAt,
+            endOfTrack = endOfTrack,
+            onStartMinutes = { viewModel.startSleepTimer(it) },
+            onStartEndOfTrack = { viewModel.startSleepTimerEndOfTrack() },
+            onCancel = { viewModel.cancelSleepTimer() },
+            onDismiss = { showSheet = false },
+            accent = accent,
+            onAccent = onAccent,
+            container = container,
+            onContainer = onContainer
+        )
+    }
+
+    return SleepTimerControl(
+        active = endsAt != null || endOfTrack,
+        open = { showSheet = true }
+    )
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/StickerPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/StickerPlayerContent.kt
@@ -41,6 +41,7 @@ import androidx.compose.material.icons.filled.RepeatOne
 import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material.icons.rounded.Bedtime
 import androidx.compose.material.icons.rounded.Lyrics
 import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material.icons.rounded.PlaylistAdd
@@ -143,6 +144,14 @@ fun StickerPlayerSheetContent(
     val inkVariant = MaterialTheme.colorScheme.onSurfaceVariant
     val chipColor = MaterialTheme.colorScheme.secondaryContainer
     val onChip = MaterialTheme.colorScheme.onSecondaryContainer
+
+    // Same chip pair the sticker's own controls use, so the picker looks cut
+    // from the same sheet.
+    val sleepTimer = rememberSleepTimerControl(
+        viewModel = viewModel,
+        accent = chipColor,
+        onAccent = onChip
+    )
     val accent = MaterialTheme.colorScheme.primary
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -200,6 +209,17 @@ fun StickerPlayerSheetContent(
                             )
                         }
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            EditorialCircleButton(
+                                onClick = sleepTimer.open,
+                                accent = if (sleepTimer.active) ink else chipColor,
+                                field = if (sleepTimer.active) chipColor else onChip,
+                                size = 44.dp
+                            ) {
+                                Icon(
+                                    Icons.Rounded.Bedtime, "Sleep timer",
+                                    modifier = Modifier.size(22.dp)
+                                )
+                            }
                             EditorialCircleButton(
                                 onClick = { showAddToPlaylist = true },
                                 accent = chipColor,

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPipController.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPipController.kt
@@ -1,0 +1,189 @@
+package com.ivor.ivormusic.ui.video
+
+import android.app.PictureInPictureParams
+import android.app.PendingIntent
+import android.app.RemoteAction
+import android.content.Intent
+import android.graphics.drawable.Icon
+import android.os.Build
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.media3.common.util.UnstableApi
+import com.ivor.ivormusic.R
+
+/**
+ * Everything that keeps the system Picture-in-Picture window in sync with the
+ * video player: its shape, its transport controls, and the receiver those
+ * controls fire into.
+ *
+ * This has to be composed **above** MainActivity's `if (isInPipMode) return`,
+ * and that is the whole reason it is its own composable rather than a block
+ * inside [VideoPlayerOverlay]. The overlay is part of the app UI that PiP
+ * replaces, so entering PiP tore it out of the composition, which disposed the
+ * broadcast receiver and unregistered it - the play/pause button in the PiP
+ * window fired an intent nothing was listening for, and did nothing. The params
+ * effect went with it, so even a working button could never have flipped its
+ * own icon between play and pause.
+ *
+ * Being composed for the whole life of the player also means the params are
+ * kept honest when there is no video: auto-enter used to stay armed after the
+ * player was closed, so leaving the app could open an empty PiP window.
+ */
+@androidx.annotation.OptIn(UnstableApi::class)
+@Composable
+fun VideoPipController(viewModel: VideoPlayerViewModel) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+    val context = LocalContext.current
+    val activity = context as? androidx.activity.ComponentActivity ?: return
+    if (!activity.packageManager.hasSystemFeature(
+            android.content.pm.PackageManager.FEATURE_PICTURE_IN_PICTURE
+        )
+    ) return
+
+    val currentVideo by viewModel.currentVideo.collectAsState()
+    val isPlaying by viewModel.isPlaying.collectAsState()
+    val isExpanded by viewModel.isExpanded.collectAsState()
+    val videoAspectRatio by viewModel.videoAspectRatio.collectAsState()
+    val videoBounds by viewModel.videoSurfaceBounds.collectAsState()
+
+    val packageName = context.packageName
+
+    // Registered for as long as a video player exists, PiP or not. Actions are
+    // package-scoped so no other app can drive playback through them.
+    DisposableEffect(context, viewModel) {
+        val receiver = object : android.content.BroadcastReceiver() {
+            override fun onReceive(ctx: android.content.Context?, intent: Intent?) {
+                when (intent?.action) {
+                    "$packageName.$ACTION_PLAY" -> viewModel.exoPlayer?.play()
+                    "$packageName.$ACTION_PAUSE" -> viewModel.exoPlayer?.pause()
+                    "$packageName.$ACTION_REWIND" ->
+                        viewModel.seekBy(-VideoPlayerViewModel.SEEK_STEP_MS)
+                    "$packageName.$ACTION_FORWARD" ->
+                        viewModel.seekBy(VideoPlayerViewModel.SEEK_STEP_MS)
+                }
+            }
+        }
+        val filter = android.content.IntentFilter().apply {
+            addAction("$packageName.$ACTION_PLAY")
+            addAction("$packageName.$ACTION_PAUSE")
+            addAction("$packageName.$ACTION_REWIND")
+            addAction("$packageName.$ACTION_FORWARD")
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.registerReceiver(receiver, filter, android.content.Context.RECEIVER_NOT_EXPORTED)
+        } else {
+            context.registerReceiver(receiver, filter)
+        }
+        onDispose { runCatching { context.unregisterReceiver(receiver) } }
+    }
+
+    LaunchedEffect(currentVideo?.videoId, isPlaying, isExpanded, videoAspectRatio, videoBounds) {
+        val builder = PictureInPictureParams.Builder()
+
+        if (currentVideo == null) {
+            // No video: disarm. Auto-enter is sticky, so a player closed while
+            // it was armed would otherwise put the app into an empty PiP window
+            // the next time the user swiped home.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                builder.setAutoEnterEnabled(false)
+            }
+            builder.setActions(emptyList<RemoteAction>())
+        } else {
+            builder.setAspectRatio(pipAspectRatio(videoAspectRatio))
+            builder.setActions(pipActions(activity, packageName, isPlaying))
+
+            // Animate the PiP window out of the video rather than out of the
+            // whole activity window. Without a source rect the system scales
+            // the entire screen down - app chrome, nav bar and all - which is
+            // what made the transition look like the UI was being sucked into
+            // the window.
+            videoBounds?.takeIf { !it.isEmpty }?.let { builder.setSourceRectHint(it) }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                // Only auto-enter PiP while the full player is on screen.
+                // Auto-entering from the mini player captures the whole app UI
+                // into the PiP window instead of just the video surface.
+                builder.setAutoEnterEnabled(isExpanded)
+                // The content is a video, not a layout that needs to reflow, so
+                // let the system crossfade the resize instead of re-laying out.
+                builder.setSeamlessResizeEnabled(true)
+            }
+        }
+
+        try {
+            activity.setPictureInPictureParams(builder.build())
+        } catch (e: Exception) {
+            android.util.Log.w(TAG, "setPictureInPictureParams refused", e)
+        }
+    }
+}
+
+/**
+ * The transport row inside the PiP window: back 10s, play/pause, forward 10s.
+ *
+ * A PiP window never receives touch events - the system owns every gesture on
+ * it, so an in-window double-tap-to-seek is not something an app can implement.
+ * RemoteActions are the only input surface PiP has, which is why the 10-second
+ * skips live here as buttons rather than as the gesture they are on the full
+ * player.
+ *
+ * Devices advertise how many actions they will render (three on every current
+ * Android build). If a device offers fewer, play/pause is the one control that
+ * must survive, so the seeks are dropped rather than the list truncated.
+ */
+private fun pipActions(
+    activity: androidx.activity.ComponentActivity,
+    packageName: String,
+    isPlaying: Boolean
+): List<RemoteAction> {
+    val playPause = if (isPlaying) {
+        remoteAction(activity, packageName, ACTION_PAUSE, R.drawable.ic_media_pause, "Pause")
+    } else {
+        remoteAction(activity, packageName, ACTION_PLAY, R.drawable.ic_media_play, "Play")
+    }
+
+    val maxActions = try {
+        activity.maxNumPictureInPictureActions
+    } catch (e: Exception) {
+        3
+    }
+    if (maxActions < 3) return listOf(playPause)
+
+    return listOf(
+        remoteAction(
+            activity, packageName, ACTION_REWIND,
+            R.drawable.ic_media_replay_10, "Back 10 seconds"
+        ),
+        playPause,
+        remoteAction(
+            activity, packageName, ACTION_FORWARD,
+            R.drawable.ic_media_forward_10, "Forward 10 seconds"
+        )
+    )
+}
+
+private fun remoteAction(
+    activity: androidx.activity.ComponentActivity,
+    packageName: String,
+    action: String,
+    iconRes: Int,
+    label: String
+): RemoteAction {
+    val intent = PendingIntent.getBroadcast(
+        activity,
+        action.hashCode(),
+        Intent("$packageName.$action").setPackage(packageName),
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    )
+    return RemoteAction(Icon.createWithResource(activity, iconRes), label, label, intent)
+}
+
+private const val TAG = "VideoPipController"
+private const val ACTION_PLAY = "PIP_PLAY"
+private const val ACTION_PAUSE = "PIP_PAUSE"
+private const val ACTION_REWIND = "PIP_REWIND"
+private const val ACTION_FORWARD = "PIP_FORWARD"

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
@@ -35,13 +35,18 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogWindowProvider
 import androidx.core.view.WindowCompat
@@ -326,6 +331,60 @@ fun VideoPlayerContent(
     // Gate authenticated actions behind login
     fun requireLogin(action: () -> Unit) {
         if (isLoggedIn) action() else showSignInDialog = true
+    }
+
+    /**
+     * Pull the watch page down to minimize, from anywhere on it.
+     *
+     * Swiping the video surface has always worked, but that surface is a 16:9
+     * strip at the top of the screen - and most of it is covered by the
+     * transport controls whenever they are up, since a single tap brings them
+     * out. People reached for the gesture on the page below, where nothing
+     * happened, and concluded it was fussy. Everything under the video is one
+     * scrolling column, so once it is at the top the leftover pull is exactly
+     * the minimize drag, fed through the same callbacks the video surface uses.
+     *
+     * Deliberately attached to the info column rather than the box around it:
+     * the comments panel slides up inside that box and has its own dismiss, so
+     * pulling its list down must not drag the player away underneath it.
+     */
+    val minimizeDelta by rememberUpdatedState(onMinimizeDragDelta)
+    val minimizeRelease by rememberUpdatedState(onMinimizeDragRelease)
+    val pullToMinimize = remember {
+        object : NestedScrollConnection {
+            /** True once this gesture has taken the page over. */
+            private var pulling = false
+
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                // Once the pull has started it keeps the gesture to the end.
+                // Handing it back on the first upward flick would scroll the
+                // list under a player left sitting half way down the screen.
+                if (!pulling || source != NestedScrollSource.UserInput) return Offset.Zero
+                minimizeDelta(available.y)
+                return Offset(0f, available.y)
+            }
+
+            override fun onPostScroll(
+                consumed: Offset,
+                available: Offset,
+                source: NestedScrollSource
+            ): Offset {
+                // Leftover downward drag means the list is already at the top.
+                if (source != NestedScrollSource.UserInput || available.y <= 0f) return Offset.Zero
+                pulling = true
+                minimizeDelta(available.y)
+                return Offset(0f, available.y)
+            }
+
+            override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+                // Only ends a pull this connection actually started, so a fling
+                // that merely runs out of list at the top is left alone.
+                if (!pulling) return Velocity.Zero
+                pulling = false
+                minimizeRelease(available.y)
+                return available
+            }
+        }
     }
 
     // ---------------- UI ----------------
@@ -666,6 +725,7 @@ fun VideoPlayerContent(
                         onVideoSelect = { viewModel.playVideo(it) },
                         modifier = Modifier
                             .fillMaxSize()
+                            .nestedScroll(pullToMinimize)
                             .background(MaterialTheme.colorScheme.surface),
                         engagement = engagement,
                         onLikeClick = { requireLogin { viewModel.toggleLike() } },

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
@@ -169,11 +169,10 @@ fun VideoPlayerContent(
     if (currentVideo == null || exoPlayer == null) return
 
     // Double-tap seek helper: jump relative to the live playhead, clamped to the clip.
-    fun seekBy(deltaMs: Long) {
-        val target = (exoPlayer.currentPosition + deltaMs)
-            .coerceIn(0L, if (exoPlayer.duration > 0) exoPlayer.duration else Long.MAX_VALUE)
-        exoPlayer.seekTo(target)
-    }
+    // Delegated rather than done here: the PiP window and the media
+    // notification skip through the same ViewModel call, and a gesture that
+    // clamped differently from the buttons would be a bug waiting to happen.
+    fun seekBy(deltaMs: Long) = viewModel.seekBy(deltaMs)
 
     LaunchedEffect(exoPlayer, currentVideo) {
         while (isActive) {
@@ -377,8 +376,8 @@ fun VideoPlayerContent(
                 videoTitle = currentVideo.title,
                 onPlayPause = { viewModel.togglePlayPause() },
                 onSeek = { newProgress -> exoPlayer.seekTo((newProgress * duration).toLong()) },
-                onSeekBackward = { seekBy(-10_000L) },
-                onSeekForward = { seekBy(10_000L) },
+                onSeekBackward = { seekBy(-VideoPlayerViewModel.SEEK_STEP_MS) },
+                onSeekForward = { seekBy(VideoPlayerViewModel.SEEK_STEP_MS) },
                 onBack = { isFullscreen = false },
                 onFullscreenToggle = { isFullscreen = false },
                 onSettings = { showQualitySheet = true },
@@ -513,8 +512,8 @@ fun VideoPlayerContent(
                     videoAspectRatio = videoAspectRatio,
                     onPlayPause = { viewModel.togglePlayPause() },
                     onSeek = { newProgress -> exoPlayer.seekTo((newProgress * duration).toLong()) },
-                    onSeekBackward = { seekBy(-10_000L) },
-                    onSeekForward = { seekBy(10_000L) },
+                    onSeekBackward = { seekBy(-VideoPlayerViewModel.SEEK_STEP_MS) },
+                    onSeekForward = { seekBy(VideoPlayerViewModel.SEEK_STEP_MS) },
                     onSeekToLive = { exoPlayer.seekToDefaultPosition() },
                     onBack = onBackClick,
                     onExitToPage = { showVideoPageForVerticalLive = true },
@@ -604,8 +603,8 @@ fun VideoPlayerContent(
                         videoTitle = currentVideo.title,
                         onPlayPause = { viewModel.togglePlayPause() },
                         onSeek = { newProgress -> exoPlayer.seekTo((newProgress * duration).toLong()) },
-                        onSeekBackward = { seekBy(-10_000L) },
-                        onSeekForward = { seekBy(10_000L) },
+                        onSeekBackward = { seekBy(-VideoPlayerViewModel.SEEK_STEP_MS) },
+                        onSeekForward = { seekBy(VideoPlayerViewModel.SEEK_STEP_MS) },
                         onBack = onBackClick,
                         onFullscreenToggle = { isFullscreen = true },
                         onSettings = { showQualitySheet = true },

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerOverlay.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerOverlay.kt
@@ -179,12 +179,6 @@ fun VideoPlayerOverlay(
         // player and the settle animation continues from wherever the finger
         // let go instead of jumping.
         val expandProgress = remember { Animatable(if (isExpanded) 1f else 0f) }
-        LaunchedEffect(isExpanded) {
-            expandProgress.animateTo(
-                if (isExpanded) 1f else 0f,
-                MINIMIZE_SETTLE_SPRING
-            )
-        }
 
         // Live value while a finger is down. The drag deliberately does not go
         // through the Animatable: Animatable.snapTo runs under a MutatorMutex,
@@ -198,6 +192,20 @@ fun VideoPlayerOverlay(
         // Where the finger picked the player up, so the commit test can measure
         // real travel instead of an absolute position on the screen.
         var dragStartProgress by remember { mutableFloatStateOf(1f) }
+
+        // Declared after isDragging so it can clear it. Once expanded/collapsed
+        // has actually changed, any drag is over by definition, and this is the
+        // backstop that guarantees the flag cannot survive into the next one -
+        // a latched isDragging freezes the player at the last dragged progress
+        // and leaves every later swipe measuring travel from a start point that
+        // never moves, which is what made minimizing work once per app launch.
+        LaunchedEffect(isExpanded) {
+            isDragging = false
+            expandProgress.animateTo(
+                if (isExpanded) 1f else 0f,
+                MINIMIZE_SETTLE_SPRING
+            )
+        }
 
         // 1:1 with the finger: height interpolates over the full screen and the
         // player is bottom-anchored, so a range of one screen height moves the
@@ -264,12 +272,23 @@ fun VideoPlayerOverlay(
                              else -> dragStartProgress - released > minimizeTravel
                          }
                          scope.launch {
-                             // Hand the dragged position to the Animatable
-                             // before dropping out of drag mode, so the settle
-                             // continues from where the finger let go instead
-                             // of snapping back to fully expanded first.
-                             expandProgress.snapTo(released)
-                             isDragging = false
+                             try {
+                                 // Hand the dragged position to the Animatable
+                                 // before dropping out of drag mode, so the
+                                 // settle continues from where the finger let
+                                 // go instead of snapping back to fully
+                                 // expanded first.
+                                 expandProgress.snapTo(released)
+                             } finally {
+                                 // In a finally because snapTo suspends on the
+                                 // Animatable's mutex: an expand/collapse
+                                 // animation that takes the mutex first
+                                 // cancels it, and the plain sequential version
+                                 // then never reached this line. The flag stuck
+                                 // on, and the gesture was dead until the
+                                 // process restarted.
+                                 isDragging = false
+                             }
                              if (minimize) {
                                  viewModel.setExpanded(false)
                              } else {

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerOverlay.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerOverlay.kt
@@ -1,10 +1,6 @@
 package com.ivor.ivormusic.ui.video
 
 import android.app.PictureInPictureParams
-import android.app.RemoteAction
-import android.app.PendingIntent
-import android.content.Intent
-import android.graphics.drawable.Icon
 import android.os.Build
 import android.util.Rational
 import androidx.compose.animation.core.Animatable
@@ -25,7 +21,6 @@ import kotlinx.coroutines.launch
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.media3.common.util.UnstableApi
-import com.ivor.ivormusic.R
 
 /**
  * Aspect ratio for the PiP window, from the video's own dimensions.
@@ -35,7 +30,7 @@ import com.ivor.ivormusic.R
  * with an IllegalArgumentException, so the video's ratio is clamped into that
  * range rather than passed through blind.
  */
-private fun pipAspectRatio(videoAspectRatio: Float?): Rational {
+internal fun pipAspectRatio(videoAspectRatio: Float?): Rational {
     val ratio = videoAspectRatio?.takeIf { it.isFinite() && it > 0f } ?: (16f / 9f)
     val clamped = ratio.coerceIn(MIN_PIP_ASPECT, MAX_PIP_ASPECT)
     // Scaled to integers: Rational(width, height) with 1000ths is precise
@@ -108,8 +103,6 @@ fun VideoPlayerOverlay(
     val isExpanded by viewModel.isExpanded.collectAsState()
     val currentVideo by viewModel.currentVideo.collectAsState()
     val isPlaying by viewModel.isPlaying.collectAsState()
-    val videoAspectRatio by viewModel.videoAspectRatio.collectAsState()
-    val videoBounds by viewModel.videoSurfaceBounds.collectAsState()
 
     // Context and Activity
     val context = LocalContext.current
@@ -151,94 +144,10 @@ fun VideoPlayerOverlay(
         }
     }
 
-    // Update PiP Params (Active when video is present)
-    val packageName = context.packageName
-    val pipPlayAction = "$packageName.PIP_PLAY"
-    val pipPauseAction = "$packageName.PIP_PAUSE"
-    
-    LaunchedEffect(currentVideo, isPlaying, isExpanded, videoAspectRatio, videoBounds) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && activity != null) {
-             val videoId = currentVideo?.videoId ?: return@LaunchedEffect
-             // Use collision-resistant request codes: masked hashcode OR'd with action bit
-             val baseCode = videoId.hashCode() and 0x7FFFFFFF
-             val reqCodePlay = baseCode or 0x1
-             val reqCodePause = baseCode or 0x2
-             
-             // Intents for PiP controls - using package-scoped actions for security
-             val playIntent = PendingIntent.getBroadcast(
-                 context, 
-                 reqCodePlay, 
-                 Intent(pipPlayAction).setPackage(packageName), 
-                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-             )
-             val pauseIntent = PendingIntent.getBroadcast(
-                 context, 
-                 reqCodePause, 
-                 Intent(pipPauseAction).setPackage(packageName), 
-                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-             )
-             
-             val playAction = RemoteAction(Icon.createWithResource(context, android.R.drawable.ic_media_play), "Play", "Play", playIntent)
-             val pauseAction = RemoteAction(Icon.createWithResource(context, android.R.drawable.ic_media_pause), "Pause", "Pause", pauseIntent)
-             
-             val actions = if (isPlaying) listOf(pauseAction) else listOf(playAction)
-
-             val paramsBuilder = PictureInPictureParams.Builder()
-                .setAspectRatio(pipAspectRatio(videoAspectRatio))
-                .setActions(actions)
-
-             // Animate the PiP window out of the video rather than out of the
-             // whole activity window. Without a source rect the system scales
-             // the entire screen down - app chrome, nav bar and all - which is
-             // what made the transition look like the UI was being sucked into
-             // the window.
-             videoBounds?.takeIf { !it.isEmpty }?.let { paramsBuilder.setSourceRectHint(it) }
-
-             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                 // Only auto-enter PiP while the full player is on screen.
-                 // Auto-entering from the mini player captures the whole app UI
-                 // into the PiP window instead of just the video surface.
-                 paramsBuilder.setAutoEnterEnabled(isExpanded)
-                 // The content is a video, not a layout that needs to reflow, so
-                 // let the system crossfade the resize instead of re-laying out.
-                 paramsBuilder.setSeamlessResizeEnabled(true)
-             }
-
-             try {
-                 activity.setPictureInPictureParams(paramsBuilder.build())
-             } catch (e: Exception) {
-                 e.printStackTrace()
-             }
-        }
-    }
-    
-    // PiP Broadcast Receiver (Handle actions) - using package-scoped actions for security
-    DisposableEffect(viewModel) {
-        val pipReceiver = object : android.content.BroadcastReceiver() {
-            override fun onReceive(ctx: android.content.Context?, intent: Intent?) {
-                when (intent?.action) {
-                    pipPauseAction -> viewModel.exoPlayer?.pause()
-                    pipPlayAction -> viewModel.exoPlayer?.play()
-                }
-            }
-        }
-        val filter = android.content.IntentFilter().apply {
-            addAction(pipPauseAction)
-            addAction(pipPlayAction)
-        }
-        // Package-scoped actions prevent other apps from triggering on all API levels
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            context.registerReceiver(pipReceiver, filter, android.content.Context.RECEIVER_NOT_EXPORTED)
-        } else {
-            context.registerReceiver(pipReceiver, filter)
-        }
-        onDispose { 
-            context.unregisterReceiver(pipReceiver)
-        }
-    }
-
     // Nothing here renders in system PiP: MainActivity swaps the whole app for
     // PipVideoSurface, so the PiP window contains the video and nothing else.
+    // The PiP window's own shape and controls are driven by VideoPipController,
+    // which MainActivity composes above that swap - see the note there.
 
     // ------------------------------------------------
     // Normal In-App Overlay UI

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -1226,45 +1226,65 @@ internal fun PlayerGestureSurface(
                 } else Modifier.pointerInput(minimizeDragEnabled, enterFullscreenEnabled) {
                     val velocityTracker = VelocityTracker()
                     val enterTravelPx = ENTER_FULLSCREEN_SWIPE_TRAVEL.toPx()
-                    // 0 undecided, 1 minimize, 2 arming fullscreen, 3 committed
-                    var mode = 0
                     var totalDy = 0f
+                    var wentFullscreen = false
+                    var minimizing = false
                     detectVerticalDragGestures(
                         onDragStart = {
                             velocityTracker.resetTracking()
-                            mode = 0
                             totalDy = 0f
+                            wentFullscreen = false
+                            minimizing = false
                         },
                         onVerticalDrag = { change, dragAmount ->
-                            velocityTracker.addPosition(change.uptimeMillis, change.position)
                             totalDy += dragAmount
-                            if (mode == 0) {
-                                // The first delta past touch slop is the
-                                // direction the user meant. Committing to it for
-                                // the rest of the gesture is what stops a
-                                // wavering swipe from doing both things.
-                                mode = when {
-                                    dragAmount < 0f && enterFullscreenEnabled -> 2
-                                    minimizeDragEnabled -> 1
-                                    else -> 0
-                                }
+
+                            // Velocity from the accumulated delta, NOT from
+                            // change.position. This surface is inside the player
+                            // being dragged, and the minimize drag moves it down
+                            // one-for-one with the finger - so the pointer's
+                            // position *within this node* barely changes, and a
+                            // tracker fed those positions reported almost no
+                            // velocity. That is why a calm downward swipe never
+                            // tripped the velocity test and minimizing felt like
+                            // it needed to be yanked. The deltas are measured
+                            // against the node's current transform and are
+                            // correct; only the absolute positions are not.
+                            velocityTracker.addPosition(
+                                change.uptimeMillis,
+                                Offset(0f, totalDy)
+                            )
+
+                            // Direction is re-read from the accumulated travel
+                            // every event rather than locked in from the first
+                            // delta past touch slop. Locking meant a swipe that
+                            // began with the smallest upward roll of the finger
+                            // - which is most of them - spent the whole gesture
+                            // in the fullscreen lane and minimized nothing.
+                            if (!wentFullscreen &&
+                                enterFullscreenEnabled &&
+                                totalDy <= -enterTravelPx
+                            ) {
+                                wentFullscreen = true
+                                haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                                enterFullscreen?.invoke()
                             }
-                            when (mode) {
-                                1 -> onMinimizeDragDelta(dragAmount)
-                                2 -> if (totalDy <= -enterTravelPx) {
-                                    mode = 3
-                                    haptics.performHapticFeedback(HapticFeedbackType.LongPress)
-                                    enterFullscreen?.invoke()
-                                }
+
+                            if (minimizeDragEnabled && !wentFullscreen) {
+                                // Upward deltas are safe to forward: the player
+                                // clamps at fully expanded, so an early wobble
+                                // costs nothing and the pull still counts.
+                                onMinimizeDragDelta(dragAmount)
+                                if (totalDy > 0f) minimizing = true
                             }
                             change.consume()
                         },
                         onDragEnd = {
-                            if (mode == 1) {
+                            if (minimizing) {
                                 onMinimizeDragRelease(velocityTracker.calculateVelocity().y)
                             }
                         },
-                        onDragCancel = { if (mode == 1) onMinimizeDragRelease(0f) }
+                        onDragCancel = { if (minimizing) onMinimizeDragRelease(0f) }
                     )
                 }
             )

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -114,6 +114,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -122,7 +123,9 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChanged
 import androidx.compose.ui.input.pointer.util.VelocityTracker
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
@@ -315,7 +318,11 @@ fun FullscreenPlayerContent(
             speedBeforeBoost = exoPlayer.playbackParameters.speed
             exoPlayer.setPlaybackSpeed(2f)
         },
-        onSpeedBoostEnd = { exoPlayer.setPlaybackSpeed(speedBeforeBoost) }
+        onSpeedBoostEnd = { exoPlayer.setPlaybackSpeed(speedBeforeBoost) },
+        // Swipe down the middle of the video to come back to portrait, the
+        // mirror of the swipe up that got here. Same callback as the toolbar's
+        // fullscreen button.
+        onExitFullscreen = onFullscreenToggle
     ) {
         // Video View
         AndroidView(
@@ -631,7 +638,10 @@ fun PortraitPlayerContent(
         onSpeedBoostEnd = { exoPlayer.setPlaybackSpeed(speedBeforeBoost) },
         minimizeDragEnabled = minimizeDragEnabled,
         onMinimizeDragDelta = onMinimizeDragDelta,
-        onMinimizeDragRelease = onMinimizeDragRelease
+        onMinimizeDragRelease = onMinimizeDragRelease,
+        // Swipe up on the video to go fullscreen. Down already minimizes, so
+        // the surface now answers both directions.
+        onEnterFullscreen = onFullscreenToggle
     ) {
         AndroidView(
             factory = { ctx ->
@@ -1027,6 +1037,37 @@ private const val PINCH_ZOOM_IN_THRESHOLD = 1.15f
 private const val PINCH_ZOOM_OUT_THRESHOLD = 0.87f
 
 /**
+ * Upward travel on the inline video that commits to fullscreen.
+ *
+ * Small, because the inline box is only a 16:9 slice of a portrait screen -
+ * there is barely 100dp of room above a finger that started in the middle of
+ * it. Comfortably past touch slop, and the gesture commits the moment it is
+ * reached rather than waiting for the finger to lift, so the rotation starts
+ * while the swipe still feels like it is happening.
+ */
+private val ENTER_FULLSCREEN_SWIPE_TRAVEL = 56.dp
+
+/**
+ * Downward travel in the centre column of a fullscreen video that exits it.
+ *
+ * Deliberately longer than the way in: leaving fullscreen throws away the
+ * orientation the user is holding the phone in, so it should take a gesture
+ * they meant.
+ */
+private val EXIT_FULLSCREEN_SWIPE_TRAVEL = 72.dp
+
+/**
+ * Half-width of the centre column reserved for the exit-fullscreen swipe, as a
+ * fraction of the surface.
+ *
+ * Vertical drags in fullscreen are already spoken for - brightness on the left,
+ * volume on the right - so the exit gesture needs a lane of its own rather than
+ * a direction of its own. A third of the width each still leaves both levels
+ * more than enough to grab, since their travel is vertical.
+ */
+private const val FULLSCREEN_CENTRE_COLUMN_HALF_WIDTH = 0.18f
+
+/**
  * Wraps the video surface with tap gestures: single tap toggles the controls,
  * a double tap on the left rewinds and on the right fast-forwards (YouTube-style),
  * with an animated badge that accumulates when tapped repeatedly.
@@ -1044,6 +1085,21 @@ private const val PINCH_ZOOM_OUT_THRESHOLD = 0.87f
  * on the surface is reported through [onMinimizeDragDelta] /
  * [onMinimizeDragRelease] so the overlay can drag the player down into the
  * mini player. Mutually exclusive with the fullscreen level drags.
+ *
+ * The two fullscreen swipes are the YouTube pair, and they are directional
+ * rather than positional so each one lands where the hand already is:
+ * - inline (portrait): swipe **up** anywhere on the video enters fullscreen,
+ *   through [onEnterFullscreen]. Down is still the minimize drag, so the video
+ *   surface answers both directions with the obvious thing.
+ * - fullscreen (landscape): swipe **down** the centre column exits, through
+ *   [onExitFullscreen]. Only the centre, because the sides are the brightness
+ *   and volume lanes.
+ *
+ * Both commit mid-gesture on travel alone rather than on release. There is no
+ * dragged preview to release into - the layout swap is an orientation change,
+ * not something that can follow a finger - so waiting for the lift would just
+ * make the gesture feel like it had not registered. Leaving either callback
+ * null leaves that swipe out entirely.
  */
 @Composable
 internal fun PlayerGestureSurface(
@@ -1058,6 +1114,8 @@ internal fun PlayerGestureSurface(
     minimizeDragEnabled: Boolean = false,
     onMinimizeDragDelta: (Float) -> Unit = {},
     onMinimizeDragRelease: (Float) -> Unit = {},
+    onEnterFullscreen: (() -> Unit)? = null,
+    onExitFullscreen: (() -> Unit)? = null,
     content: @Composable BoxScope.() -> Unit
 ) {
     // side: -1 rewind, +1 forward, 0 hidden. seconds accumulates on rapid taps.
@@ -1067,6 +1125,20 @@ internal fun PlayerGestureSurface(
 
     // Press-and-hold anywhere temporarily boosts playback to 2x (YouTube-style).
     var isBoosting by remember { mutableStateOf(false) }
+
+    // The player recomposes on every position tick, so these arrive as fresh
+    // lambda instances several times a second. Read through a state holder and
+    // key the pointerInputs on whether the gesture exists at all, or every tick
+    // would restart the gesture detectors and cancel a drag in progress.
+    val enterFullscreen by rememberUpdatedState(onEnterFullscreen)
+    val exitFullscreen by rememberUpdatedState(onExitFullscreen)
+    val enterFullscreenEnabled = onEnterFullscreen != null
+    val exitFullscreenEnabled = onExitFullscreen != null
+
+    // Both fullscreen swipes commit while the finger is still down and have no
+    // dragged preview behind them, so a tick is the only thing that tells the
+    // user the gesture took before the screen turns.
+    val haptics = LocalHapticFeedback.current
 
     // Hide the badge a short while after the last tap. Re-runs (and so resets
     // the timer) every double tap because it is keyed on `pulse`.
@@ -1147,40 +1219,79 @@ internal fun PlayerGestureSurface(
                 )
             }
             .then(
-                if (!minimizeDragEnabled || fullscreenGesturesEnabled) Modifier
-                else Modifier.pointerInput(Unit) {
+                if (fullscreenGesturesEnabled ||
+                    (!minimizeDragEnabled && !enterFullscreenEnabled)
+                ) {
+                    Modifier
+                } else Modifier.pointerInput(minimizeDragEnabled, enterFullscreenEnabled) {
                     val velocityTracker = VelocityTracker()
+                    val enterTravelPx = ENTER_FULLSCREEN_SWIPE_TRAVEL.toPx()
+                    // 0 undecided, 1 minimize, 2 arming fullscreen, 3 committed
+                    var mode = 0
+                    var totalDy = 0f
                     detectVerticalDragGestures(
-                        onDragStart = { velocityTracker.resetTracking() },
+                        onDragStart = {
+                            velocityTracker.resetTracking()
+                            mode = 0
+                            totalDy = 0f
+                        },
                         onVerticalDrag = { change, dragAmount ->
                             velocityTracker.addPosition(change.uptimeMillis, change.position)
-                            onMinimizeDragDelta(dragAmount)
+                            totalDy += dragAmount
+                            if (mode == 0) {
+                                // The first delta past touch slop is the
+                                // direction the user meant. Committing to it for
+                                // the rest of the gesture is what stops a
+                                // wavering swipe from doing both things.
+                                mode = when {
+                                    dragAmount < 0f && enterFullscreenEnabled -> 2
+                                    minimizeDragEnabled -> 1
+                                    else -> 0
+                                }
+                            }
+                            when (mode) {
+                                1 -> onMinimizeDragDelta(dragAmount)
+                                2 -> if (totalDy <= -enterTravelPx) {
+                                    mode = 3
+                                    haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                                    enterFullscreen?.invoke()
+                                }
+                            }
                             change.consume()
                         },
                         onDragEnd = {
-                            onMinimizeDragRelease(velocityTracker.calculateVelocity().y)
+                            if (mode == 1) {
+                                onMinimizeDragRelease(velocityTracker.calculateVelocity().y)
+                            }
                         },
-                        onDragCancel = { onMinimizeDragRelease(0f) }
+                        onDragCancel = { if (mode == 1) onMinimizeDragRelease(0f) }
                     )
                 }
             )
             .then(
                 if (!fullscreenGesturesEnabled) Modifier
-                else Modifier.pointerInput(activity) {
+                else Modifier.pointerInput(activity, exitFullscreenEnabled) {
+                    val exitTravelPx = EXIT_FULLSCREEN_SWIPE_TRAVEL.toPx()
                     awaitEachGesture {
                         val down = awaitFirstDown(requireUnconsumed = false)
                         val leftSide = down.position.x < size.width / 2f
-                        // Level drags only arm in the bottom 70% of the
+                        // Vertical drags only arm in the bottom 70% of the
                         // surface: a swipe from the top area is almost always
                         // the user reaching for the notification shade, and
                         // grabbing it as a brightness/volume drag was a
-                        // constant misfire. Pinch-to-zoom stays available
-                        // everywhere.
-                        val inLevelDragZone = down.position.y >= size.height * 0.3f
-                        // 0 = undecided, 1 = vertical level drag, 2 = pinch
+                        // constant misfire - the same is true of a downward
+                        // swipe meant to leave fullscreen. Pinch-to-zoom stays
+                        // available everywhere.
+                        val inDragZone = down.position.y >= size.height * 0.3f
+                        // The exit-fullscreen lane, between the two level lanes.
+                        val inCentreColumn = abs(down.position.x - size.width / 2f) <=
+                            size.width * FULLSCREEN_CENTRE_COLUMN_HALF_WIDTH
+                        // 0 = undecided, 1 = vertical level drag, 2 = pinch,
+                        // 3 = downward swipe out of fullscreen
                         var mode = 0
                         var accumulatedZoom = 1f
                         var level = 0f
+                        var exitCommitted = false
                         while (true) {
                             val event = awaitPointerEvent()
                             val pressed = event.changes.filter { it.pressed }
@@ -1202,15 +1313,19 @@ internal fun PlayerGestureSurface(
                                 if (mode == 0) {
                                     val totalDx = change.position.x - down.position.x
                                     val totalDy = change.position.y - down.position.y
-                                    if (inLevelDragZone &&
+                                    if (inDragZone &&
                                         abs(totalDy) > viewConfiguration.touchSlop &&
                                         abs(totalDy) > abs(totalDx)
                                     ) {
-                                        mode = 1
-                                        level = if (leftSide) {
-                                            activity?.let { currentWindowBrightness(it) } ?: 0.5f
+                                        if (inCentreColumn && exitFullscreenEnabled) {
+                                            mode = 3
                                         } else {
-                                            currentVolumeFraction(audioManager)
+                                            mode = 1
+                                            level = if (leftSide) {
+                                                activity?.let { currentWindowBrightness(it) } ?: 0.5f
+                                            } else {
+                                                currentVolumeFraction(audioManager)
+                                            }
                                         }
                                     }
                                 }
@@ -1227,6 +1342,18 @@ internal fun PlayerGestureSurface(
                                     }
                                     adjustmentLevel = level
                                     adjustPulse++
+                                    change.consume()
+                                } else if (mode == 3) {
+                                    // Upward in this lane is deliberately
+                                    // nothing: the centre is the way out of
+                                    // fullscreen, not a third level slider.
+                                    if (!exitCommitted &&
+                                        change.position.y - down.position.y >= exitTravelPx
+                                    ) {
+                                        exitCommitted = true
+                                        haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                                        exitFullscreen?.invoke()
+                                    }
                                     change.consume()
                                 }
                             }

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
@@ -379,6 +379,12 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
             .setWakeMode(C.WAKE_MODE_NETWORK)
             .setAudioAttributes(AudioAttributes.DEFAULT, true)
             .setHandleAudioBecomingNoisy(true)
+            // 10s each way, matching the player's own double-tap seek. These
+            // are what the media notification's and PiP window's skip buttons
+            // move by, so they must agree with the in-app gesture rather than
+            // with Media3's 5s/15s defaults.
+            .setSeekBackIncrementMs(SEEK_STEP_MS)
+            .setSeekForwardIncrementMs(SEEK_STEP_MS)
             .build().apply {
             playWhenReady = true
             // Repeat is persisted, so a fresh player must adopt the stored
@@ -737,6 +743,13 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         _playbackSpeed.value = 1f
         _exoPlayer?.setPlaybackSpeed(1f)
 
+        // Publish to the system's media controls. Started here, from a user tap,
+        // because a foreground service may not be started from the background;
+        // repeat calls once it is up are no-ops.
+        _exoPlayer?.let {
+            com.ivor.ivormusic.service.VideoPlaybackService.start(context, it)
+        }
+
         // ========== PHASE 1: START PLAYBACK ASAP (fast) ==========
         // Uses lightweight getVideoStreamQualities() which ONLY fetches stream URLs
         viewModelScope.launch {
@@ -769,7 +782,7 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
                                 audioUrl = null
                             )
                             val source = ProgressiveMediaSource.Factory(streamDataSourceFactory)
-                                .createMediaSource(MediaItem.fromUri(streamUrl))
+                                .createMediaSource(nowPlayingMediaItem(streamUrl))
                             _exoPlayer?.setMediaSource(source)
                             _exoPlayer?.prepare()
                             _exoPlayer?.play() // FORCE PLAY
@@ -801,7 +814,14 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
                 if (_currentVideo.value?.videoId != video.videoId) return@launch
                 _engagement.value = watchNext.engagement
                 if (watchNext.updatedVideoItem != null) {
+                    val wasNameless = _currentVideo.value?.title.isNullOrBlank()
                     _currentVideo.value = watchNext.updatedVideoItem
+                    // A video opened from a shared link starts out nameless -
+                    // give the lock screen and shade the real title now that
+                    // there is one. Deliberately only for that case: every other
+                    // entry point already carries a title, and touching the
+                    // media item is not worth it just to swap a thumbnail size.
+                    if (wasNameless) refreshNowPlayingMetadata()
                 }
                 if (watchNext.relatedVideos.isNotEmpty()) {
                     _relatedVideos.value = watchNext.relatedVideos
@@ -898,8 +918,8 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
             // Adaptive manifest - hand it to the player and let its MediaSource
             // factory build the DASH/HLS source, no merging needed.
             _exoPlayer?.setMediaItem(
-                MediaItem.Builder()
-                    .setUri(quality.url)
+                nowPlayingMediaItem(quality.url)
+                    .buildUpon()
                     .setMimeType(adaptiveMimeType(quality))
                     .build()
             )
@@ -910,19 +930,75 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
                 // Non-DASH with separate audio - use MergingMediaSource.
                 // adjustPeriodTimeOffsets aligns the two tracks' start offsets,
                 // preventing A/V desync when they don't begin at the same time.
+                // The merged source reports the *video* item's MediaItem, which
+                // is why the metadata rides on that one.
                 val videoSource = ProgressiveMediaSource.Factory(dataSourceFactory)
-                    .createMediaSource(MediaItem.fromUri(quality.url))
+                    .createMediaSource(nowPlayingMediaItem(quality.url))
                 val audioSource = ProgressiveMediaSource.Factory(dataSourceFactory)
                     .createMediaSource(MediaItem.fromUri(audioUrl))
                 MergingMediaSource(true, videoSource, audioSource)
             } else {
                 ProgressiveMediaSource.Factory(dataSourceFactory)
-                    .createMediaSource(MediaItem.fromUri(quality.url))
+                    .createMediaSource(nowPlayingMediaItem(quality.url))
             }
 
             _exoPlayer?.setMediaSource(primarySource)
         }
         _exoPlayer?.prepare()
+    }
+
+    /**
+     * A [MediaItem] for [uri] carrying the current video's title, channel and
+     * thumbnail.
+     *
+     * Without this the player has no metadata at all, and the lock screen /
+     * shade / Bluetooth display that [com.ivor.ivormusic.service.VideoPlaybackService]
+     * publishes would be a blank card with transport buttons on it. The artwork
+     * URI is loaded by Media3's own bitmap loader, so no bitmap work happens
+     * here.
+     */
+    private fun nowPlayingMediaItem(uri: String): MediaItem {
+        val video = _currentVideo.value
+        val builder = MediaItem.Builder().setUri(uri)
+        if (video != null) {
+            builder.setMediaId(video.videoId)
+            builder.setMediaMetadata(
+                androidx.media3.common.MediaMetadata.Builder()
+                    .setTitle(video.title.takeIf { it.isNotBlank() })
+                    .setArtist(video.channelName.takeIf { it.isNotBlank() })
+                    .setArtworkUri(video.thumbnailUrl?.let { android.net.Uri.parse(it) })
+                    .setIsBrowsable(false)
+                    .setIsPlayable(true)
+                    .build()
+            )
+        }
+        return builder.build()
+    }
+
+    /**
+     * Push freshly-learned title/channel into the already-playing media item.
+     *
+     * Only matters for the shared-link path, which starts playback from a video
+     * id alone and so hands the session a nameless card until watch-next lands.
+     * [Player.replaceMediaItem] is metadata-only here - the URI is untouched, so
+     * every source type in use reports it can update in place and playback is
+     * not interrupted. Guarded anyway: a wrong guess would rebuild the source
+     * and cost a rebuffer, which is never worth a caption.
+     */
+    private fun refreshNowPlayingMetadata() {
+        val player = _exoPlayer ?: return
+        if (player.mediaItemCount != 1) return
+        val current = player.currentMediaItem ?: return
+        val uri = current.localConfiguration?.uri?.toString() ?: return
+        val metadata = nowPlayingMediaItem(uri).mediaMetadata
+        if (metadata == current.mediaMetadata) return
+        try {
+            // buildUpon rather than a fresh item: the URI, MIME type and cache
+            // key all have to stay byte-identical for the update to be seamless.
+            player.replaceMediaItem(0, current.buildUpon().setMediaMetadata(metadata).build())
+        } catch (e: Exception) {
+            android.util.Log.w("VideoPlayerVM", "Could not refresh now-playing metadata", e)
+        }
     }
 
     /**
@@ -1074,6 +1150,8 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         liveChatStartedForVideoId = null
         _currentVideo.value = null
         _isExpanded.value = false
+        // Nothing is playing any more, so nothing should be on the lock screen.
+        com.ivor.ivormusic.service.VideoPlaybackService.stop(context)
     }
 
     fun togglePlayPause() {
@@ -1082,6 +1160,20 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         } else {
             _exoPlayer?.play()
         }
+    }
+
+    /**
+     * Skip [deltaMs] from the current position, clamped to the media.
+     *
+     * Lives here rather than in the player UI because the same step is driven
+     * from outside the composition too - the Picture-in-Picture window's
+     * RemoteActions have no other way to reach the player.
+     */
+    fun seekBy(deltaMs: Long) {
+        val player = _exoPlayer ?: return
+        val duration = player.duration
+        val upperBound = if (duration > 0) duration else Long.MAX_VALUE
+        player.seekTo((player.currentPosition + deltaMs).coerceIn(0L, upperBound))
     }
 
     /** Pause without closing the player (music or Shorts playback started). */
@@ -1668,6 +1760,12 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         /** Speeds offered in the player's speed menu. */
         val PLAYBACK_SPEED_OPTIONS = listOf(0.25f, 0.5f, 0.75f, 1f, 1.25f, 1.5f, 1.75f, 2f)
 
+        /**
+         * One skip step, shared by the double-tap gesture on the player, the
+         * media notification and the Picture-in-Picture controls.
+         */
+        const val SEEK_STEP_MS = 10_000L
+
         /** Silent re-prepare attempts before a renderer error reaches the UI. */
         private const val MAX_RENDERER_RETRIES = 2
 
@@ -1724,6 +1822,10 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         sourceRecoveryJob?.cancel()
         sourceRecoveryJob = null
         stopLivePolling()
+        // Before the release below, not after: stop() drops the MediaSession
+        // synchronously on this thread, and a session outliving the player it
+        // wraps crashes the next time Media3 reads state off it.
+        com.ivor.ivormusic.service.VideoPlaybackService.stop(context)
         _exoPlayer?.release()
         _exoPlayer = null
     }

--- a/app/src/main/res/drawable/ic_media_forward_10.xml
+++ b/app/src/main/res/drawable/ic_media_forward_10.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    "Forward 10 seconds". The ring is ic_media_replay_10's mirrored about
+    x = 12 so the pair reads as one control; the digits are not mirrored.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFFFF">
+
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,5V1l5,5l-5,5V7c-3.31,0 -6,2.69 -6,6c0,3.31 2.69,6 6,6c3.31,0 6,-2.69 6,-6h2c0,4.42 -3.58,8 -8,8c-4.42,0 -8,-3.58 -8,-8c0,-4.42 3.58,-8 8,-8z" />
+
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M10.5,10h-0.6l-1.4,0.7v1l1,-0.5v4.8h1z" />
+
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:fillType="evenOdd"
+        android:pathData="M13.75,10c0.97,0 1.75,0.78 1.75,1.75v2.5c0,0.97 -0.78,1.75 -1.75,1.75c-0.97,0 -1.75,-0.78 -1.75,-1.75v-2.5c0,-0.97 0.78,-1.75 1.75,-1.75zM13.75,11.6c-0.28,0 -0.5,0.22 -0.5,0.5v2.3c0,0.28 0.22,0.5 0.5,0.5c0.28,0 0.5,-0.22 0.5,-0.5v-2.3c0,-0.28 -0.22,-0.5 -0.5,-0.5z" />
+</vector>

--- a/app/src/main/res/drawable/ic_media_pause.xml
+++ b/app/src/main/res/drawable/ic_media_pause.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Pause counterpart to ic_media_play. See that file for why these exist. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFFFF">
+
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M6,5h4v14h-4z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M14,5h4v14h-4z" />
+</vector>

--- a/app/src/main/res/drawable/ic_media_play.xml
+++ b/app/src/main/res/drawable/ic_media_play.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Transport icon for the Picture-in-Picture RemoteActions and the video
+    media notification. Both surfaces render a silhouette from the alpha
+    channel, so this is a solid white shape on transparent.
+
+    Koda draws its own rather than using android.R.drawable.ic_media_play:
+    the platform set is the 2011 Holo artwork, which sits badly next to the
+    seek-10 pair below it in the same control row.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFFFF">
+
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M8,5v14l11,-7z" />
+</vector>

--- a/app/src/main/res/drawable/ic_media_replay_10.xml
+++ b/app/src/main/res/drawable/ic_media_replay_10.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    "Back 10 seconds" for the Picture-in-Picture controls and the video media
+    notification.
+
+    Three paths: the counter-clockwise ring with its arrow head, then the two
+    digits sitting inside it. The ring is centred on (12,13) with an inner
+    radius of 6, which is what leaves room for a legible "10" at the 24dp the
+    system renders these at.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFFFF">
+
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,5V1L7,6l5,5V7c3.31,0 6,2.69 6,6c0,3.31 -2.69,6 -6,6c-3.31,0 -6,-2.69 -6,-6H4c0,4.42 3.58,8 8,8c4.42,0 8,-3.58 8,-8c0,-4.42 -3.58,-8 -8,-8z" />
+
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M10.5,10h-0.6l-1.4,0.7v1l1,-0.5v4.8h1z" />
+
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:fillType="evenOdd"
+        android:pathData="M13.75,10c0.97,0 1.75,0.78 1.75,1.75v2.5c0,0.97 -0.78,1.75 -1.75,1.75c-0.97,0 -1.75,-0.78 -1.75,-1.75v-2.5c0,-0.97 0.78,-1.75 1.75,-1.75zM13.75,11.6c-0.28,0 -0.5,0.22 -0.5,0.5v2.3c0,0.28 0.22,0.5 0.5,0.5c0.28,0 0.5,-0.22 0.5,-0.5v-2.3c0,-0.28 -0.22,-0.5 -0.5,-0.5z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,12 @@
       up listing "Now playing" twice.
     -->
     <string name="now_playing_channel_name">Now playing</string>
+
+    <!--
+      The video pipeline posts its own media notification from
+      VideoPlaybackService. Separate from "Now playing" on purpose: music and
+      video are separate players here, and a user who wants one of them out of
+      their shade should not have to silence both.
+    -->
+    <string name="video_playback_channel_name">Video playback</string>
 </resources>


### PR DESCRIPTION
Three related gaps around video playback outside the app's own UI.

PiP transport controls did nothing. MainActivity swaps the whole app for
PipVideoSurface when PiP starts, so VideoPlayerOverlay - which owned both
the PictureInPictureParams effect and the BroadcastReceiver its actions
fired into - left the composition at exactly the moment those controls
became visible. The receiver was unregistered and the button's intent went
nowhere; the params effect went with it, so the icon could never have
flipped between play and pause either. That logic now lives in
VideoPipController, composed above the PiP swap in MainActivity so it
survives it. Closing the player also disarms auto-enter now, which
previously stayed armed and could open an empty PiP window.

PiP gains back-10s and forward-10s controls. A PiP window receives no touch
events - the system owns every gesture on it - so an in-window double tap is
not something an app can implement; RemoteActions are the only input surface
PiP has. The row is now [-10s] [play/pause] [+10s], falling back to
play/pause alone if a device advertises fewer than three action slots.

Video is published to the system's media controls. VideoPlaybackService
wraps the ViewModel's ExoPlayer in a MediaSession, so a video now appears on
the lock screen, in the shade's media area and the output switcher, and
answers headset and Bluetooth transport buttons - and background video audio
is a declared foreground service rather than an unannounced one. The player
stays owned by VideoPlayerViewModel; the service borrows it and never
releases it. Media items carry title, channel and thumbnail so the card is
not blank, and the notification carries the same 10s skip pair.

Supporting changes: 10s seek increments on the video ExoPlayer, a shared
VideoPlayerViewModel.seekBy so the gesture, the PiP buttons and the
notification clamp identically, and four transport vector drawables.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Wrx2W3gA5tEvMWPyTwDe3i