### PR TITLE
Give the brightness and volume drag a segmented level indicator

### DIFF
--- a/app/src/main/java/com/ivor/ivormusic/ui/video/PlayerLevelIndicator.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/PlayerLevelIndicator.kt
@@ -1,0 +1,277 @@
+package com.ivor.ivormusic.ui.video
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.VolumeDown
+import androidx.compose.material.icons.automirrored.rounded.VolumeOff
+import androidx.compose.material.icons.automirrored.rounded.VolumeUp
+import androidx.compose.material.icons.rounded.BrightnessHigh
+import androidx.compose.material.icons.rounded.BrightnessLow
+import androidx.compose.material.icons.rounded.BrightnessMedium
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.lerp
+import com.ivor.ivormusic.ui.theme.contrastInk
+import kotlin.math.roundToInt
+
+/** Which level a vertical drag on the video surface is adjusting. */
+internal enum class LevelAdjustment { Brightness, Volume }
+
+/**
+ * Overall height of the slat stack, gaps included.
+ *
+ * Sized against the shortest landscape phone rather than the roomiest: the pill
+ * is vertically centred and the whole stack (readout, ladder, icon) has to clear
+ * a ~320dp-tall window without touching the edges.
+ */
+private val LADDER_LENGTH = 138.dp
+
+/** Space between slats. Small on purpose - the slats should read as a stack. */
+private val LADDER_GAP = 3.dp
+
+/**
+ * Slat widths at the bottom and top of the ladder.
+ *
+ * The taper is what makes the level legible from the corner of the eye: a lit
+ * stack is not just taller at 90% than at 30%, it is visibly *wider*, so the
+ * silhouette carries the value on its own without anyone reading the number.
+ */
+private val SLAT_MIN_WIDTH = 13.dp
+private val SLAT_MAX_WIDTH = 30.dp
+
+/** How visible an unlit slat is. Present enough to show the range, quiet enough to ignore. */
+private const val SLAT_UNLIT_ALPHA = 0.20f
+
+/**
+ * Feedback for a brightness or volume drag on the video surface: a segmented
+ * ladder of slats that light from the bottom, a live percentage, and the lane's
+ * icon.
+ *
+ * The point of segmenting it is that volume genuinely *is* stepped - a
+ * continuous bar quietly lies about a control the system exposes in about
+ * fifteen notches. [segments] comes from the device's own media volume steps,
+ * so a haptic tick and a slat lighting are the same event rather than two
+ * things that happen near each other. Brightness has no steps of its own and
+ * borrows the same count, which is what keeps the two lanes feeling like one
+ * control.
+ *
+ * Three things carry the value, deliberately redundantly:
+ * - **how many** slats are lit, which is the precise reading;
+ * - **how wide** the lit stack is, because the slats taper from narrow at the
+ *   bottom to wide at the top and unlit ones all sit at the narrow width - so
+ *   the wedge is something the level reveals rather than a shape that is always
+ *   there. This is the glanceable reading;
+ * - **the frontier slat**, which fills fractionally rather than snapping, so
+ *   fine adjustment inside a step is still visible.
+ *
+ * Each slat springs on its own, so sweeping the finger fast lights them in a
+ * cascade rather than all at once - the stagger falls out of the drag itself
+ * and costs no extra machinery.
+ *
+ * Kept as two instances - one per side, mirroring [SeekFeedbackBadge] - so each
+ * can animate out on its own edge instead of one pill sliding across the video
+ * when the user switches lanes.
+ */
+@Composable
+internal fun PlayerLevelIndicator(
+    kind: LevelAdjustment,
+    level: Float,
+    segments: Int,
+    visible: Boolean,
+    modifier: Modifier = Modifier
+) {
+    val scheme = MaterialTheme.colorScheme
+
+    // This overlay always sits on a dark scrim over the video frame, whatever
+    // the app's light/dark mode is, so `primary` alone will not do: in a light
+    // scheme it is a tone-40 that disappears against black. `inversePrimary` is
+    // the tone-80 of the same seed, so the accent reads identically either way
+    // and still comes from the user's palette.
+    val accent = if (scheme.surface.luminance() < 0.5f) scheme.primary else scheme.inversePrimary
+    val ink = contrastInk(scheme.scrim)
+
+    val clamped = level.coerceIn(0f, 1f)
+    val percent = (clamped * 100).roundToInt()
+
+    val slatCount = segments.coerceAtLeast(2)
+    val slatHeight = (LADDER_LENGTH - LADDER_GAP * (slatCount - 1)) / slatCount
+
+    val label = when (kind) {
+        LevelAdjustment.Brightness -> "Brightness"
+        LevelAdjustment.Volume -> "Volume"
+    }
+
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(spring(stiffness = Spring.StiffnessMedium)) + scaleIn(
+            animationSpec = spring(
+                dampingRatio = Spring.DampingRatioMediumBouncy,
+                stiffness = Spring.StiffnessMedium
+            ),
+            initialScale = 0.85f,
+            // Grows out of the edge it belongs to rather than appearing from
+            // nowhere in the middle of the frame.
+            transformOrigin = TransformOrigin(
+                pivotFractionX = if (kind == LevelAdjustment.Brightness) 0f else 1f,
+                pivotFractionY = 0.5f
+            )
+        ),
+        // Leaving is not a moment: it happens while the user has already moved
+        // on, so it goes out on a short tween rather than a spring that would
+        // still be settling.
+        exit = fadeOut(tween(durationMillis = 180)) +
+            scaleOut(animationSpec = tween(durationMillis = 180), targetScale = 0.92f),
+        modifier = modifier
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier
+                .background(
+                    color = scheme.scrim.copy(alpha = 0.55f),
+                    shape = RoundedCornerShape(32.dp)
+                )
+                .padding(horizontal = 16.dp, vertical = 14.dp)
+                .semantics(mergeDescendants = true) {
+                    contentDescription = "$label $percent percent"
+                }
+        ) {
+            Text(
+                text = "$percent%",
+                color = ink,
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold
+            )
+
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(LADDER_GAP)
+            ) {
+                // Drawn top down, so index 0 - the first slat to light - is the
+                // one at the bottom of the stack.
+                for (index in slatCount - 1 downTo 0) {
+                    LevelSlat(
+                        fill = (clamped * slatCount - index).coerceIn(0f, 1f),
+                        width = lerp(
+                            start = SLAT_MIN_WIDTH,
+                            stop = SLAT_MAX_WIDTH,
+                            fraction = index / (slatCount - 1f)
+                        ),
+                        height = slatHeight,
+                        color = accent
+                    )
+                }
+            }
+
+            AnimatedContent(
+                targetState = levelIcon(kind, clamped),
+                transitionSpec = {
+                    (fadeIn(tween(140)) + scaleIn(tween(180), initialScale = 0.7f)) togetherWith
+                        (fadeOut(tween(140)) + scaleOut(tween(180), targetScale = 0.7f))
+                },
+                label = "levelIcon"
+            ) { vector ->
+                Icon(
+                    imageVector = vector,
+                    contentDescription = null,
+                    tint = accent,
+                    modifier = Modifier.size(22.dp)
+                )
+            }
+        }
+    }
+}
+
+/**
+ * One slat of the ladder, lit by [fill] between 0 and 1.
+ *
+ * [width] is the slat's width once lit; unlit it renders at [SLAT_MIN_WIDTH]
+ * whatever its place in the taper. That narrowing is done with a draw-time
+ * scale rather than an animated width on purpose - the spring here is bouncy so
+ * a newly lit slat overshoots its width slightly and snaps back, and a bouncy
+ * spring driving a real layout size is exactly the thing that dips below zero
+ * for one frame and throws.
+ */
+@Composable
+private fun LevelSlat(
+    fill: Float,
+    width: Dp,
+    height: Dp,
+    color: Color
+) {
+    val lit by animateFloatAsState(
+        targetValue = fill,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMedium
+        ),
+        label = "levelSlat"
+    )
+
+    val narrow = (SLAT_MIN_WIDTH / width).coerceAtMost(1f)
+
+    Box(
+        modifier = Modifier
+            .width(width)
+            .height(height)
+            // Read inside the layer block so lighting a slat costs a draw, not
+            // a recomposition - there are up to sixteen of these on screen.
+            .graphicsLayer {
+                scaleX = narrow + (1f - narrow) * lit
+                alpha = (SLAT_UNLIT_ALPHA + (1f - SLAT_UNLIT_ALPHA) * lit).coerceIn(0f, 1f)
+            }
+            .background(color = color, shape = CircleShape)
+    )
+}
+
+/**
+ * Three stages per level so the icon keeps up with the drag instead of sitting
+ * on one glyph for most of the range.
+ */
+private fun levelIcon(kind: LevelAdjustment, level: Float): ImageVector = when (kind) {
+    LevelAdjustment.Volume -> when {
+        level <= 0.001f -> Icons.AutoMirrored.Rounded.VolumeOff
+        level < 0.5f -> Icons.AutoMirrored.Rounded.VolumeDown
+        else -> Icons.AutoMirrored.Rounded.VolumeUp
+    }
+    LevelAdjustment.Brightness -> when {
+        level < 0.33f -> Icons.Rounded.BrightnessLow
+        level < 0.66f -> Icons.Rounded.BrightnessMedium
+        else -> Icons.Rounded.BrightnessHigh
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -55,13 +55,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.Chat
 import androidx.compose.material.icons.automirrored.rounded.Comment
-import androidx.compose.material.icons.automirrored.rounded.VolumeOff
-import androidx.compose.material.icons.automirrored.rounded.VolumeUp
 import androidx.compose.material.icons.outlined.ThumbDown
 import androidx.compose.material.icons.outlined.ThumbUp
 import androidx.compose.material.icons.rounded.Autorenew
-import androidx.compose.material.icons.rounded.BrightnessHigh
-import androidx.compose.material.icons.rounded.BrightnessLow
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.ClosedCaption
@@ -1029,8 +1025,22 @@ private fun ChapterTitleChip(
 /** Seconds jumped per double-tap on either edge of the video surface. */
 private const val DOUBLE_TAP_SEEK_SECONDS = 10
 
-/** Which level a vertical drag is adjusting, for the feedback overlay. */
-private enum class LevelAdjustment { Brightness, Volume }
+/**
+ * Bounds on the level ladder's segment count.
+ *
+ * The count itself comes from the device's own media volume steps, so one slat
+ * is one real notch of volume and the haptic tick lands on the slat lighting.
+ * That number is not universal though - most phones expose 15, a few expose 7,
+ * and some expose 100, which would be neither drawable nor tickable - so it is
+ * clamped into a range that stays legible at the ladder's height. Brightness is
+ * continuous and borrows the same count, which is what keeps the two lanes
+ * feeling like one control.
+ */
+private const val LEVEL_SEGMENT_MIN = 8
+private const val LEVEL_SEGMENT_MAX = 16
+
+/** How long the level indicator stays up after the last movement. */
+private const val LEVEL_HIDE_MS = 800L
 
 /** Accumulated pinch ratios beyond these thresholds toggle zoom-to-fill. */
 private const val PINCH_ZOOM_IN_THRESHOLD = 1.15f
@@ -1162,9 +1172,18 @@ internal fun PlayerGestureSurface(
     var adjustmentLevel by remember { mutableFloatStateOf(0f) }
     var adjustPulse by remember { mutableIntStateOf(0) }
 
+    // One slat per real volume notch, shared by both lanes. Read once: the
+    // stream's step count does not change while a video is open.
+    val levelSegments = remember(audioManager) {
+        audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
+            .coerceIn(LEVEL_SEGMENT_MIN, LEVEL_SEGMENT_MAX)
+    }
+
+    // Re-keyed by every drag frame, so a continuous drag never gets past the
+    // delay and the indicator stays up for as long as the finger moves.
     LaunchedEffect(adjustPulse) {
         if (adjustment != null) {
-            delay(800)
+            delay(LEVEL_HIDE_MS)
             adjustment = null
         }
     }
@@ -1312,6 +1331,10 @@ internal fun PlayerGestureSurface(
                         var accumulatedZoom = 1f
                         var level = 0f
                         var exitCommitted = false
+                        // Whether the level is currently pinned to 0 or 1, so
+                        // the rail tick fires once on arrival rather than on
+                        // every frame the finger keeps pushing past the end.
+                        var atRail = false
                         while (true) {
                             val event = awaitPointerEvent()
                             val pressed = event.changes.filter { it.pressed }
@@ -1352,6 +1375,7 @@ internal fun PlayerGestureSurface(
                                 if (mode == 1) {
                                     val dy = change.position.y - change.previousPosition.y
                                     // Dragging ~70% of the surface height sweeps the full range
+                                    val previousLevel = level
                                     level = (level - dy / (size.height * 0.7f)).coerceIn(0f, 1f)
                                     if (leftSide) {
                                         activity?.let { setWindowBrightness(it, level.coerceAtLeast(0.01f)) }
@@ -1360,6 +1384,25 @@ internal fun PlayerGestureSurface(
                                         setVolumeFraction(audioManager, level)
                                         adjustment = LevelAdjustment.Volume
                                     }
+                                    // One tick per slat, on both lanes, because
+                                    // the ladder is drawn at exactly this
+                                    // granularity - the tick and the slat
+                                    // lighting are meant to be one event, not
+                                    // two that happen near each other.
+                                    val crossed = (level * levelSegments).toInt() !=
+                                        (previousLevel * levelSegments).toInt()
+                                    if (crossed) {
+                                        haptics.performHapticFeedback(
+                                            HapticFeedbackType.SegmentFrequentTick
+                                        )
+                                    }
+                                    val onRail = level <= 0f || level >= 1f
+                                    if (onRail && !atRail) {
+                                        haptics.performHapticFeedback(
+                                            HapticFeedbackType.GestureThresholdActivate
+                                        )
+                                    }
+                                    atRail = onRail
                                     adjustmentLevel = level
                                     adjustPulse++
                                     change.consume()
@@ -1412,59 +1455,25 @@ internal fun PlayerGestureSurface(
             modifier = Modifier.align(Alignment.CenterEnd)
         )
 
-        adjustment?.let { kind ->
-            LevelIndicator(
-                kind = kind,
-                level = adjustmentLevel,
-                modifier = Modifier
-                    .align(if (kind == LevelAdjustment.Brightness) Alignment.CenterStart else Alignment.CenterEnd)
-                    .padding(horizontal = 48.dp)
-            )
-        }
-    }
-}
-
-/** Vertical level bar + icon shown while a brightness/volume drag is active. */
-@Composable
-private fun LevelIndicator(
-    kind: LevelAdjustment,
-    level: Float,
-    modifier: Modifier = Modifier
-) {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-        modifier = modifier
-            .clip(RoundedCornerShape(20.dp))
-            .background(Color.Black.copy(alpha = 0.55f))
-            .padding(horizontal = 14.dp, vertical = 18.dp)
-    ) {
-        Box(
+        // One per lane rather than one that moves, so switching sides mid-video
+        // fades the old pill out on its own edge instead of flying it across.
+        PlayerLevelIndicator(
+            kind = LevelAdjustment.Brightness,
+            level = adjustmentLevel,
+            segments = levelSegments,
+            visible = adjustment == LevelAdjustment.Brightness,
             modifier = Modifier
-                .width(6.dp)
-                .height(110.dp)
-                .clip(CircleShape)
-                .background(Color.White.copy(alpha = 0.3f)),
-            contentAlignment = Alignment.BottomCenter
-        ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .fillMaxHeight(level.coerceIn(0f, 1f))
-                    .clip(CircleShape)
-                    .background(Color.White)
-            )
-        }
-        Icon(
-            imageVector = when {
-                kind == LevelAdjustment.Volume && level <= 0.001f -> Icons.AutoMirrored.Rounded.VolumeOff
-                kind == LevelAdjustment.Volume -> Icons.AutoMirrored.Rounded.VolumeUp
-                level < 0.3f -> Icons.Rounded.BrightnessLow
-                else -> Icons.Rounded.BrightnessHigh
-            },
-            contentDescription = null,
-            tint = Color.White,
-            modifier = Modifier.size(22.dp)
+                .align(Alignment.CenterStart)
+                .padding(horizontal = 48.dp)
+        )
+        PlayerLevelIndicator(
+            kind = LevelAdjustment.Volume,
+            level = adjustmentLevel,
+            segments = levelSegments,
+            visible = adjustment == LevelAdjustment.Volume,
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .padding(horizontal = 48.dp)
         )
     }
 }


### PR DESCRIPTION
The overlay the fullscreen brightness/volume gestures put on screen was a flat white bar in a black pill. It popped in and out with **no animation at all**, hard-cut its icon between states, and hardcoded every colour it used.

It's now a ladder of slats that light from the bottom.

### Why segmented

Volume genuinely *is* stepped — the system exposes it in about fifteen notches — and a continuous bar quietly lied about that. The segment count comes from `getStreamMaxVolume(STREAM_MUSIC)` (clamped 8–16, because a few devices report 7 and some report 100), so **one slat is one real notch** and the haptic tick and the slat lighting are the same event rather than two things that happen near each other.

Brightness is continuous and has no steps of its own. It borrows the same count, which is what keeps the two lanes feeling like one control.

### What carries the value

Three things, deliberately redundantly:

- **How many slats are lit** — the precise reading.
- **How wide the lit stack is** — slats taper from 13dp at the bottom to 30dp at the top, but unlit ones all render at the narrow width, so the wedge is something the level *reveals* rather than a shape that's always sitting there. This is the glanceable reading: 90% isn't just taller than 30%, it's visibly wider.
- **The frontier slat**, which fills fractionally rather than snapping, so fine adjustment inside a step still shows.

Each slat springs on its own, so sweeping fast lights them in a cascade — the stagger falls out of the drag itself and costs no extra machinery.

### Two decisions worth flagging

**Slats are plain capsules, not morphing `MaterialShapes`.** At fifteen segments a slat is ~6dp tall, and a MaterialShape's silhouette isn't readable at that size — you'd pay for a `Morph` per slat and see a blur. The shape lever moved up to the column's silhouette instead.

**Colours are tokens now.** Container is `scrim`; the accent is `primary` in a dark scheme but `inversePrimary` in a light one, because this overlay sits on a dark scrim regardless of app theme and `primary` is a tone-40 in a light palette. `primaryFixed` would've been the textbook answer, but `ColorPalettes.kt` doesn't populate the fixed roles, so all 27 palettes would have rendered baseline purple.

### Also

Haptics the gesture never had: a `SegmentFrequentTick` per notch on both lanes, plus a firmer `GestureThresholdActivate` on arriving at 0 or 100, fired once per arrival rather than every frame the finger keeps pushing.

### Testing

Compiles clean (`compileDebugKotlin`) and installs. Verified on a Pixel 9 API 37 emulator — note that emulator haptics aren't felt, so the tick cadence is unverified on real hardware.

These gestures only arm in landscape fullscreen (`fullscreenGesturesEnabled`, i.e. `FullscreenPlayerContent`), so that's the only place this is visible. Portrait inline and vertical-live have no brightness/volume drag at all — pre-existing, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G96UKaUybB55egux7pePoM