### PR TITLE
Dress the vertical live player in the app's own design language

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,18 +118,29 @@ Undo is a single app-wide `SnackbarHost` at the root of `MainActivity`, fed by `
 
 ### Settings plumbing (adding a new setting)
 
-All app settings live in `data/ThemePreferences.kt` (SharedPreferences `ivor_music_theme_prefs`, one `MutableStateFlow` + KEY constant + private getter + public setter per setting). A new setting must be threaded through **four files**:
+All app settings live in `data/ThemePreferences.kt` (SharedPreferences `ivor_music_theme_prefs`, one `MutableStateFlow` + KEY constant + private getter + public setter per setting). A new setting must be threaded through **five files**:
 
 1. `ThemePreferences` — StateFlow, KEY constant, getter/setter.
 2. `ui/theme/ThemeViewModel.kt` — exposes the flow + a `setX()` delegate.
 3. `MainActivity.kt` — collect the flow in `setContent`, add a param pair to the `MusicApp` composable, pass through to the `SettingsScreen` call inside the `settings` nav route (the params are threaded twice: setContent → MusicApp → SettingsScreen).
-4. `ui/settings/SettingsScreen.kt` — new params + a UI item.
+4. `ui/settings/SettingsScreen.kt` — new params on `SettingsScreen`, passed down to whichever page owns the setting.
+5. `ui/settings/SettingsPages.kt` — the actual row, on the right page.
+
+**Then add it to `buildSettingsSearchIndex` in `ui/settings/SettingsSearch.kt`.** A setting that is not in the index is unfindable by search, and there is no compile error to tell you — that is the one omission here that fails silently.
 
 Theming beyond light/dark: a **color palette** setting (`color_palette` pref, default `dynamic`) chooses between wallpaper-based dynamic color and the predefined palettes in `ui/theme/ColorPalettes.kt`, selected through `ColorPaletteScreen` and applied in `ui/theme/Theme.kt`.
 
 Because there is no DI, every consumer news up its own `ThemePreferences` — StateFlow updates do NOT cross instances. ViewModels that need a setting at decision time must do a fresh pref read (pattern: `isSaveVideoHistoryEnabled()` reads straight from prefs; `VideoPlayerViewModel` already holds a `themePreferences` instance).
 
-`SettingsScreen` layout conventions: sections are `SettingsSection(title)` wrapping `ExpressiveSettingsCard`, rows separated by `SettingsDivider()`. Row composables to copy: `ExpressiveSettingsItem` (icon + title/subtitle clickable row, optional chevron), the various `Expressive*ToggleItem` (switch rows with 48dp icon box, `RoundedCornerShape(14.dp)`, press-scale spring animation), and segmented-button groups (`ExpressiveVideoModeToggleItem`, `ExpressivePlayerStyleSelectItem`). Dialogs (`ExpressiveAboutDialog`, `FolderExclusionDialog`): `AlertDialog` with `containerColor = surfaceContainerHigh`, `shape = RoundedCornerShape(32.dp)`, 64dp rounded icon box, spring `scaleIn` entry via `AnimatedVisibility`. Video-related settings belong in the "Content Mode" section. Material icons extended is available (`Icons.Rounded.*` like `FolderOff`, `SwipeRight` are already used).
+**Settings is a hub and eleven detail pages, not one scroll.** `SettingsScreen.kt` holds the hub, the page router and every dialog; `SettingsPages.kt` holds the pages; `SettingsComponents.kt` holds the shared rows; `SettingsSearch.kt` holds the index and the matcher.
+
+Pages are a `SettingsPage` enum driven by `AnimatedContent`, **not** nav routes — `SettingsScreen` takes 74 parameters and a NavHost destination per category would repeat that list eleven times (the Home tab system makes the same trade). Back unwinds one step at a time: open page → hub → clear the search query → leave. **`SettingsScreen`'s signature is the contract with `MainActivity`**; add parameters, do not reorder or restructure it.
+
+Row composables to copy, all in `SettingsComponents.kt`: `SettingsRow` (icon + title/subtitle, optional chevron), `SettingsToggleRow` (the same with a switch; the whole row is the hit target), `SettingsHubRow` (category + live value), `SettingsCard`, `SettingsSection`, `SettingsDivider`, and `SettingsDetailScaffold` for the page chrome. These read their colors from the theme — do not add `textColor`/`accentColor` parameters back, and never hardcode a color. Destructive or blocked rows take `SettingsRowDefaults.destructiveTint`.
+
+**Every hub row shows the live value of what is inside it** ("Dark, Vibrant", "412 MB cached"). A category row without one is a worse version of the flat list this replaced.
+
+Dialogs (`ExpressiveAboutDialog`, `FolderExclusionDialog`, `StreamQualityDialog`, ...) stay hosted by `SettingsScreen` and are opened by pages through callbacks, because a dialog owned by a page would die with the page transition. `AlertDialog` with `containerColor = surfaceContainerHigh`, `shape = RoundedCornerShape(32.dp)`, 64dp rounded icon box, spring `scaleIn` entry via `AnimatedVisibility`. Material icons extended is available (`Icons.Rounded.*` like `FolderOff`, `SwipeRight` are already used).
 
 ### YouTube data layer (`data/YouTubeRepository.kt`, ~3k lines — the heart of the app)
 
@@ -216,9 +227,11 @@ Adding or renaming a style means touching **four** places (an omission compiles 
 1. `data/ThemePreferences.kt` — the `PlayerStyle` enum constant (persisted by `name`, so treat existing constants as frozen).
 2. `ui/player/<Name>PlayerContent.kt` — a `<Name>PlayerSheetContent(viewModel, ...)` composable, the convention every style follows.
 3. `ui/player/ExpandablePlayer.kt` — a branch in the `when (playerStyle)` around line 305 that calls it. This `when` is the only dispatch point.
-4. Both pickers, which are separate hardcoded lists that must stay in sync: `rememberPlayerStyleWheelEntries()` in `ui/player/PlayerStyleWheel.kt` (label + `Icons.Rounded.*` + a `MaterialShapes` shape) and `playerStyleOptions` in `ui/settings/SettingsScreen.kt` (label + subtitle + icon).
+4. `playerStyleCatalog` in `ui/player/PlayerStyleCatalog.kt` — label, subtitle, icon and the `MaterialShapes` polygon that is the style's die-cut identity in the wheel.
 
-Onboarding (`ui/onboarding/OnboardingScreen.kt`) deliberately offers only `CLASSIC` and `GESTURE` — it is a curated first-run pair, not a list to keep in sync with the other four.
+**The catalog is the only list.** The settings picker, onboarding and `rememberPlayerStyleWheelEntries()` all derive from it, so there is nothing left to keep in sync by hand — that used to be three hardcoded lists and the way one of them went stale. A new style also wants a branch in `PlayerStylePicker`'s `PlayerStylePreview`, which sketches a wireframe of each layout; the `when` there is exhaustive over `PlayerStyle`, so a missing one is a compile error rather than a silent gap.
+
+**Both the settings picker and onboarding show every style.** Onboarding used to offer a curated `CLASSIC`/`GESTURE` pair; that was changed deliberately on request — people pick a look at first run and were not finding the other six. `PlayerStylePicker` is non-lazy for exactly this reason: it renders inside onboarding's `verticalScroll` column and inside the settings page's `LazyColumn` item, and a lazy grid nested in a scrollable parent has unbounded height.
 
 ### Reference docs in-repo
 

--- a/app/src/main/java/com/ivor/ivormusic/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/onboarding/OnboardingScreen.kt
@@ -112,6 +112,7 @@ import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
 import com.ivor.ivormusic.data.PlayerStyle
+import com.ivor.ivormusic.ui.player.PlayerStylePicker
 import com.ivor.ivormusic.data.SessionManager
 import com.ivor.ivormusic.ui.auth.YouTubeAuthDialog
 import com.ivor.ivormusic.ui.theme.ThemeMode
@@ -684,23 +685,16 @@ private fun LookAndFeelPage(
         )
 
         ChoiceCard(title = "Player style") {
-            ConnectedChoiceGroup(
-                options = listOf(
-                    PlayerStyle.CLASSIC to "Classic",
-                    PlayerStyle.GESTURE to "Gesture"
-                ),
-                selected = playerStyle,
-                onSelect = onPlayerStyleChange
-            )
-            Spacer(modifier = Modifier.height(8.dp))
             Text(
-                text = if (playerStyle == PlayerStyle.GESTURE) {
-                    "Swipe-driven player with fluid, physical motion."
-                } else {
-                    "Familiar buttons for play, pause and skipping."
-                },
+                text = "Pick the player you want. You can change it any time in " +
+                    "Settings, or by long-pressing the artwork while a song plays.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            PlayerStylePicker(
+                currentStyle = playerStyle,
+                onStyleSelected = onPlayerStyleChange
             )
         }
     }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerStyleCatalog.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerStyleCatalog.kt
@@ -1,0 +1,523 @@
+package com.ivor.ivormusic.ui.player
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Animation
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material.icons.rounded.GridView
+import androidx.compose.material.icons.rounded.Interests
+import androidx.compose.material.icons.rounded.Newspaper
+import androidx.compose.material.icons.rounded.PlayCircle
+import androidx.compose.material.icons.rounded.RadioButtonChecked
+import androidx.compose.material.icons.rounded.SwipeRight
+import androidx.compose.material.icons.rounded.Wallpaper
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialShapes
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.graphics.shapes.RoundedPolygon
+import com.ivor.ivormusic.data.PlayerStyle
+
+/**
+ * The one description of a player style.
+ *
+ * There used to be three hardcoded lists - the settings chips, the onboarding
+ * pair and the style wheel - and adding a style meant remembering all of them.
+ * They now all read this, so a new style is one entry here plus the branch in
+ * [ExpandablePlayer] that renders it.
+ *
+ * [polygon] is the die-cut identity the wheel blooms into; shape signals which
+ * style you are aiming at before the label is readable.
+ */
+internal data class PlayerStyleInfo(
+    val style: PlayerStyle,
+    val label: String,
+    val subtitle: String,
+    val icon: ImageVector,
+    val polygon: RoundedPolygon
+)
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+internal val playerStyleCatalog: List<PlayerStyleInfo> = listOf(
+    PlayerStyleInfo(
+        PlayerStyle.CLASSIC, "Classic", "Button controls for playback",
+        Icons.Rounded.PlayCircle, MaterialShapes.Circle
+    ),
+    PlayerStyleInfo(
+        PlayerStyle.GESTURE, "Gesture", "Swipe album art to navigate",
+        Icons.Rounded.SwipeRight, MaterialShapes.Pill
+    ),
+    PlayerStyleInfo(
+        PlayerStyle.EDITORIAL, "Editorial", "Two-tone magazine layout",
+        Icons.Rounded.Newspaper, MaterialShapes.Flower
+    ),
+    // The enum key stays POSTER for SharedPreferences compatibility; every
+    // user-facing string says Canvas.
+    PlayerStyleInfo(
+        PlayerStyle.POSTER, "Canvas", "Full-bleed album art",
+        Icons.Rounded.Wallpaper, MaterialShapes.Gem
+    ),
+    PlayerStyleInfo(
+        PlayerStyle.BENTO, "Bento", "Squishy grid of flat tiles",
+        Icons.Rounded.GridView, MaterialShapes.Cookie4Sided
+    ),
+    PlayerStyleInfo(
+        PlayerStyle.STICKER, "Sticker", "Die-cut art with toy physics",
+        Icons.Rounded.Interests, MaterialShapes.Clover4Leaf
+    ),
+    PlayerStyleInfo(
+        PlayerStyle.MORPH, "Morph", "Living shape that breathes",
+        Icons.Rounded.Animation, MaterialShapes.SoftBurst
+    ),
+    PlayerStyleInfo(
+        PlayerStyle.DIAL, "Dial", "Rotary ring, spin to scrub",
+        Icons.Rounded.RadioButtonChecked, MaterialShapes.Sunny
+    )
+)
+
+internal fun playerStyleInfo(style: PlayerStyle): PlayerStyleInfo =
+    playerStyleCatalog.firstOrNull { it.style == style } ?: playerStyleCatalog.first()
+
+/**
+ * Picks a player style from a grid of tiles that each draw a miniature of the
+ * layout they select.
+ *
+ * A name and an icon do not tell anyone what "Bento" or "Editorial" will look
+ * like, and this is a choice about appearance - so each tile sketches the real
+ * thing: Classic has its button row, Bento its grid of tiles, Dial its ring.
+ *
+ * Deliberately not lazy. It renders inside a scrolling settings page and inside
+ * onboarding's `verticalScroll` column, and a lazy grid nested in a scrollable
+ * parent has unbounded height.
+ */
+@Composable
+internal fun PlayerStylePicker(
+    currentStyle: PlayerStyle,
+    onStyleSelected: (PlayerStyle) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        playerStyleCatalog.chunked(2).forEach { row ->
+            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                row.forEach { info ->
+                    PlayerStyleTile(
+                        info = info,
+                        selected = info.style == currentStyle,
+                        onClick = { onStyleSelected(info.style) },
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+                // Keeps a trailing odd tile at half width instead of stretching
+                // it across the row.
+                if (row.size == 1) Spacer(modifier = Modifier.weight(1f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlayerStyleTile(
+    info: PlayerStyleInfo,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.96f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
+        label = "tileScale"
+    )
+
+    val containerColor = if (selected) {
+        MaterialTheme.colorScheme.primaryContainer
+    } else {
+        MaterialTheme.colorScheme.surfaceContainerHigh
+    }
+    val labelColor = if (selected) {
+        MaterialTheme.colorScheme.onPrimaryContainer
+    } else {
+        MaterialTheme.colorScheme.onSurface
+    }
+
+    Column(
+        modifier = modifier
+            .scale(scale)
+            .clip(RoundedCornerShape(20.dp))
+            .background(containerColor)
+            .then(
+                if (selected) {
+                    Modifier.border(
+                        width = 2.dp,
+                        color = MaterialTheme.colorScheme.primary,
+                        shape = RoundedCornerShape(20.dp)
+                    )
+                } else {
+                    Modifier
+                }
+            )
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick
+            )
+            .padding(10.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1.25f)
+                .clip(RoundedCornerShape(12.dp))
+                .background(MaterialTheme.colorScheme.surface)
+        ) {
+            PlayerStylePreview(
+                style = info.style,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(8.dp)
+            )
+
+            if (selected) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(4.dp)
+                        .size(18.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.primary),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.Check,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimary,
+                        modifier = Modifier.size(12.dp)
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = info.label,
+            color = labelColor,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        Text(
+            text = info.subtitle,
+            color = if (selected) {
+                MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.75f)
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            },
+            fontSize = 11.sp,
+            lineHeight = 14.sp,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+/**
+ * A wireframe of each player style, abstract enough to stay honest when the
+ * real screens change but specific enough to be recognisable.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun PlayerStylePreview(style: PlayerStyle, modifier: Modifier = Modifier) {
+    val art = MaterialTheme.colorScheme.primary
+    val soft = MaterialTheme.colorScheme.primary.copy(alpha = 0.28f)
+    val line = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f)
+
+    Box(modifier = modifier) {
+        when (style) {
+            // Square art, a title, and the row of transport buttons.
+            PlayerStyle.CLASSIC -> Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .aspectRatio(1f)
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(art)
+                )
+                PreviewLine(color = line, widthFraction = 0.6f)
+                Row(horizontalArrangement = Arrangement.spacedBy(5.dp)) {
+                    repeat(3) { index ->
+                        Box(
+                            modifier = Modifier
+                                .size(if (index == 1) 10.dp else 7.dp)
+                                .clip(CircleShape)
+                                .background(if (index == 1) art else soft)
+                        )
+                    }
+                }
+            }
+
+            // Art card with the neighbouring tracks peeking in from both sides.
+            PlayerStyle.GESTURE -> Row(
+                modifier = Modifier.fillMaxSize(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .width(8.dp)
+                        .fillMaxHeight(0.55f)
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(soft)
+                )
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight(0.8f)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(art)
+                )
+                Box(
+                    modifier = Modifier
+                        .width(8.dp)
+                        .fillMaxHeight(0.55f)
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(soft)
+                )
+            }
+
+            // Two-tone split with a stack of headline rules.
+            PlayerStyle.EDITORIAL -> Column(modifier = Modifier.fillMaxSize()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                        .clip(RoundedCornerShape(topStart = 6.dp, topEnd = 6.dp))
+                        .background(art)
+                )
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                        .clip(RoundedCornerShape(bottomStart = 6.dp, bottomEnd = 6.dp))
+                        .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                        .padding(6.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    PreviewLine(color = line, widthFraction = 0.9f)
+                    PreviewLine(color = line, widthFraction = 0.65f)
+                    PreviewLine(color = line, widthFraction = 0.4f)
+                }
+            }
+
+            // Edge-to-edge art with the text scrim across the bottom.
+            PlayerStyle.POSTER -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(art)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .fillMaxWidth()
+                        .padding(6.dp),
+                    verticalArrangement = Arrangement.spacedBy(3.dp)
+                ) {
+                    PreviewLine(
+                        color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.9f),
+                        widthFraction = 0.7f
+                    )
+                    PreviewLine(
+                        color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.55f),
+                        widthFraction = 0.45f
+                    )
+                }
+            }
+
+            // Grid of unequal tiles.
+            PlayerStyle.BENTO -> Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1.4f),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .weight(1.6f)
+                            .fillMaxHeight()
+                            .clip(RoundedCornerShape(6.dp))
+                            .background(art)
+                    )
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxHeight(),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .weight(1f)
+                                .clip(RoundedCornerShape(5.dp))
+                                .background(soft)
+                        )
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .weight(1f)
+                                .clip(RoundedCornerShape(5.dp))
+                                .background(soft)
+                        )
+                    }
+                }
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    repeat(3) {
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxHeight()
+                                .clip(RoundedCornerShape(5.dp))
+                                .background(soft)
+                        )
+                    }
+                }
+            }
+
+            // Die-cut artwork, tilted like a sticker that has been peeled on.
+            PlayerStyle.STICKER -> Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                PreviewPolygon(
+                    polygon = MaterialShapes.Clover4Leaf,
+                    color = art,
+                    modifier = Modifier
+                        .fillMaxSize(0.82f)
+                        .rotate(-12f)
+                )
+            }
+
+            // One soft blob, mid-breath.
+            PlayerStyle.MORPH -> Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                PreviewPolygon(
+                    polygon = MaterialShapes.SoftBurst,
+                    color = art,
+                    modifier = Modifier.fillMaxSize(0.9f)
+                )
+            }
+
+            // Scrub ring with its handle.
+            PlayerStyle.DIAL -> Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxHeight(0.92f)
+                        .aspectRatio(1f)
+                        .clip(CircleShape)
+                        .border(width = 4.dp, color = soft, shape = CircleShape),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize(0.42f)
+                            .clip(CircleShape)
+                            .background(art)
+                    )
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.TopCenter)
+                            .size(7.dp)
+                            .clip(CircleShape)
+                            .background(art)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PreviewLine(color: Color, widthFraction: Float) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth(widthFraction)
+            .height(3.dp)
+            .clip(RoundedCornerShape(2.dp))
+            .background(color)
+    )
+}
+
+@Composable
+private fun PreviewPolygon(
+    polygon: RoundedPolygon,
+    color: Color,
+    modifier: Modifier = Modifier
+) {
+    val shape = remember(polygon) { EditorialPolygonShape(polygon) }
+    Box(
+        modifier = modifier
+            .clip(shape)
+            .background(color)
+    )
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerStyleWheel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerStyleWheel.kt
@@ -182,19 +182,16 @@ fun Modifier.styleWheelHold(controller: PlayerStyleWheelController?): Modifier {
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+/**
+ * Derived from [playerStyleCatalog] rather than listed again here - the wheel,
+ * the settings picker and onboarding all describe the same eight styles, and
+ * keeping three copies in step by hand is how one of them goes stale.
+ */
 @Composable
 internal fun rememberPlayerStyleWheelEntries(): List<PlayerStyleWheelEntry> = remember {
-    listOf(
-        PlayerStyleWheelEntry(PlayerStyle.CLASSIC, "Classic", Icons.Rounded.PlayCircle, MaterialShapes.Circle),
-        PlayerStyleWheelEntry(PlayerStyle.GESTURE, "Gesture", Icons.Rounded.SwipeRight, MaterialShapes.Pill),
-        PlayerStyleWheelEntry(PlayerStyle.EDITORIAL, "Editorial", Icons.Rounded.Newspaper, MaterialShapes.Flower),
-        PlayerStyleWheelEntry(PlayerStyle.POSTER, "Canvas", Icons.Rounded.Wallpaper, MaterialShapes.Gem),
-        PlayerStyleWheelEntry(PlayerStyle.BENTO, "Bento", Icons.Rounded.GridView, MaterialShapes.Cookie4Sided),
-        PlayerStyleWheelEntry(PlayerStyle.STICKER, "Sticker", Icons.Rounded.Interests, MaterialShapes.Clover4Leaf),
-        PlayerStyleWheelEntry(PlayerStyle.MORPH, "Morph", Icons.Rounded.Animation, MaterialShapes.SoftBurst),
-        PlayerStyleWheelEntry(PlayerStyle.DIAL, "Dial", Icons.Rounded.RadioButtonChecked, MaterialShapes.Sunny)
-    )
+    playerStyleCatalog.map { info ->
+        PlayerStyleWheelEntry(info.style, info.label, info.icon, info.polygon)
+    }
 }
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)

--- a/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsComponents.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsComponents.kt
@@ -1,0 +1,401 @@
+package com.ivor.ivormusic.ui.settings
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.ChevronRight
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Shared building blocks for the settings hub and its detail pages.
+ *
+ * These replace the dozen near-identical `Expressive*ToggleItem` composables the
+ * settings screen used to carry, which differed from each other only by icon,
+ * title and subtitle. Colors are resolved from the theme here instead of being
+ * threaded in as parameters, because every call site passed the same three
+ * roles - only the destructive rows ever wanted something else, and those say so
+ * with [SettingsRowDefaults.destructiveTint].
+ */
+
+object SettingsRowDefaults {
+    /**
+     * Tint for rows whose action is hard to take back (clear the cache, sign
+     * out) or that report a problem the user has to leave the app to fix.
+     */
+    val destructiveTint: Color
+        @Composable get() = MaterialTheme.colorScheme.error
+}
+
+@Composable
+internal fun SettingsSection(
+    title: String,
+    content: @Composable () -> Unit
+) {
+    // No entrance animation on purpose: these live in a LazyColumn, which
+    // recomposes items as they scroll into view - any enter animation replays
+    // on every scroll and makes the cards look like they're "loading".
+    Column {
+        Text(
+            text = title.uppercase(),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.SemiBold,
+            letterSpacing = 1.2.sp,
+            modifier = Modifier.padding(start = 8.dp, bottom = 10.dp)
+        )
+        content()
+    }
+}
+
+@Composable
+internal fun SettingsCard(
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(24.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        tonalElevation = 2.dp,
+        shadowElevation = 0.dp
+    ) {
+        Column(modifier = Modifier.padding(6.dp), content = content)
+    }
+}
+
+/**
+ * Icon + title/subtitle row that opens something else - a dialog, a page, an
+ * Android settings screen. [showChevron] is for the ones that navigate; leave it
+ * off for rows that act in place.
+ */
+@Composable
+internal fun SettingsRow(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit,
+    tint: Color = MaterialTheme.colorScheme.primary,
+    titleColor: Color = MaterialTheme.colorScheme.onBackground,
+    showChevron: Boolean = false
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.97f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
+        label = "rowScale"
+    )
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .scale(scale)
+            .clip(RoundedCornerShape(18.dp))
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick
+            )
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        SettingsRowIcon(icon = icon, tint = tint)
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                color = titleColor,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = subtitle,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 13.sp
+            )
+        }
+
+        if (showChevron) {
+            Icon(
+                imageVector = Icons.Rounded.ChevronRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(24.dp)
+            )
+        }
+    }
+}
+
+/**
+ * Icon + title/subtitle row with a switch. The whole row is the hit target, not
+ * just the switch.
+ */
+@Composable
+internal fun SettingsToggleRow(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    enabled: Boolean,
+    onToggle: (Boolean) -> Unit,
+    tint: Color = MaterialTheme.colorScheme.primary
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.97f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
+        label = "toggleScale"
+    )
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .scale(scale)
+            .clip(RoundedCornerShape(18.dp))
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null
+            ) { onToggle(!enabled) }
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        SettingsRowIcon(icon = icon, tint = tint)
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                color = MaterialTheme.colorScheme.onBackground,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = subtitle,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 13.sp
+            )
+        }
+
+        Switch(
+            checked = enabled,
+            onCheckedChange = onToggle,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = MaterialTheme.colorScheme.onPrimary,
+                checkedTrackColor = tint,
+                uncheckedThumbColor = MaterialTheme.colorScheme.outline,
+                uncheckedTrackColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                uncheckedBorderColor = Color.Transparent,
+                checkedBorderColor = Color.Transparent
+            )
+        )
+    }
+}
+
+/** The 48dp tinted icon box every settings row leads with. */
+@Composable
+private fun SettingsRowIcon(icon: ImageVector, tint: Color) {
+    Box(
+        modifier = Modifier
+            .size(48.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(tint.copy(alpha = 0.12f)),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = tint,
+            modifier = Modifier.size(26.dp)
+        )
+    }
+}
+
+@Composable
+internal fun SettingsDivider() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 4.dp)
+            .height(1.dp)
+            .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+    )
+}
+
+/**
+ * One category on the settings hub. [value] is the live state of whatever lives
+ * inside, so the hub can be read without opening every page - that is the whole
+ * point of splitting the screen up, and a row without it is a worse version of
+ * the flat list it replaced.
+ */
+@Composable
+internal fun SettingsHubRow(
+    icon: ImageVector,
+    title: String,
+    value: String,
+    onClick: () -> Unit,
+    tint: Color = MaterialTheme.colorScheme.primary
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.97f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
+        label = "hubScale"
+    )
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .scale(scale)
+            .clip(RoundedCornerShape(18.dp))
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick
+            )
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        SettingsRowIcon(icon = icon, tint = tint)
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                color = MaterialTheme.colorScheme.onBackground,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = value,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 13.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
+        Icon(
+            imageVector = Icons.Rounded.ChevronRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(24.dp)
+        )
+    }
+}
+
+/**
+ * Chrome shared by every settings detail page: the back-to-hub bar plus the
+ * scrolling body. Pages supply `item { }` blocks so long lists (the palette of
+ * player styles, a folder list) still recycle.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+internal fun SettingsDetailScaffold(
+    title: String,
+    onBack: () -> Unit,
+    content: LazyListScope.() -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+    ) {
+        TopAppBar(
+            title = {
+                Text(
+                    text = title,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.headlineSmall,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            },
+            navigationIcon = {
+                IconButton(
+                    onClick = onBack,
+                    shapes = IconButtonDefaults.shapes(),
+                    colors = IconButtonDefaults.iconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        contentColor = MaterialTheme.colorScheme.onBackground
+                    ),
+                    modifier = Modifier
+                        .padding(start = 8.dp)
+                        .size(44.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                        contentDescription = "Back"
+                    )
+                }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
+            modifier = Modifier.windowInsetsPadding(WindowInsets.statusBars)
+        )
+
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp)
+        ) {
+            content()
+            item { Spacer(modifier = Modifier.height(32.dp)) }
+        }
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsPages.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsPages.kt
@@ -1,0 +1,1090 @@
+package com.ivor.ivormusic.ui.settings
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.Comment
+import androidx.compose.material.icons.automirrored.rounded.Logout
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
+import androidx.compose.material.icons.rounded.BookmarkAdd
+import androidx.compose.material.icons.rounded.Bolt
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.CloudOff
+import androidx.compose.material.icons.rounded.Contrast
+import androidx.compose.material.icons.rounded.Cookie
+import androidx.compose.material.icons.rounded.FilterList
+import androidx.compose.material.icons.rounded.FlashOn
+import androidx.compose.material.icons.rounded.Folder
+import androidx.compose.material.icons.rounded.FolderOff
+import androidx.compose.material.icons.rounded.GraphicEq
+import androidx.compose.material.icons.rounded.HdrOn
+import androidx.compose.material.icons.rounded.HighQuality
+import androidx.compose.material.icons.rounded.Info
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.NotInterested
+import androidx.compose.material.icons.rounded.Palette
+import androidx.compose.material.icons.rounded.Save
+import androidx.compose.material.icons.rounded.Security
+import androidx.compose.material.icons.rounded.SignalCellularAlt
+import androidx.compose.material.icons.rounded.Subscriptions
+import androidx.compose.material.icons.rounded.ToggleOn
+import androidx.compose.material.icons.rounded.VideoLibrary
+import androidx.compose.material.icons.rounded.Visibility
+import androidx.compose.material.icons.rounded.Wifi
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.ivor.ivormusic.data.CacheManager
+import com.ivor.ivormusic.data.PlayerStyle
+import com.ivor.ivormusic.data.SessionManager
+import com.ivor.ivormusic.data.ThemePreferences
+import com.ivor.ivormusic.ui.theme.ThemeMode
+
+/**
+ * The settings detail pages. Each one owns a single category from the hub.
+ *
+ * The re-sort matters as much as the split: video quality used to sit under
+ * "Content Mode" while music quality sat under "Playback", so the same decision
+ * lived in two places. Both now live on [PlaybackSettingsPage] behind one
+ * Wi-Fi/mobile switch.
+ */
+
+/* ------------------------------------------------------------------ */
+/* Account                                                             */
+/* ------------------------------------------------------------------ */
+
+@Composable
+internal fun AccountSettingsPage(
+    isLoggedIn: Boolean,
+    accountRefreshKey: Int,
+    sessionManager: SessionManager,
+    saveVideoHistory: Boolean,
+    onSaveVideoHistoryToggle: (Boolean) -> Unit,
+    onShowAuthDialog: () -> Unit,
+    onShowCookieSheet: () -> Unit,
+    onSignOut: () -> Unit,
+    onBack: () -> Unit
+) {
+    SettingsDetailScaffold(title = "Account", onBack = onBack) {
+        if (isLoggedIn) {
+            item {
+                SettingsSection(title = "YouTube Music") {
+                    SettingsCard {
+                        key(accountRefreshKey) {
+                            ExpressiveAccountItem(
+                                sessionManager = sessionManager,
+                                textColor = MaterialTheme.colorScheme.onBackground,
+                                secondaryTextColor = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        SettingsDivider()
+                        SettingsToggleRow(
+                            icon = Icons.Rounded.CheckCircle,
+                            title = "Save Watch History",
+                            subtitle = if (saveVideoHistory) {
+                                "Videos you watch are added to your YouTube history"
+                            } else {
+                                "Watching does not touch your YouTube history"
+                            },
+                            enabled = saveVideoHistory,
+                            onToggle = onSaveVideoHistoryToggle
+                        )
+                        SettingsDivider()
+                        SettingsRow(
+                            icon = Icons.Rounded.Cookie,
+                            title = "Replace Session Cookies",
+                            subtitle = "Paste a fresh cookie header if your session goes stale",
+                            onClick = onShowCookieSheet,
+                            showChevron = true
+                        )
+                    }
+                }
+            }
+
+            item {
+                SettingsCard {
+                    SettingsRow(
+                        icon = Icons.AutoMirrored.Rounded.Logout,
+                        title = "Sign Out",
+                        subtitle = "Disconnect your YouTube account",
+                        onClick = onSignOut,
+                        tint = SettingsRowDefaults.destructiveTint,
+                        titleColor = SettingsRowDefaults.destructiveTint
+                    )
+                }
+            }
+        } else {
+            // Signed out is a supported state, not an error - say what signing
+            // in buys rather than nagging.
+            item {
+                SettingsNotice(
+                    icon = Icons.Rounded.Info,
+                    text = "Koda works signed out. Signing in adds your playlists, " +
+                        "liked songs, subscriptions and watch history."
+                )
+            }
+
+            item {
+                SettingsSection(title = "YouTube Music") {
+                    SettingsCard {
+                        SettingsRow(
+                            icon = Icons.Rounded.MusicNote,
+                            title = "Connect YouTube Music",
+                            subtitle = "Sign in to access your playlists and liked songs",
+                            onClick = onShowAuthDialog,
+                            showChevron = true
+                        )
+                        SettingsDivider()
+                        SettingsRow(
+                            icon = Icons.Rounded.Cookie,
+                            title = "Sign In With Cookies",
+                            subtitle = "Paste a cookie header instead of using the web sign-in",
+                            onClick = onShowCookieSheet,
+                            showChevron = true
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Appearance                                                          */
+/* ------------------------------------------------------------------ */
+
+@Composable
+internal fun AppearanceSettingsPage(
+    currentThemeMode: ThemeMode,
+    onThemeModeChange: (ThemeMode) -> Unit,
+    colorPalette: String,
+    onNavigateToColorPalette: () -> Unit,
+    amoledTheme: Boolean,
+    onAmoledThemeToggle: (Boolean) -> Unit,
+    ambientBackground: Boolean,
+    onAmbientBackgroundToggle: (Boolean) -> Unit,
+    onBack: () -> Unit
+) {
+    val paletteName = if (colorPalette == ThemePreferences.DEFAULT_COLOR_PALETTE) {
+        "Dynamic (from wallpaper)"
+    } else {
+        com.ivor.ivormusic.ui.theme.findPalette(colorPalette)?.name ?: "Dynamic"
+    }
+
+    SettingsDetailScaffold(title = "Appearance", onBack = onBack) {
+        item {
+            SettingsSection(title = "Theme") {
+                SettingsCard {
+                    ExpressiveThemeSelectGroup(
+                        currentMode = currentThemeMode,
+                        onModeSelected = onThemeModeChange,
+                        textColor = MaterialTheme.colorScheme.onBackground,
+                        accentColor = MaterialTheme.colorScheme.primary
+                    )
+                    SettingsDivider()
+                    SettingsRow(
+                        icon = Icons.Rounded.Palette,
+                        title = "Color palette",
+                        subtitle = paletteName,
+                        onClick = onNavigateToColorPalette,
+                        showChevron = true
+                    )
+                    SettingsDivider()
+                    SettingsToggleRow(
+                        icon = Icons.Rounded.Contrast,
+                        title = "AMOLED Black",
+                        subtitle = if (amoledTheme) {
+                            "Pure black backgrounds in dark theme"
+                        } else {
+                            "Standard dark backgrounds"
+                        },
+                        enabled = amoledTheme,
+                        onToggle = onAmoledThemeToggle
+                    )
+                }
+            }
+        }
+
+        item {
+            SettingsSection(title = "Backgrounds") {
+                SettingsCard {
+                    SettingsToggleRow(
+                        icon = Icons.Rounded.Palette,
+                        title = "Ambient Background",
+                        subtitle = if (ambientBackground) {
+                            "Dynamic colors from album art"
+                        } else {
+                            "Solid background"
+                        },
+                        enabled = ambientBackground,
+                        onToggle = onAmbientBackgroundToggle
+                    )
+                }
+            }
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Player                                                              */
+/* ------------------------------------------------------------------ */
+
+@Composable
+internal fun PlayerSettingsPage(
+    playerStyle: PlayerStyle,
+    onPlayerStyleChange: (PlayerStyle) -> Unit,
+    playerArtworkColors: Boolean,
+    onPlayerArtworkColorsToggle: (Boolean) -> Unit,
+    onBack: () -> Unit
+) {
+    SettingsDetailScaffold(title = "Player", onBack = onBack) {
+        item {
+            SettingsSection(title = "Style") {
+                SettingsCard {
+                    ExpressivePlayerStyleSelectItem(
+                        currentStyle = playerStyle,
+                        onStyleSelected = onPlayerStyleChange,
+                        textColor = MaterialTheme.colorScheme.onBackground,
+                        secondaryTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        accentColor = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+        }
+
+        item {
+            SettingsSection(title = "Colors") {
+                SettingsCard {
+                    SettingsToggleRow(
+                        icon = Icons.Rounded.Palette,
+                        title = "Album Art Colors",
+                        subtitle = "Color the expanded player's buttons from the current cover",
+                        enabled = playerArtworkColors,
+                        onToggle = onPlayerArtworkColorsToggle
+                    )
+                }
+            }
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Playback and quality                                                */
+/* ------------------------------------------------------------------ */
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+internal fun PlaybackSettingsPage(
+    crossfadeEnabled: Boolean,
+    onCrossfadeEnabledToggle: (Boolean) -> Unit,
+    crossfadeDurationMs: Int,
+    onCrossfadeDurationChange: (Int) -> Unit,
+    autoLoadQueue: Boolean,
+    onAutoLoadQueueToggle: (Boolean) -> Unit,
+    musicQualityWifi: String,
+    musicQualityMobile: String,
+    videoQualityWifi: String,
+    videoQualityMobile: String,
+    preferHdr: Boolean,
+    onPreferHdrToggle: (Boolean) -> Unit,
+    onOpenQualityPicker: (QualityDialogTarget) -> Unit,
+    onBack: () -> Unit
+) {
+    // Which network the quality rows below are talking about. Reframing the
+    // whole block beats four near-identical rows that each name their network
+    // in the title.
+    var showingWifi by remember { mutableStateOf(true) }
+
+    SettingsDetailScaffold(title = "Playback and quality", onBack = onBack) {
+        item {
+            SettingsSection(title = "Playback") {
+                SettingsCard {
+                    SettingsToggleRow(
+                        icon = Icons.Rounded.GraphicEq,
+                        title = "Crossfade",
+                        subtitle = "Smoothly fade between songs",
+                        enabled = crossfadeEnabled,
+                        onToggle = onCrossfadeEnabledToggle
+                    )
+
+                    AnimatedVisibility(
+                        visible = crossfadeEnabled,
+                        enter = fadeIn(tween(200)) + slideInVertically(
+                            initialOffsetY = { -it / 4 },
+                            animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
+                        ),
+                        exit = fadeOut(tween(150))
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 8.dp)
+                        ) {
+                            Text(
+                                text = "Duration: ${crossfadeDurationMs / 1000}s",
+                                color = MaterialTheme.colorScheme.onBackground,
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.Medium
+                            )
+                            Slider(
+                                value = crossfadeDurationMs.toFloat(),
+                                onValueChange = { onCrossfadeDurationChange(it.toInt()) },
+                                valueRange = 1000f..12000f,
+                                steps = 10,
+                                colors = SliderDefaults.colors(
+                                    thumbColor = MaterialTheme.colorScheme.primary,
+                                    activeTrackColor = MaterialTheme.colorScheme.primary
+                                )
+                            )
+                        }
+                    }
+
+                    SettingsDivider()
+
+                    SettingsToggleRow(
+                        icon = Icons.AutoMirrored.Rounded.QueueMusic,
+                        title = "Auto-load Queue",
+                        subtitle = "Add recommended songs when the queue runs low",
+                        enabled = autoLoadQueue,
+                        onToggle = onAutoLoadQueueToggle
+                    )
+                }
+            }
+        }
+
+        item {
+            SettingsSection(title = "Streaming quality") {
+                SettingsCard {
+                    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp)) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Box(
+                                modifier = Modifier
+                                    .size(48.dp)
+                                    .clip(RoundedCornerShape(14.dp))
+                                    .background(
+                                        MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+                                    ),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Rounded.HighQuality,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier.size(26.dp)
+                                )
+                            }
+                            Spacer(modifier = Modifier.width(16.dp))
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = "Quality per network",
+                                    color = MaterialTheme.colorScheme.onBackground,
+                                    fontSize = 16.sp,
+                                    fontWeight = FontWeight.SemiBold
+                                )
+                                Spacer(modifier = Modifier.height(2.dp))
+                                Text(
+                                    text = "Koda picks these based on the connection in use",
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    fontSize = 13.sp
+                                )
+                            }
+                        }
+
+                        Spacer(modifier = Modifier.height(14.dp))
+
+                        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                            SegmentedButton(
+                                selected = showingWifi,
+                                onClick = { showingWifi = true },
+                                shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+                                icon = {
+                                    SegmentedButtonDefaults.Icon(active = showingWifi) {
+                                        Icon(
+                                            imageVector = Icons.Rounded.Wifi,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(18.dp)
+                                        )
+                                    }
+                                }
+                            ) {
+                                Text("Wi-Fi")
+                            }
+                            SegmentedButton(
+                                selected = !showingWifi,
+                                onClick = { showingWifi = false },
+                                shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+                                icon = {
+                                    SegmentedButtonDefaults.Icon(active = !showingWifi) {
+                                        Icon(
+                                            imageVector = Icons.Rounded.SignalCellularAlt,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(18.dp)
+                                        )
+                                    }
+                                }
+                            ) {
+                                Text("Mobile data")
+                            }
+                        }
+                    }
+
+                    SettingsDivider()
+
+                    SettingsRow(
+                        icon = Icons.Rounded.MusicNote,
+                        title = "Music quality",
+                        subtitle = musicQualityLabel(
+                            if (showingWifi) musicQualityWifi else musicQualityMobile
+                        ),
+                        onClick = {
+                            onOpenQualityPicker(
+                                if (showingWifi) QualityDialogTarget.MUSIC_WIFI
+                                else QualityDialogTarget.MUSIC_MOBILE
+                            )
+                        },
+                        showChevron = true
+                    )
+
+                    SettingsDivider()
+
+                    SettingsRow(
+                        icon = Icons.Rounded.VideoLibrary,
+                        title = "Video quality",
+                        subtitle = videoQualityLabel(
+                            if (showingWifi) videoQualityWifi else videoQualityMobile
+                        ),
+                        onClick = {
+                            onOpenQualityPicker(
+                                if (showingWifi) QualityDialogTarget.VIDEO_WIFI
+                                else QualityDialogTarget.VIDEO_MOBILE
+                            )
+                        },
+                        showChevron = true
+                    )
+
+                    SettingsDivider()
+
+                    SettingsToggleRow(
+                        icon = Icons.Rounded.HdrOn,
+                        title = "Prefer HDR Videos",
+                        subtitle = "Fetch HDR streams when a video has them",
+                        enabled = preferHdr,
+                        onToggle = onPreferHdrToggle
+                    )
+                }
+            }
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Content and feeds                                                   */
+/* ------------------------------------------------------------------ */
+
+@Composable
+internal fun ContentSettingsPage(
+    localOnlyMode: Boolean,
+    onLocalOnlyModeToggle: (Boolean) -> Unit,
+    videoMode: Boolean,
+    onVideoModeToggle: (Boolean) -> Unit,
+    homeModeToggleEnabled: Boolean,
+    onHomeModeToggleChange: (Boolean) -> Unit,
+    timedCommentsEnabled: Boolean,
+    onTimedCommentsToggle: (Boolean) -> Unit,
+    shortsEnabled: Boolean,
+    onShortsEnabledToggle: (Boolean) -> Unit,
+    shortsHiddenActions: Set<String>,
+    onShowShortsButtons: () -> Unit,
+    onNavigateToNotInterested: () -> Unit,
+    onBack: () -> Unit
+) {
+    SettingsDetailScaffold(title = "Content and feeds", onBack = onBack) {
+        item {
+            SettingsSection(title = "Mode") {
+                SettingsCard {
+                    SettingsToggleRow(
+                        icon = Icons.Rounded.CloudOff,
+                        title = "Local Only",
+                        subtitle = if (localOnlyMode) {
+                            "Offline: device library only, no internet"
+                        } else {
+                            "YouTube features enabled"
+                        },
+                        enabled = localOnlyMode,
+                        onToggle = onLocalOnlyModeToggle
+                    )
+
+                    // Everything below is about YouTube content, which local-only
+                    // mode switches off wholesale.
+                    AnimatedVisibility(
+                        visible = !localOnlyMode,
+                        enter = fadeIn(tween(200)) + slideInVertically(
+                            initialOffsetY = { -it / 4 },
+                            animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
+                        ),
+                        exit = fadeOut(tween(150))
+                    ) {
+                        Column {
+                            SettingsDivider()
+                            ExpressiveVideoModeToggleItem(
+                                enabled = videoMode,
+                                onToggle = onVideoModeToggle,
+                                textColor = MaterialTheme.colorScheme.onBackground,
+                                secondaryTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                accentColor = MaterialTheme.colorScheme.primary
+                            )
+                            SettingsDivider()
+                            SettingsToggleRow(
+                                icon = Icons.Rounded.ToggleOn,
+                                title = "Home Screen Mode Toggle",
+                                subtitle = if (homeModeToggleEnabled) {
+                                    "Switch music and video from the Home header"
+                                } else {
+                                    "Change the mode here in Settings only"
+                                },
+                                enabled = homeModeToggleEnabled,
+                                onToggle = onHomeModeToggleChange
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!localOnlyMode) {
+            item {
+                SettingsSection(title = "Video") {
+                    SettingsCard {
+                        SettingsToggleRow(
+                            icon = Icons.AutoMirrored.Rounded.Comment,
+                            title = "Timed Comments",
+                            subtitle = if (timedCommentsEnabled) {
+                                "Comments appear on the seek bar where they were posted"
+                            } else {
+                                "Comments stay in the comment sheet"
+                            },
+                            enabled = timedCommentsEnabled,
+                            onToggle = onTimedCommentsToggle
+                        )
+
+                        SettingsDivider()
+
+                        SettingsToggleRow(
+                            icon = Icons.Rounded.Bolt,
+                            title = "Shorts",
+                            subtitle = if (shortsEnabled) {
+                                "Shorts shelves appear in your feeds"
+                            } else {
+                                "Shorts are hidden everywhere"
+                            },
+                            enabled = shortsEnabled,
+                            onToggle = onShortsEnabledToggle
+                        )
+
+                        // Shorts button visibility - only relevant while Shorts are on
+                        AnimatedVisibility(
+                            visible = shortsEnabled,
+                            enter = fadeIn(tween(200)) + slideInVertically(
+                                initialOffsetY = { -it / 4 },
+                                animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
+                            ),
+                            exit = fadeOut(tween(150))
+                        ) {
+                            Column {
+                                SettingsDivider()
+                                SettingsRow(
+                                    icon = Icons.Rounded.Visibility,
+                                    title = "Shorts Buttons",
+                                    subtitle = if (shortsHiddenActions.isEmpty()) {
+                                        "All buttons shown"
+                                    } else {
+                                        "${shortsHiddenActions.size} hidden"
+                                    },
+                                    onClick = onShowShortsButtons,
+                                    showChevron = true
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            item {
+                SettingsSection(title = "Recommendations") {
+                    SettingsCard {
+                        SettingsRow(
+                            icon = Icons.Rounded.NotInterested,
+                            title = "Not Recommended",
+                            subtitle = "Videos and channels you've hidden from your feeds",
+                            onClick = onNavigateToNotInterested,
+                            showChevron = true
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Subscriptions                                                       */
+/* ------------------------------------------------------------------ */
+
+@Composable
+internal fun SubscriptionsSettingsPage(
+    subscriptionSource: String,
+    subscribeTarget: String,
+    fastSubscriptionFeed: Boolean,
+    onFastSubscriptionFeedToggle: (Boolean) -> Unit,
+    onNavigateToSubscriptions: () -> Unit,
+    onOpenRoutingPicker: (SubscriptionDialogTarget) -> Unit,
+    onBack: () -> Unit
+) {
+    SettingsDetailScaffold(title = "Subscriptions", onBack = onBack) {
+        item {
+            SettingsSection(title = "Channels") {
+                SettingsCard {
+                    SettingsRow(
+                        icon = Icons.Rounded.Subscriptions,
+                        title = "Manage Subscriptions",
+                        subtitle = "Import, export and group the channels you follow",
+                        onClick = onNavigateToSubscriptions,
+                        showChevron = true
+                    )
+                }
+            }
+        }
+
+        item {
+            SettingsSection(title = "Where they live") {
+                SettingsCard {
+                    SettingsRow(
+                        icon = Icons.Rounded.FilterList,
+                        title = "Subscriptions Shown",
+                        subtitle = subscriptionSourceLabel(subscriptionSource),
+                        onClick = { onOpenRoutingPicker(SubscriptionDialogTarget.SOURCE) },
+                        showChevron = true
+                    )
+                    SettingsDivider()
+                    SettingsRow(
+                        icon = Icons.Rounded.BookmarkAdd,
+                        title = "Subscribe Saves To",
+                        subtitle = subscribeTargetLabel(subscribeTarget),
+                        onClick = { onOpenRoutingPicker(SubscriptionDialogTarget.TARGET) },
+                        showChevron = true
+                    )
+                }
+            }
+        }
+
+        item {
+            SettingsSection(title = "Feed") {
+                SettingsCard {
+                    SettingsToggleRow(
+                        icon = Icons.Rounded.Bolt,
+                        title = "Fast Subscription Refresh",
+                        subtitle = if (fastSubscriptionFeed) {
+                            "Much less data and exact upload times, but no duration badges"
+                        } else {
+                            "Full details for every video - slow on a large subscription list"
+                        },
+                        enabled = fastSubscriptionFeed,
+                        onToggle = onFastSubscriptionFeedToggle
+                    )
+                }
+            }
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Storage and cache                                                   */
+/* ------------------------------------------------------------------ */
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+internal fun StorageSettingsPage(
+    cacheEnabled: Boolean,
+    onCacheEnabledToggle: (Boolean) -> Unit,
+    maxCacheSizeMb: Long,
+    onMaxCacheSizeMbChange: (Long) -> Unit,
+    currentCacheSize: Long,
+    onClearCacheClick: () -> Unit,
+    onBack: () -> Unit
+) {
+    SettingsDetailScaffold(title = "Storage and cache", onBack = onBack) {
+        item {
+            SettingsSection(title = "Cache") {
+                SettingsCard {
+                    SettingsToggleRow(
+                        icon = Icons.Rounded.Save,
+                        title = "Cache Music",
+                        subtitle = "Store streamed songs for instant replay",
+                        enabled = cacheEnabled,
+                        onToggle = onCacheEnabledToggle
+                    )
+
+                    SettingsDivider()
+
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(12.dp)
+                            .clip(RoundedCornerShape(16.dp))
+                            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.1f))
+                            .padding(16.dp)
+                    ) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(
+                                imageVector = Icons.Rounded.Folder,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(32.dp)
+                            )
+                            Spacer(modifier = Modifier.width(16.dp))
+                            Column {
+                                Text(
+                                    text = "Local Cache",
+                                    color = MaterialTheme.colorScheme.onBackground,
+                                    fontWeight = FontWeight.SemiBold,
+                                    fontSize = 16.sp
+                                )
+                                Text(
+                                    text = CacheManager.formatSize(currentCacheSize),
+                                    color = MaterialTheme.colorScheme.primary,
+                                    fontWeight = FontWeight.Bold,
+                                    fontSize = 24.sp
+                                )
+                            }
+                        }
+                    }
+
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(
+                            text = "Max Cache Size",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontSize = 13.sp,
+                            fontWeight = FontWeight.Medium,
+                            modifier = Modifier.padding(bottom = 8.dp)
+                        )
+                        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                            val options = listOf(256L, 512L, 1024L, 2048L)
+                            val labels = listOf("256MB", "512MB", "1GB", "2GB")
+
+                            options.forEachIndexed { index, size ->
+                                SegmentedButton(
+                                    selected = maxCacheSizeMb == size,
+                                    onClick = { onMaxCacheSizeMbChange(size) },
+                                    shape = SegmentedButtonDefaults.itemShape(
+                                        index = index,
+                                        count = options.size
+                                    )
+                                ) {
+                                    Text(text = labels[index])
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        item {
+            SettingsCard {
+                SettingsRow(
+                    icon = Icons.Rounded.FolderOff,
+                    title = "Clear Cache",
+                    subtitle = "Free up storage space",
+                    onClick = onClearCacheClick,
+                    tint = SettingsRowDefaults.destructiveTint,
+                    titleColor = SettingsRowDefaults.destructiveTint
+                )
+            }
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Notifications                                                       */
+/* ------------------------------------------------------------------ */
+
+@Composable
+internal fun NotificationsSettingsPage(
+    liveDownloadUpdates: Boolean,
+    onLiveDownloadUpdatesToggle: (Boolean) -> Unit,
+    livePlaybackUpdates: Boolean,
+    onLivePlaybackUpdatesToggle: (Boolean) -> Unit,
+    canPostPromoted: Boolean,
+    onOpenSystemSettings: () -> Unit,
+    onBack: () -> Unit
+) {
+    SettingsDetailScaffold(title = "Notifications", onBack = onBack) {
+        item {
+            SettingsSection(title = "Live updates") {
+                SettingsCard {
+                    SettingsToggleRow(
+                        icon = Icons.Rounded.Bolt,
+                        title = "Live download updates",
+                        subtitle = "Show download progress as a live status bar chip",
+                        enabled = liveDownloadUpdates,
+                        onToggle = onLiveDownloadUpdatesToggle
+                    )
+
+                    SettingsDivider()
+
+                    SettingsToggleRow(
+                        icon = Icons.Rounded.GraphicEq,
+                        title = "Live playback updates",
+                        subtitle = "Show what's playing as a live status bar chip",
+                        enabled = livePlaybackUpdates,
+                        onToggle = onLivePlaybackUpdatesToggle
+                    )
+
+                    // Promotion is a request the system can refuse. When the
+                    // user has revoked it at the OS level the toggles above are
+                    // a lie, so surface the way to fix it.
+                    if ((liveDownloadUpdates || livePlaybackUpdates) && !canPostPromoted) {
+                        SettingsDivider()
+                        SettingsRow(
+                            icon = Icons.Rounded.Security,
+                            title = "Blocked by system settings",
+                            subtitle = "Allow live updates for Koda in Android settings",
+                            onClick = onOpenSystemSettings,
+                            tint = SettingsRowDefaults.destructiveTint,
+                            titleColor = SettingsRowDefaults.destructiveTint,
+                            showChevron = true
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Local library                                                       */
+/* ------------------------------------------------------------------ */
+
+@Composable
+internal fun LocalLibrarySettingsPage(
+    loadLocalSongs: Boolean,
+    onLoadLocalSongsToggle: (Boolean) -> Unit,
+    excludedFolderCount: Int,
+    onOpenFolderExclusion: () -> Unit,
+    onBack: () -> Unit
+) {
+    SettingsDetailScaffold(title = "Local library", onBack = onBack) {
+        item {
+            SettingsSection(title = "Device music") {
+                SettingsCard {
+                    SettingsToggleRow(
+                        icon = Icons.Rounded.Folder,
+                        title = "Load Local Songs",
+                        subtitle = if (loadLocalSongs) {
+                            "Shows songs from your device"
+                        } else {
+                            "YouTube Music only"
+                        },
+                        enabled = loadLocalSongs,
+                        onToggle = onLoadLocalSongsToggle
+                    )
+
+                    AnimatedVisibility(
+                        visible = loadLocalSongs,
+                        enter = fadeIn(tween(200)) + slideInVertically(
+                            initialOffsetY = { -it / 4 },
+                            animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
+                        ),
+                        exit = fadeOut(tween(150))
+                    ) {
+                        Column {
+                            SettingsDivider()
+                            SettingsRow(
+                                icon = Icons.Rounded.FolderOff,
+                                title = "Excluded Folders",
+                                subtitle = if (excludedFolderCount == 0) {
+                                    "All folders included"
+                                } else {
+                                    "$excludedFolderCount folder" +
+                                        "${if (excludedFolderCount == 1) "" else "s"} excluded"
+                                },
+                                onClick = onOpenFolderExclusion,
+                                showChevron = true
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Advanced                                                            */
+/* ------------------------------------------------------------------ */
+
+@Composable
+internal fun AdvancedSettingsPage(
+    manualScanEnabled: Boolean,
+    onManualScanEnabledToggle: (Boolean) -> Unit,
+    onBack: () -> Unit
+) {
+    val context = LocalContext.current
+
+    SettingsDetailScaffold(title = "Advanced", onBack = onBack) {
+        // The old screen showed this section to everyone. It only means
+        // anything on the OEMs that break background playback and MediaStore,
+        // so lead with why it is here.
+        if (isXiaomiDevice()) {
+            item {
+                SettingsNotice(
+                    icon = Icons.Rounded.Info,
+                    text = "Xiaomi device detected. Enabling both of these is highly recommended.",
+                    tint = MaterialTheme.colorScheme.tertiary
+                )
+            }
+        }
+
+        item {
+            SettingsSection(title = "Compatibility") {
+                SettingsCard {
+                    SettingsToggleRow(
+                        icon = Icons.Rounded.Security,
+                        title = "High Compatibility Scanning",
+                        subtitle = "Bypasses MediaStore (Fixes missing music on HyperOS)",
+                        enabled = manualScanEnabled,
+                        onToggle = { enabled ->
+                            if (enabled && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+                                if (!android.os.Environment.isExternalStorageManager()) {
+                                    val intent = Intent(
+                                        android.provider.Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION
+                                    ).apply {
+                                        data = Uri.parse("package:${context.packageName}")
+                                    }
+                                    context.startActivity(intent)
+                                }
+                            }
+                            onManualScanEnabledToggle(enabled)
+                        }
+                    )
+
+                    SettingsDivider()
+
+                    SettingsRow(
+                        icon = Icons.Rounded.FlashOn,
+                        title = "Ignore Battery Optimizations",
+                        subtitle = "Prevents playback from stopping in background",
+                        onClick = {
+                            val packageName = context.packageName
+                            val intent = Intent(
+                                android.provider.Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
+                            ).apply {
+                                data = Uri.parse("package:$packageName")
+                            }
+                            try {
+                                context.startActivity(intent)
+                            } catch (e: Exception) {
+                                // Fallback for HyperOS/Restrictive OEMs: Open App Info
+                                // From here user can manually set "No restrictions" in Battery saver
+                                try {
+                                    val appInfoIntent = Intent(
+                                        android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+                                    ).apply {
+                                        data = Uri.parse("package:$packageName")
+                                    }
+                                    context.startActivity(appInfoIntent)
+                                } catch (e2: Exception) {
+                                    // Absolute fallback
+                                    context.startActivity(
+                                        Intent(android.provider.Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
+                                    )
+                                }
+                            }
+                        },
+                        tint = MaterialTheme.colorScheme.tertiary,
+                        showChevron = true
+                    )
+                }
+            }
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Shared bits                                                         */
+/* ------------------------------------------------------------------ */
+
+/** Inline explanatory banner - used for empty states and device-specific advice. */
+@Composable
+private fun SettingsNotice(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    text: String,
+    tint: Color = MaterialTheme.colorScheme.primary
+) {
+    Surface(
+        shape = RoundedCornerShape(16.dp),
+        color = tint.copy(alpha = 0.1f),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier.padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = tint,
+                modifier = Modifier.size(20.dp)
+            )
+            Spacer(modifier = Modifier.width(10.dp))
+            Text(
+                text = text,
+                color = tint,
+                fontSize = 12.sp,
+                lineHeight = 17.sp,
+                fontWeight = FontWeight.Medium
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsPages.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsPages.kt
@@ -79,6 +79,7 @@ import com.ivor.ivormusic.data.CacheManager
 import com.ivor.ivormusic.data.PlayerStyle
 import com.ivor.ivormusic.data.SessionManager
 import com.ivor.ivormusic.data.ThemePreferences
+import com.ivor.ivormusic.ui.player.PlayerStylePicker
 import com.ivor.ivormusic.ui.theme.ThemeMode
 
 /**
@@ -282,15 +283,30 @@ internal fun PlayerSettingsPage(
         item {
             SettingsSection(title = "Style") {
                 SettingsCard {
-                    ExpressivePlayerStyleSelectItem(
-                        currentStyle = playerStyle,
-                        onStyleSelected = onPlayerStyleChange,
-                        textColor = MaterialTheme.colorScheme.onBackground,
-                        secondaryTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                        accentColor = MaterialTheme.colorScheme.primary
-                    )
+                    Column(modifier = Modifier.padding(10.dp)) {
+                        Text(
+                            text = "Every style plays the same music - they differ in " +
+                                "layout and how you control it.",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontSize = 13.sp,
+                            lineHeight = 18.sp,
+                            modifier = Modifier.padding(bottom = 12.dp)
+                        )
+                        PlayerStylePicker(
+                            currentStyle = playerStyle,
+                            onStyleSelected = onPlayerStyleChange
+                        )
+                    }
                 }
             }
+        }
+
+        item {
+            SettingsNotice(
+                icon = Icons.Rounded.Info,
+                text = "Long-press the artwork in any player to switch styles from " +
+                    "the wheel without coming back here."
+            )
         }
 
         item {

--- a/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
@@ -146,6 +146,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
@@ -330,10 +331,16 @@ fun SettingsScreen(
         onDispose { lifecycle?.removeObserver(observer) }
     }
 
-    // Which category page is open. Back pops to the hub before it leaves
-    // Settings altogether.
+    // Which category page is open, and what is typed in the hub's search box.
     var page by remember { mutableStateOf(SettingsPage.HUB) }
-    BackHandler(enabled = page != SettingsPage.HUB) { page = SettingsPage.HUB }
+    var searchQuery by remember { mutableStateOf("") }
+
+    // Back unwinds one step at a time: an open page returns to the hub, then a
+    // live query clears, and only then does Settings close. The query survives
+    // opening a result on purpose, so coming back lands on the same list.
+    BackHandler(enabled = page != SettingsPage.HUB || searchQuery.isNotEmpty()) {
+        if (page != SettingsPage.HUB) page = SettingsPage.HUB else searchQuery = ""
+    }
 
     // Dialog state for YouTube auth
     var showAuthDialog by remember { mutableStateOf(false) }
@@ -369,6 +376,21 @@ fun SettingsScreen(
         showFolderExclusionDialog = true
     }
 
+    // Not remembered: the closures capture callbacks that arrive as parameters,
+    // and ~38 small objects per recomposition is cheaper than a stale index.
+    val searchEntries = buildSettingsSearchIndex(
+        onOpenPage = { page = it },
+        onOpenQualityPicker = { qualityDialogTarget = it },
+        onOpenRoutingPicker = { subscriptionDialogTarget = it },
+        onShowAbout = { showAboutDialog = true },
+        onShowShortsButtons = { showShortsButtonsDialog = true },
+        onOpenFolderExclusion = openFolderExclusion,
+        onNavigateToColorPalette = onNavigateToColorPalette,
+        onNavigateToSubscriptions = onNavigateToSubscriptions,
+        onNavigateToNotInterested = onNavigateToNotInterested,
+        supportsLiveUpdates = ThemePreferences.SUPPORTS_LIVE_UPDATES
+    )
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -396,6 +418,9 @@ fun SettingsScreen(
         ) { currentPage ->
             when (currentPage) {
                 SettingsPage.HUB -> SettingsHub(
+                    searchQuery = searchQuery,
+                    onSearchQueryChange = { searchQuery = it },
+                    searchEntries = searchEntries,
                     isLoggedIn = isLoggedIn,
                     accountRefreshKey = accountRefreshKey,
                     sessionManager = sessionManager,
@@ -653,6 +678,9 @@ fun SettingsScreen(
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun SettingsHub(
+    searchQuery: String,
+    onSearchQueryChange: (String) -> Unit,
+    searchEntries: List<SettingsSearchEntry>,
     isLoggedIn: Boolean,
     accountRefreshKey: Int,
     sessionManager: SessionManager,
@@ -682,6 +710,9 @@ private fun SettingsHub(
         isVisible = true
     }
 
+    // Opening a result should put the keyboard away before the page slides in.
+    val focusManager = LocalFocusManager.current
+
     val accountValue = key(accountRefreshKey) {
         when {
             !isLoggedIn -> "Not signed in"
@@ -699,8 +730,7 @@ private fun SettingsHub(
     } else {
         com.ivor.ivormusic.ui.theme.findPalette(colorPalette)?.name ?: "Dynamic"
     }
-    val playerStyleLabel = (playerStyleOptions.firstOrNull { it.style == playerStyle }
-        ?: playerStyleOptions.first()).label
+    val playerStyleLabel = com.ivor.ivormusic.ui.player.playerStyleInfo(playerStyle).label
 
     val contentValue = when {
         localOnlyMode -> "Local only, offline"
@@ -773,6 +803,36 @@ private fun SettingsHub(
             contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
+            item {
+                SettingsSearchField(
+                    query = searchQuery,
+                    onQueryChange = onSearchQueryChange
+                )
+            }
+
+            val results = searchSettings(searchQuery, searchEntries)
+
+            if (searchQuery.isNotBlank()) {
+                if (results.isEmpty()) {
+                    item { SettingsSearchEmptyState(query = searchQuery) }
+                } else {
+                    item {
+                        SettingsCard {
+                            results.forEachIndexed { index, entry ->
+                                if (index > 0) SettingsDivider()
+                                SettingsSearchResultRow(
+                                    entry = entry,
+                                    onClick = {
+                                        focusManager.clearFocus()
+                                        entry.action()
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+            } else {
+
             item {
                 SettingsSection(title = "You") {
                     SettingsCard {
@@ -896,6 +956,8 @@ private fun SettingsHub(
                         )
                     }
                 }
+            }
+
             }
 
             item { Spacer(modifier = Modifier.height(32.dp)) }
@@ -1125,107 +1187,6 @@ internal fun ExpressiveVideoModeToggleItem(
                 ) {
                     Text(label)
                 }
-            }
-        }
-    }
-}
-
-internal data class PlayerStyleOption(
-    val style: PlayerStyle,
-    val label: String,
-    val subtitle: String,
-    val icon: androidx.compose.ui.graphics.vector.ImageVector
-)
-
-internal val playerStyleOptions = listOf(
-    PlayerStyleOption(PlayerStyle.CLASSIC, "Classic", "Button controls for playback", Icons.Rounded.PlayCircle),
-    PlayerStyleOption(PlayerStyle.GESTURE, "Gesture", "Swipe album art to navigate", Icons.Rounded.SwipeRight),
-    PlayerStyleOption(PlayerStyle.EDITORIAL, "Editorial", "Two-tone magazine layout", Icons.Rounded.Newspaper),
-    PlayerStyleOption(PlayerStyle.POSTER, "Canvas", "Full-bleed album art", Icons.Rounded.Wallpaper),
-    PlayerStyleOption(PlayerStyle.BENTO, "Bento", "Squishy grid of flat tiles", Icons.Rounded.GridView),
-    PlayerStyleOption(PlayerStyle.STICKER, "Sticker", "Die-cut art with toy physics", Icons.Rounded.Interests),
-    PlayerStyleOption(PlayerStyle.MORPH, "Morph", "Living shape that breathes", Icons.Rounded.Animation),
-    PlayerStyleOption(PlayerStyle.DIAL, "Dial", "Rotary ring, spin to scrub", Icons.Rounded.RadioButtonChecked)
-)
-
-@OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
-@Composable
-internal fun ExpressivePlayerStyleSelectItem(
-    currentStyle: PlayerStyle,
-    onStyleSelected: (PlayerStyle) -> Unit,
-    textColor: Color,
-    secondaryTextColor: Color,
-    accentColor: Color
-) {
-    val current = playerStyleOptions.firstOrNull { it.style == currentStyle }
-        ?: playerStyleOptions.first()
-
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 14.dp)
-    ) {
-        // Header Row
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            // Icon
-            Box(
-                modifier = Modifier
-                    .size(48.dp)
-                    .clip(RoundedCornerShape(14.dp))
-                    .background(accentColor.copy(alpha = 0.12f)),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    imageVector = current.icon,
-                    contentDescription = null,
-                    tint = accentColor,
-                    modifier = Modifier.size(26.dp)
-                )
-            }
-
-            Spacer(modifier = Modifier.width(16.dp))
-
-            // Text
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = "Player Style",
-                    color = textColor,
-                    fontSize = 16.sp,
-                    fontWeight = FontWeight.SemiBold
-                )
-                Spacer(modifier = Modifier.height(2.dp))
-                Text(
-                    text = current.subtitle,
-                    color = secondaryTextColor,
-                    fontSize = 13.sp
-                )
-            }
-        }
-
-        Spacer(modifier = Modifier.height(12.dp))
-
-        // Wrapping chip grid - scales past the point where a segmented row
-        // stops fitting.
-        FlowRow(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            playerStyleOptions.forEach { option ->
-                FilterChip(
-                    selected = currentStyle == option.style,
-                    onClick = { onStyleSelected(option.style) },
-                    label = { Text(option.label) },
-                    leadingIcon = {
-                        Icon(
-                            imageVector = option.icon,
-                            contentDescription = null,
-                            modifier = Modifier.size(18.dp)
-                        )
-                    }
-                )
             }
         }
     }

--- a/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsScreen.kt
@@ -2,7 +2,12 @@ package com.ivor.ivormusic.ui.settings
 
 import android.content.Intent
 import android.net.Uri
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
@@ -146,6 +151,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -200,6 +206,26 @@ private class PolygonShape(private val polygon: RoundedPolygon) : Shape {
         path.transform(matrix)
         return Outline.Generic(path)
     }
+}
+
+/**
+ * One page of the settings screen. These are not nav routes on purpose: the
+ * screen takes ~60 parameters, and threading those into a NavHost destination
+ * per category would mean repeating the whole list eleven times. The Home tab
+ * system solves the same problem the same way.
+ */
+internal enum class SettingsPage {
+    HUB,
+    ACCOUNT,
+    APPEARANCE,
+    PLAYER,
+    PLAYBACK,
+    CONTENT,
+    SUBSCRIPTIONS,
+    STORAGE,
+    NOTIFICATIONS,
+    LOCAL_LIBRARY,
+    ADVANCED
 }
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -283,7 +309,7 @@ fun SettingsScreen(
     val context = LocalContext.current
     val sessionManager = remember { SessionManager(context) }
     val coroutineScope = rememberCoroutineScope()
-    
+
     // Check actual login status
     var isLoggedIn by remember { mutableStateOf(sessionManager.isLoggedIn()) }
 
@@ -303,12 +329,11 @@ fun SettingsScreen(
         lifecycle?.addObserver(observer)
         onDispose { lifecycle?.removeObserver(observer) }
     }
-    
-    val backgroundColor = MaterialTheme.colorScheme.background
-    val surfaceColor = MaterialTheme.colorScheme.surfaceContainer
-    val textColor = MaterialTheme.colorScheme.onBackground
-    val secondaryTextColor = MaterialTheme.colorScheme.onSurfaceVariant
-    val accentColor = MaterialTheme.colorScheme.primary
+
+    // Which category page is open. Back pops to the hub before it leaves
+    // Settings altogether.
+    var page by remember { mutableStateOf(SettingsPage.HUB) }
+    BackHandler(enabled = page != SettingsPage.HUB) { page = SettingsPage.HUB }
 
     // Dialog state for YouTube auth
     var showAuthDialog by remember { mutableStateOf(false) }
@@ -321,7 +346,7 @@ fun SettingsScreen(
 
     // Dialog state for About
     var showAboutDialog by remember { mutableStateOf(false) }
-    
+
     // Which per-network quality picker is open, if any
     var qualityDialogTarget by remember { mutableStateOf<QualityDialogTarget?>(null) }
 
@@ -333,849 +358,184 @@ fun SettingsScreen(
     var showShortsButtonsDialog by remember { mutableStateOf(false) }
     var availableFolders by remember { mutableStateOf<List<FolderInfo>>(emptyList()) }
     var isFoldersLoading by remember { mutableStateOf(false) }
-    
-    // Animation states for staggered entry
-    var isVisible by remember { mutableStateOf(false) }
-    LaunchedEffect(Unit) {
-        delay(100)
-        isVisible = true
+
+    val openFolderExclusion: () -> Unit = {
+        // Load available folders when opening dialog
+        isFoldersLoading = true
+        coroutineScope.launch {
+            availableFolders = homeViewModel.getAvailableFolders()
+            isFoldersLoading = false
+        }
+        showFolderExclusionDialog = true
     }
 
-    Column(
+    Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(backgroundColor)
+            .background(MaterialTheme.colorScheme.background)
             .padding(contentPadding)
     ) {
-        // Top App Bar with expressive back button
-        TopAppBar(
-            title = {
-                AnimatedVisibility(
-                    visible = isVisible,
-                    enter = fadeIn(tween(400)) + slideInVertically(
-                        initialOffsetY = { -it / 2 },
-                        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
-                    )
-                ) {
-                    Text(
-                        text = "Settings",
-                        color = textColor,
-                        fontWeight = FontWeight.Bold,
-                        style = MaterialTheme.typography.headlineMedium
-                    )
+        AnimatedContent(
+            targetState = page,
+            transitionSpec = {
+                // Going deeper slides in from the trailing edge; coming back
+                // reverses it, so the hierarchy stays legible.
+                val slide = spring<IntOffset>(
+                    dampingRatio = Spring.DampingRatioNoBouncy,
+                    stiffness = Spring.StiffnessMediumLow
+                )
+                if (targetState != SettingsPage.HUB) {
+                    (slideInHorizontally(slide) { it / 5 } + fadeIn(tween(200))) togetherWith
+                        (fadeOut(tween(130)) + slideOutHorizontally(slide) { -it / 12 })
+                } else {
+                    (slideInHorizontally(slide) { -it / 5 } + fadeIn(tween(200))) togetherWith
+                        (fadeOut(tween(130)) + slideOutHorizontally(slide) { it / 12 })
                 }
             },
-            navigationIcon = {
-                IconButton(
-                    onClick = onBackClick,
-                    shapes = IconButtonDefaults.shapes(),
-                    colors = IconButtonDefaults.iconButtonColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                        contentColor = textColor
-                    ),
-                    modifier = Modifier
-                        .padding(start = 8.dp)
-                        .size(44.dp)
-                ) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
-                        contentDescription = "Back"
-                    )
-                }
-            },
-            colors = TopAppBarDefaults.topAppBarColors(
-                containerColor = Color.Transparent
-            ),
-            modifier = Modifier.windowInsetsPadding(WindowInsets.statusBars)
-        )
+            label = "settingsPage"
+        ) { currentPage ->
+            when (currentPage) {
+                SettingsPage.HUB -> SettingsHub(
+                    isLoggedIn = isLoggedIn,
+                    accountRefreshKey = accountRefreshKey,
+                    sessionManager = sessionManager,
+                    currentThemeMode = currentThemeMode,
+                    colorPalette = colorPalette,
+                    playerStyle = playerStyle,
+                    musicQualityWifi = musicQualityWifi,
+                    videoQualityWifi = videoQualityWifi,
+                    localOnlyMode = localOnlyMode,
+                    videoMode = videoMode,
+                    subscriptionSource = subscriptionSource,
+                    cacheEnabled = cacheEnabled,
+                    currentCacheSize = currentCacheSize,
+                    liveDownloadUpdates = liveDownloadUpdates,
+                    livePlaybackUpdates = livePlaybackUpdates,
+                    canPostPromoted = canPostPromoted,
+                    loadLocalSongs = loadLocalSongs,
+                    excludedFolderCount = excludedFolders.size,
+                    onOpenPage = { page = it },
+                    onShowAbout = { showAboutDialog = true },
+                    onBackClick = onBackClick
+                )
 
-        LazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(20.dp)
-        ) {
-            // Appearance Section with staggered animation
-            item {
-                SettingsSection(
-                    title = "Appearance",
-                    textColor = secondaryTextColor
-                ) {
-                    ExpressiveSettingsCard(surfaceColor = surfaceColor) {
-                        ExpressiveThemeSelectGroup(
-                            currentMode = currentThemeMode,
-                            onModeSelected = onThemeModeChange,
-                            textColor = textColor,
-                            accentColor = accentColor
-                        )
+                SettingsPage.ACCOUNT -> AccountSettingsPage(
+                    isLoggedIn = isLoggedIn,
+                    accountRefreshKey = accountRefreshKey,
+                    sessionManager = sessionManager,
+                    saveVideoHistory = saveVideoHistory,
+                    onSaveVideoHistoryToggle = onSaveVideoHistoryToggle,
+                    onShowAuthDialog = { showAuthDialog = true },
+                    onShowCookieSheet = { showCookiePasteSheet = true },
+                    onSignOut = {
+                        sessionManager.clearSession()
+                        isLoggedIn = false
+                        onLogoutClick()
+                    },
+                    onBack = { page = SettingsPage.HUB }
+                )
 
-                        SettingsDivider()
+                SettingsPage.APPEARANCE -> AppearanceSettingsPage(
+                    currentThemeMode = currentThemeMode,
+                    onThemeModeChange = onThemeModeChange,
+                    colorPalette = colorPalette,
+                    onNavigateToColorPalette = onNavigateToColorPalette,
+                    amoledTheme = amoledTheme,
+                    onAmoledThemeToggle = onAmoledThemeToggle,
+                    ambientBackground = ambientBackground,
+                    onAmbientBackgroundToggle = onAmbientBackgroundToggle,
+                    onBack = { page = SettingsPage.HUB }
+                )
 
-                        // Color palette picker link
-                        val paletteName = if (colorPalette == ThemePreferences.DEFAULT_COLOR_PALETTE) {
-                            "Dynamic (from wallpaper)"
-                        } else {
-                            com.ivor.ivormusic.ui.theme.findPalette(colorPalette)?.name ?: "Dynamic"
-                        }
-                        ExpressiveSettingsItem(
-                            icon = Icons.Rounded.Palette,
-                            title = "Color palette",
-                            subtitle = paletteName,
-                            onClick = onNavigateToColorPalette,
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            iconTint = accentColor,
-                            showChevron = true
-                        )
+                SettingsPage.PLAYER -> PlayerSettingsPage(
+                    playerStyle = playerStyle,
+                    onPlayerStyleChange = onPlayerStyleChange,
+                    playerArtworkColors = playerArtworkColors,
+                    onPlayerArtworkColorsToggle = onPlayerArtworkColorsToggle,
+                    onBack = { page = SettingsPage.HUB }
+                )
 
-                        SettingsDivider()
+                SettingsPage.PLAYBACK -> PlaybackSettingsPage(
+                    crossfadeEnabled = crossfadeEnabled,
+                    onCrossfadeEnabledToggle = onCrossfadeEnabledToggle,
+                    crossfadeDurationMs = crossfadeDurationMs,
+                    onCrossfadeDurationChange = onCrossfadeDurationChange,
+                    autoLoadQueue = autoLoadQueue,
+                    onAutoLoadQueueToggle = onAutoLoadQueueToggle,
+                    musicQualityWifi = musicQualityWifi,
+                    musicQualityMobile = musicQualityMobile,
+                    videoQualityWifi = videoQualityWifi,
+                    videoQualityMobile = videoQualityMobile,
+                    preferHdr = preferHdr,
+                    onPreferHdrToggle = onPreferHdrToggle,
+                    onOpenQualityPicker = { qualityDialogTarget = it },
+                    onBack = { page = SettingsPage.HUB }
+                )
 
-                        // AMOLED pure black toggle
-                        ExpressiveAmoledThemeToggleItem(
-                            enabled = amoledTheme,
-                            onToggle = onAmoledThemeToggle,
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            accentColor = accentColor
-                        )
+                SettingsPage.CONTENT -> ContentSettingsPage(
+                    localOnlyMode = localOnlyMode,
+                    onLocalOnlyModeToggle = onLocalOnlyModeToggle,
+                    videoMode = videoMode,
+                    onVideoModeToggle = onVideoModeToggle,
+                    homeModeToggleEnabled = homeModeToggleEnabled,
+                    onHomeModeToggleChange = onHomeModeToggleChange,
+                    timedCommentsEnabled = timedCommentsEnabled,
+                    onTimedCommentsToggle = onTimedCommentsToggle,
+                    shortsEnabled = shortsEnabled,
+                    onShortsEnabledToggle = onShortsEnabledToggle,
+                    shortsHiddenActions = shortsHiddenActions,
+                    onShowShortsButtons = { showShortsButtonsDialog = true },
+                    onNavigateToNotInterested = onNavigateToNotInterested,
+                    onBack = { page = SettingsPage.HUB }
+                )
 
-                        SettingsDivider()
+                SettingsPage.SUBSCRIPTIONS -> SubscriptionsSettingsPage(
+                    subscriptionSource = subscriptionSource,
+                    subscribeTarget = subscribeTarget,
+                    fastSubscriptionFeed = fastSubscriptionFeed,
+                    onFastSubscriptionFeedToggle = onFastSubscriptionFeedToggle,
+                    onNavigateToSubscriptions = onNavigateToSubscriptions,
+                    onOpenRoutingPicker = { subscriptionDialogTarget = it },
+                    onBack = { page = SettingsPage.HUB }
+                )
 
-                        // Ambient Background toggle
-                        ExpressiveAmbientBackgroundToggleItem(
-                            enabled = ambientBackground,
-                            onToggle = onAmbientBackgroundToggle,
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            accentColor = accentColor
-                        )
-                    }
-                }
-            }
-            
-            // Player UI Section
-            item {
-                SettingsSection(
-                    title = "Player UI",
-                    textColor = secondaryTextColor
-                ) {
-                    ExpressiveSettingsCard(surfaceColor = surfaceColor) {
-                        ExpressivePlayerStyleSelectItem(
-                            currentStyle = playerStyle,
-                            onStyleSelected = onPlayerStyleChange,
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            accentColor = accentColor
-                        )
+                SettingsPage.STORAGE -> StorageSettingsPage(
+                    cacheEnabled = cacheEnabled,
+                    onCacheEnabledToggle = onCacheEnabledToggle,
+                    maxCacheSizeMb = maxCacheSizeMb,
+                    onMaxCacheSizeMbChange = onMaxCacheSizeMbChange,
+                    currentCacheSize = currentCacheSize,
+                    onClearCacheClick = onClearCacheClick,
+                    onBack = { page = SettingsPage.HUB }
+                )
 
-                        SettingsDivider()
+                SettingsPage.NOTIFICATIONS -> NotificationsSettingsPage(
+                    liveDownloadUpdates = liveDownloadUpdates,
+                    onLiveDownloadUpdatesToggle = onLiveDownloadUpdatesToggle,
+                    livePlaybackUpdates = livePlaybackUpdates,
+                    onLivePlaybackUpdatesToggle = onLivePlaybackUpdatesToggle,
+                    canPostPromoted = canPostPromoted,
+                    onOpenSystemSettings = {
+                        notificationHelper
+                            .promotedNotificationSettingsIntent()
+                            ?.let { runCatching { context.startActivity(it) } }
+                    },
+                    onBack = { page = SettingsPage.HUB }
+                )
 
-                        // Album-art button colors, applies to every player style
-                        ExpressiveOemToggleItem(
-                            icon = Icons.Rounded.Palette,
-                            title = "Album Art Colors",
-                            subtitle = "Color the expanded player's buttons from the current cover",
-                            enabled = playerArtworkColors,
-                            onToggle = onPlayerArtworkColorsToggle,
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            accentColor = accentColor
-                        )
-                    }
-                }
-            }
+                SettingsPage.LOCAL_LIBRARY -> LocalLibrarySettingsPage(
+                    loadLocalSongs = loadLocalSongs,
+                    onLoadLocalSongsToggle = onLoadLocalSongsToggle,
+                    excludedFolderCount = excludedFolders.size,
+                    onOpenFolderExclusion = openFolderExclusion,
+                    onBack = { page = SettingsPage.HUB }
+                )
 
-            // Playback Section
-            item {
-                SettingsSection(
-                    title = "Playback",
-                    textColor = secondaryTextColor
-                ) {
-                    ExpressiveSettingsCard(surfaceColor = surfaceColor) {
-                        // Crossfade Toggle
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 16.dp, vertical = 14.dp),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Column(modifier = Modifier.weight(1f)) {
-                                Text(
-                                    text = "Crossfade",
-                                    color = textColor,
-                                    fontSize = 16.sp,
-                                    fontWeight = FontWeight.SemiBold
-                                )
-                                Spacer(modifier = Modifier.height(2.dp))
-                                Text(
-                                    text = "Smoothly fade between songs",
-                                    color = secondaryTextColor,
-                                    fontSize = 13.sp
-                                )
-                            }
-                            Switch(
-                                checked = crossfadeEnabled,
-                                onCheckedChange = onCrossfadeEnabledToggle,
-                                colors = SwitchDefaults.colors(checkedThumbColor = Color.White, checkedTrackColor = accentColor)
-                            )
-                        }
-                        
-                        AnimatedVisibility(visible = crossfadeEnabled) {
-                            Column(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 16.dp, vertical = 8.dp)
-                            ) {
-                                Text(
-                                    text = "Duration: ${crossfadeDurationMs / 1000}s",
-                                    color = textColor,
-                                    fontSize = 14.sp,
-                                    fontWeight = FontWeight.Medium
-                                )
-                                androidx.compose.material3.Slider(
-                                    value = crossfadeDurationMs.toFloat(),
-                                    onValueChange = { onCrossfadeDurationChange(it.toInt()) },
-                                    valueRange = 1000f..12000f,
-                                    steps = 10,
-                                    colors = androidx.compose.material3.SliderDefaults.colors(
-                                        thumbColor = accentColor,
-                                        activeTrackColor = accentColor
-                                    )
-                                )
-                            }
-                        }
-
-                        SettingsDivider()
-
-                        // Auto-load Queue Toggle
-                        ExpressiveOemToggleItem(
-                            icon = Icons.AutoMirrored.Rounded.QueueMusic,
-                            title = "Auto-load Queue",
-                            subtitle = "Add recommended songs when the queue runs low",
-                            enabled = autoLoadQueue,
-                            onToggle = onAutoLoadQueueToggle,
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            accentColor = accentColor
-                        )
-
-                        SettingsDivider()
-
-                        ExpressiveSettingsItem(
-                            icon = Icons.Rounded.Wifi,
-                            title = "Music Quality on Wi-Fi",
-                            subtitle = musicQualityLabel(musicQualityWifi),
-                            onClick = { qualityDialogTarget = QualityDialogTarget.MUSIC_WIFI },
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            iconTint = accentColor,
-                            showChevron = true
-                        )
-
-                        SettingsDivider()
-
-                        ExpressiveSettingsItem(
-                            icon = Icons.Rounded.SignalCellularAlt,
-                            title = "Music Quality on Mobile Data",
-                            subtitle = musicQualityLabel(musicQualityMobile),
-                            onClick = { qualityDialogTarget = QualityDialogTarget.MUSIC_MOBILE },
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            iconTint = accentColor,
-                            showChevron = true
-                        )
-                    }
-                }
-            }
-
-            // OEM & HyperOS Fixes Section
-            item {
-                SettingsSection(
-                    title = "OEM & HyperOS Fixes",
-                    textColor = secondaryTextColor
-                ) {
-                    ExpressiveSettingsCard(surfaceColor = surfaceColor) {
-                        // High Compatibility Scanning (Manual Scan)
-                        ExpressiveOemToggleItem(
-                            icon = Icons.Rounded.Security,
-                            title = "High Compatibility Scanning",
-                            subtitle = "Bypasses MediaStore (Fixes missing music on HyperOS)",
-                            enabled = manualScanEnabled,
-                            onToggle = { enabled ->
-                                if (enabled && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
-                                    if (!android.os.Environment.isExternalStorageManager()) {
-                                        val intent = Intent(android.provider.Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply {
-                                            data = Uri.parse("package:${context.packageName}")
-                                        }
-                                        context.startActivity(intent)
-                                    }
-                                }
-                                onManualScanEnabledToggle(enabled)
-                            },
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            accentColor = Color(0xFF4CAF50)
-                        )
-                        
-                        SettingsDivider()
-                        
-                        // Battery Optimization Fix
-                        ExpressiveSettingsItem(
-                            icon = Icons.Rounded.FlashOn,
-                            title = "Ignore Battery Optimizations",
-                            subtitle = "Prevents playback from stopping in background",
-                            onClick = {
-                                val packageName = context.packageName
-                                val intent = Intent(android.provider.Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
-                                    data = Uri.parse("package:$packageName")
-                                }
-                                try {
-                                    context.startActivity(intent)
-                                } catch (e: Exception) {
-                                    // Fallback for HyperOS/Restrictive OEMs: Open App Info
-                                    // From here user can manually set "No restrictions" in Battery saver
-                                    try {
-                                        val appInfoIntent = Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
-                                            data = Uri.parse("package:$packageName")
-                                        }
-                                        context.startActivity(appInfoIntent)
-                                    } catch (e2: Exception) {
-                                        // Absolute fallback
-                                        context.startActivity(Intent(android.provider.Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS))
-                                    }
-                                }
-                            },
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            iconTint = Color(0xFFFFB300),
-                            showChevron = true
-                        )
-                    }
-                    
-                    if (isXiaomiDevice()) {
-                        Spacer(modifier = Modifier.height(8.dp))
-                        Surface(
-                            shape = RoundedCornerShape(16.dp),
-                            color = Color(0xFFFFB300).copy(alpha = 0.1f),
-                            modifier = Modifier.padding(horizontal = 4.dp)
-                        ) {
-                            Row(
-                                modifier = Modifier.padding(12.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Rounded.Info,
-                                    contentDescription = null,
-                                    tint = Color(0xFFF57C00),
-                                    modifier = Modifier.size(20.dp)
-                                )
-                                Spacer(modifier = Modifier.width(10.dp))
-                                Text(
-                                    text = "Xiaomi device detected. Enabling these is highly recommended.",
-                                    color = Color(0xFFF57C00),
-                                    fontSize = 12.sp,
-                                    fontWeight = FontWeight.Medium
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-            
-            // Storage & Cache Section
-            item {
-                SettingsSection(
-                    title = "Storage & Cache",
-                    textColor = secondaryTextColor
-                ) {
-                    ExpressiveSettingsCard(surfaceColor = surfaceColor) {
-                        // Music Cache Toggle
-                        ExpressiveOemToggleItem(
-                            icon = Icons.Rounded.Save,
-                            title = "Cache Music",
-                            subtitle = "Store streamed songs for instant replay",
-                            enabled = cacheEnabled,
-                            onToggle = onCacheEnabledToggle,
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            accentColor = accentColor
-                        )
-
-                        SettingsDivider()
-
-                        // Cache Size Display (Expressive Card)
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(12.dp)
-                                .clip(RoundedCornerShape(16.dp))
-                                .background(accentColor.copy(alpha = 0.1f))
-                                .padding(16.dp)
-                        ) {
-                             Row(verticalAlignment = Alignment.CenterVertically) {
-                                 Icon(
-                                     imageVector = Icons.Rounded.Folder,
-                                     contentDescription = null,
-                                     tint = accentColor,
-                                     modifier = Modifier.size(32.dp)
-                                 )
-                                 Spacer(modifier = Modifier.width(16.dp))
-                                 Column {
-                                     Text(
-                                         text = "Local Cache",
-                                         color = textColor,
-                                         fontWeight = FontWeight.SemiBold,
-                                         fontSize = 16.sp
-                                     )
-                                     Text(
-                                         text = com.ivor.ivormusic.data.CacheManager.formatSize(currentCacheSize), 
-                                         color = accentColor,
-                                         fontWeight = FontWeight.Bold,
-                                         fontSize = 24.sp
-                                     )
-                                 }
-                             }
-                        }
-                        
-                        // Limit Selector
-                        Column(modifier = Modifier.padding(16.dp)) {
-                            Text(
-                                text = "Max Cache Size",
-                                color = secondaryTextColor,
-                                fontSize = 13.sp,
-                                fontWeight = FontWeight.Medium,
-                                modifier = Modifier.padding(bottom = 8.dp)
-                            )
-                            SingleChoiceSegmentedButtonRow(
-                                modifier = Modifier.fillMaxWidth()
-                            ) {
-                                val options = listOf(256L, 512L, 1024L, 2048L)
-                                val labels = listOf("256MB", "512MB", "1GB", "2GB")
-                                
-                                options.forEachIndexed { index, size ->
-                                    SegmentedButton(
-                                        selected = maxCacheSizeMb == size,
-                                        onClick = { onMaxCacheSizeMbChange(size) },
-                                        shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size)
-                                    ) {
-                                        Text(text = labels[index])
-                                    }
-                                }
-                            }
-                        }
-                        
-                        SettingsDivider()
-                        
-                        // Clear Cache Button
-                        ExpressiveSettingsItem(
-                            icon = Icons.Rounded.FolderOff,
-                            title = "Clear Cache",
-                            subtitle = "Free up storage space",
-                            onClick = onClearCacheClick,
-                            textColor = Color(0xFFE53935),
-                            secondaryTextColor = secondaryTextColor,
-                            iconTint = Color(0xFFE53935)
-                        )
-                    }
-                }
-            }
-
-            // YouTube Music Section
-            item {
-                SettingsSection(
-                    title = "YouTube Music",
-                    textColor = secondaryTextColor
-                ) {
-                    ExpressiveSettingsCard(surfaceColor = surfaceColor) {
-                    if (isLoggedIn) {
-                            // Logged in state with user avatar
-                            key(accountRefreshKey) {
-                                ExpressiveAccountItem(
-                                    sessionManager = sessionManager,
-                                    textColor = textColor,
-                                    secondaryTextColor = secondaryTextColor
-                                )
-                            }
-                            SettingsDivider()
-                            // Save Video History Toggle
-                            ExpressiveSaveHistoryToggleItem(
-                                enabled = saveVideoHistory,
-                                onToggle = onSaveVideoHistoryToggle,
-                                textColor = textColor,
-                                secondaryTextColor = secondaryTextColor,
-                                accentColor = Color(0xFFFF0000) // YouTube red
-                            )
-                            SettingsDivider()
-                            ExpressiveSettingsItem(
-                                icon = Icons.Rounded.Cookie,
-                                title = "Replace Session Cookies",
-                                subtitle = "Paste a fresh cookie header if your session goes stale",
-                                onClick = { showCookiePasteSheet = true },
-                                textColor = textColor,
-                                secondaryTextColor = secondaryTextColor,
-                                iconTint = accentColor,
-                                showChevron = true
-                            )
-                            SettingsDivider()
-                            ExpressiveSettingsItem(
-                                icon = Icons.AutoMirrored.Rounded.Logout,
-                                title = "Sign Out",
-                                subtitle = "Disconnect your YouTube account",
-                                onClick = {
-                                    sessionManager.clearSession()
-                                    isLoggedIn = false
-                                    onLogoutClick()
-                                },
-                                textColor = Color(0xFFE53935),
-                                secondaryTextColor = secondaryTextColor,
-                                iconTint = Color(0xFFE53935)
-                            )
-                        } else {
-                            // Logged out state
-                            ExpressiveSettingsItem(
-                                icon = Icons.Rounded.MusicNote,
-                                title = "Connect YouTube Music",
-                                subtitle = "Sign in to access your playlists and liked songs",
-                                onClick = { showAuthDialog = true },
-                                textColor = textColor,
-                                secondaryTextColor = secondaryTextColor,
-                                iconTint = Color(0xFFFF0000),
-                                showChevron = true
-                            )
-                            SettingsDivider()
-                            ExpressiveSettingsItem(
-                                icon = Icons.Rounded.Cookie,
-                                title = "Sign In With Cookies",
-                                subtitle = "Paste a cookie header instead of using the web sign-in",
-                                onClick = { showCookiePasteSheet = true },
-                                textColor = textColor,
-                                secondaryTextColor = secondaryTextColor,
-                                iconTint = accentColor,
-                                showChevron = true
-                            )
-                        }
-                    }
-                }
-            }
-
-            // Notifications Section - only meaningful where the platform can
-            // actually promote an ongoing notification (Android 16+)
-            if (ThemePreferences.SUPPORTS_LIVE_UPDATES) {
-                item {
-                    SettingsSection(
-                        title = "Notifications",
-                        textColor = secondaryTextColor
-                    ) {
-                        ExpressiveSettingsCard(surfaceColor = surfaceColor) {
-                            ExpressiveOemToggleItem(
-                                icon = Icons.Rounded.Bolt,
-                                title = "Live download updates",
-                                subtitle = "Show download progress as a live status bar chip",
-                                enabled = liveDownloadUpdates,
-                                onToggle = onLiveDownloadUpdatesToggle,
-                                textColor = textColor,
-                                secondaryTextColor = secondaryTextColor,
-                                accentColor = accentColor
-                            )
-
-                            SettingsDivider()
-                            ExpressiveOemToggleItem(
-                                icon = Icons.Rounded.GraphicEq,
-                                title = "Live playback updates",
-                                subtitle = "Show what's playing as a live status bar chip",
-                                enabled = livePlaybackUpdates,
-                                onToggle = onLivePlaybackUpdatesToggle,
-                                textColor = textColor,
-                                secondaryTextColor = secondaryTextColor,
-                                accentColor = accentColor
-                            )
-
-                            // Promotion is a request the system can refuse. When
-                            // the user has revoked it at the OS level the toggles
-                            // above are a lie, so surface the way to fix it.
-                            if ((liveDownloadUpdates || livePlaybackUpdates) && !canPostPromoted) {
-                                SettingsDivider()
-                                ExpressiveSettingsItem(
-                                    icon = Icons.Rounded.Security,
-                                    title = "Blocked by system settings",
-                                    subtitle = "Allow live updates for Koda in Android settings",
-                                    onClick = {
-                                        notificationHelper
-                                            .promotedNotificationSettingsIntent()
-                                            ?.let { runCatching { context.startActivity(it) } }
-                                    },
-                                    textColor = Color(0xFFE53935),
-                                    secondaryTextColor = secondaryTextColor,
-                                    iconTint = Color(0xFFE53935),
-                                    showChevron = true
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Content Mode Section (Video/Music toggle)
-            item {
-                SettingsSection(
-                    title = "Content Mode",
-                    textColor = secondaryTextColor
-                ) {
-                    ExpressiveSettingsCard(surfaceColor = surfaceColor) {
-                        ExpressiveLocalOnlyToggleItem(
-                            enabled = localOnlyMode,
-                            onToggle = onLocalOnlyModeToggle,
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            accentColor = accentColor
-                        )
-
-                        SettingsDivider()
-
-                        ExpressiveVideoModeToggleItem(
-                            enabled = videoMode,
-                            onToggle = onVideoModeToggle,
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            accentColor = Color(0xFFFF0000) // YouTube red
-                        )
-
-                        SettingsDivider()
-
-                        ExpressiveHomeModeToggleItem(
-                            enabled = homeModeToggleEnabled,
-                            onToggle = onHomeModeToggleChange,
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            accentColor = accentColor
-                        )
-
-                        SettingsDivider()
-
-                        ExpressiveTimedCommentsToggleItem(
-                            enabled = timedCommentsEnabled,
-                            onToggle = onTimedCommentsToggle,
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            accentColor = accentColor
-                        )
-
-                        SettingsDivider()
-
-                        ExpressiveShortsToggleItem(
-                            enabled = shortsEnabled,
-                            onToggle = onShortsEnabledToggle,
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            accentColor = accentColor
-                        )
-
-                        // Shorts button visibility - only relevant while Shorts are on
-                        AnimatedVisibility(
-                            visible = shortsEnabled,
-                            enter = fadeIn(tween(200)) + slideInVertically(
-                                initialOffsetY = { -it / 4 },
-                                animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
-                            ),
-                            exit = fadeOut(tween(150))
-                        ) {
-                            Column {
-                                SettingsDivider()
-                                ExpressiveSettingsItem(
-                                    icon = Icons.Rounded.Visibility,
-                                    title = "Shorts Buttons",
-                                    subtitle = if (shortsHiddenActions.isEmpty()) "All buttons shown"
-                                        else "${shortsHiddenActions.size} hidden",
-                                    onClick = { showShortsButtonsDialog = true },
-                                    textColor = textColor,
-                                    secondaryTextColor = secondaryTextColor,
-                                    iconTint = accentColor,
-                                    showChevron = true
-                                )
-                            }
-                        }
-
-                        SettingsDivider()
-
-                        ExpressiveSettingsItem(
-                            icon = Icons.Rounded.Wifi,
-                            title = "Video Quality on Wi-Fi",
-                            subtitle = videoQualityLabel(videoQualityWifi),
-                            onClick = { qualityDialogTarget = QualityDialogTarget.VIDEO_WIFI },
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            iconTint = accentColor,
-                            showChevron = true
-                        )
-
-                        SettingsDivider()
-
-                        ExpressiveSettingsItem(
-                            icon = Icons.Rounded.SignalCellularAlt,
-                            title = "Video Quality on Mobile Data",
-                            subtitle = videoQualityLabel(videoQualityMobile),
-                            onClick = { qualityDialogTarget = QualityDialogTarget.VIDEO_MOBILE },
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            iconTint = accentColor,
-                            showChevron = true
-                        )
-
-                        SettingsDivider()
-
-                        ExpressiveOemToggleItem(
-                            icon = Icons.Rounded.HdrOn,
-                            title = "Prefer HDR Videos",
-                            subtitle = "Fetch HDR streams when a video has them",
-                            enabled = preferHdr,
-                            onToggle = onPreferHdrToggle,
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            accentColor = accentColor
-                        )
-
-                        SettingsDivider()
-
-                        ExpressiveSettingsItem(
-                            icon = Icons.Rounded.Subscriptions,
-                            title = "Manage Subscriptions",
-                            subtitle = "Import, export and group the channels you follow",
-                            onClick = onNavigateToSubscriptions,
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            iconTint = accentColor,
-                            showChevron = true
-                        )
-
-                        SettingsDivider()
-
-                        ExpressiveSettingsItem(
-                            icon = Icons.Rounded.NotInterested,
-                            title = "Not Recommended",
-                            subtitle = "Videos and channels you've hidden from your feeds",
-                            onClick = onNavigateToNotInterested,
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            iconTint = accentColor,
-                            showChevron = true
-                        )
-
-                        SettingsDivider()
-
-                        ExpressiveSettingsItem(
-                            icon = Icons.Rounded.FilterList,
-                            title = "Subscriptions Shown",
-                            subtitle = subscriptionSourceLabel(subscriptionSource),
-                            onClick = { subscriptionDialogTarget = SubscriptionDialogTarget.SOURCE },
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            iconTint = accentColor,
-                            showChevron = true
-                        )
-
-                        SettingsDivider()
-
-                        ExpressiveSettingsItem(
-                            icon = Icons.Rounded.BookmarkAdd,
-                            title = "Subscribe Saves To",
-                            subtitle = subscribeTargetLabel(subscribeTarget),
-                            onClick = { subscriptionDialogTarget = SubscriptionDialogTarget.TARGET },
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            iconTint = accentColor,
-                            showChevron = true
-                        )
-
-                        SettingsDivider()
-
-                        ExpressiveOemToggleItem(
-                            icon = Icons.Rounded.Bolt,
-                            title = "Fast Subscription Refresh",
-                            subtitle = if (fastSubscriptionFeed) {
-                                "Much less data and exact upload times, but no duration badges"
-                            } else {
-                                "Full details for every video - slow on a large subscription list"
-                            },
-                            enabled = fastSubscriptionFeed,
-                            onToggle = onFastSubscriptionFeedToggle,
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            accentColor = accentColor
-                        )
-                    }
-                }
-            }
-
-            // Library Section
-            item {
-                SettingsSection(
-                    title = "Library",
-                    textColor = secondaryTextColor
-                ) {
-                    ExpressiveSettingsCard(surfaceColor = surfaceColor) {
-                        ExpressiveLocalSongsToggleItem(
-                            loadLocalSongs = loadLocalSongs,
-                            onToggle = onLoadLocalSongsToggle,
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            accentColor = accentColor
-                        )
-                        
-                        // Folder Exclusion - only show when local songs are enabled
-                        AnimatedVisibility(
-                            visible = loadLocalSongs,
-                            enter = fadeIn(tween(200)) + slideInVertically(
-                                initialOffsetY = { -it / 4 },
-                                animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
-                            ),
-                            exit = fadeOut(tween(150))
-                        ) {
-                            Column {
-                                SettingsDivider()
-                                ExpressiveFolderExclusionItem(
-                                    excludedFoldersCount = excludedFolders.size,
-                                    onClick = {
-                                        // Load available folders when opening dialog
-                                        isFoldersLoading = true
-                                        coroutineScope.launch {
-                                            availableFolders = homeViewModel.getAvailableFolders()
-                                            isFoldersLoading = false
-                                        }
-                                        showFolderExclusionDialog = true
-                                    },
-                                    textColor = textColor,
-                                    secondaryTextColor = secondaryTextColor,
-                                    accentColor = accentColor
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-
-            // About Section
-            item {
-                SettingsSection(
-                    title = "About",
-                    textColor = secondaryTextColor
-                ) {
-                    ExpressiveSettingsCard(surfaceColor = surfaceColor) {
-                        ExpressiveSettingsItem(
-                            icon = Icons.Rounded.Info,
-                            title = "Koda",
-                            subtitle = "Version ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
-                            onClick = { showAboutDialog = true },
-                            textColor = textColor,
-                            secondaryTextColor = secondaryTextColor,
-                            iconTint = accentColor,
-                            showChevron = true
-                        )
-                    }
-                }
-            }
-
-            item {
-                Spacer(modifier = Modifier.height(32.dp))
+                SettingsPage.ADVANCED -> AdvancedSettingsPage(
+                    manualScanEnabled = manualScanEnabled,
+                    onManualScanEnabledToggle = onManualScanEnabledToggle,
+                    onBack = { page = SettingsPage.HUB }
+                )
             }
         }
     }
@@ -1217,7 +577,7 @@ fun SettingsScreen(
             onNavigateToUpdate = onNavigateToUpdate
         )
     }
-    
+
     // Per-network stream quality pickers (video + music, Wi-Fi + mobile data)
     qualityDialogTarget?.let { target ->
         val currentQuality = when (target) {
@@ -1285,50 +645,267 @@ fun SettingsScreen(
     }
 }
 
+/**
+ * The category list. Every row carries the live value of what is inside it, so
+ * the common "what is this set to?" question is answered without opening
+ * anything.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun SettingsSection(
-    title: String,
-    textColor: Color,
-    content: @Composable () -> Unit
+private fun SettingsHub(
+    isLoggedIn: Boolean,
+    accountRefreshKey: Int,
+    sessionManager: SessionManager,
+    currentThemeMode: ThemeMode,
+    colorPalette: String,
+    playerStyle: PlayerStyle,
+    musicQualityWifi: String,
+    videoQualityWifi: String,
+    localOnlyMode: Boolean,
+    videoMode: Boolean,
+    subscriptionSource: String,
+    cacheEnabled: Boolean,
+    currentCacheSize: Long,
+    liveDownloadUpdates: Boolean,
+    livePlaybackUpdates: Boolean,
+    canPostPromoted: Boolean,
+    loadLocalSongs: Boolean,
+    excludedFolderCount: Int,
+    onOpenPage: (SettingsPage) -> Unit,
+    onShowAbout: () -> Unit,
+    onBackClick: () -> Unit
 ) {
-    // No entrance animation on purpose: these live in a LazyColumn, which
-    // recomposes items as they scroll into view — any enter animation replays
-    // on every scroll and makes the cards look like they're "loading".
-    Column {
-        Text(
-            text = title.uppercase(),
-            color = textColor,
-            fontSize = 12.sp,
-            fontWeight = FontWeight.SemiBold,
-            letterSpacing = 1.2.sp,
-            modifier = Modifier.padding(start = 8.dp, bottom = 10.dp)
-        )
-        content()
+    // Animation states for staggered entry
+    var isVisible by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        delay(100)
+        isVisible = true
     }
-}
 
-@Composable
-private fun ExpressiveSettingsCard(
-    surfaceColor: Color,
-    content: @Composable () -> Unit
-) {
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(24.dp),
-        color = surfaceColor,
-        tonalElevation = 2.dp,
-        shadowElevation = 0.dp
-    ) {
-        Column(modifier = Modifier.padding(6.dp)) {
-            content()
+    val accountValue = key(accountRefreshKey) {
+        when {
+            !isLoggedIn -> "Not signed in"
+            else -> sessionManager.getUserName() ?: "Signed in"
+        }
+    }
+
+    val themeLabel = when (currentThemeMode) {
+        ThemeMode.SYSTEM -> "System"
+        ThemeMode.LIGHT -> "Light"
+        ThemeMode.DARK -> "Dark"
+    }
+    val paletteName = if (colorPalette == ThemePreferences.DEFAULT_COLOR_PALETTE) {
+        "Dynamic"
+    } else {
+        com.ivor.ivormusic.ui.theme.findPalette(colorPalette)?.name ?: "Dynamic"
+    }
+    val playerStyleLabel = (playerStyleOptions.firstOrNull { it.style == playerStyle }
+        ?: playerStyleOptions.first()).label
+
+    val contentValue = when {
+        localOnlyMode -> "Local only, offline"
+        videoMode -> "Video mode"
+        else -> "Music mode"
+    }
+
+    val storageValue = if (cacheEnabled) {
+        "${com.ivor.ivormusic.data.CacheManager.formatSize(currentCacheSize)} cached"
+    } else {
+        "Caching off"
+    }
+
+    val notificationsValue = when {
+        !canPostPromoted && (liveDownloadUpdates || livePlaybackUpdates) -> "Blocked by system"
+        liveDownloadUpdates && livePlaybackUpdates -> "Downloads and playback"
+        liveDownloadUpdates -> "Downloads only"
+        livePlaybackUpdates -> "Playback only"
+        else -> "Off"
+    }
+
+    val localLibraryValue = when {
+        !loadLocalSongs -> "Off"
+        excludedFolderCount > 0 -> "On, $excludedFolderCount folder${if (excludedFolderCount == 1) "" else "s"} excluded"
+        else -> "On"
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TopAppBar(
+            title = {
+                AnimatedVisibility(
+                    visible = isVisible,
+                    enter = fadeIn(tween(400)) + slideInVertically(
+                        initialOffsetY = { -it / 2 },
+                        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
+                    )
+                ) {
+                    Text(
+                        text = "Settings",
+                        color = MaterialTheme.colorScheme.onBackground,
+                        fontWeight = FontWeight.Bold,
+                        style = MaterialTheme.typography.headlineMedium
+                    )
+                }
+            },
+            navigationIcon = {
+                IconButton(
+                    onClick = onBackClick,
+                    shapes = IconButtonDefaults.shapes(),
+                    colors = IconButtonDefaults.iconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        contentColor = MaterialTheme.colorScheme.onBackground
+                    ),
+                    modifier = Modifier
+                        .padding(start = 8.dp)
+                        .size(44.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                        contentDescription = "Back"
+                    )
+                }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
+            modifier = Modifier.windowInsetsPadding(WindowInsets.statusBars)
+        )
+
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp)
+        ) {
+            item {
+                SettingsSection(title = "You") {
+                    SettingsCard {
+                        SettingsHubRow(
+                            icon = Icons.Rounded.AccountCircle,
+                            title = "Account",
+                            value = accountValue,
+                            onClick = { onOpenPage(SettingsPage.ACCOUNT) }
+                        )
+                    }
+                }
+            }
+
+            item {
+                SettingsSection(title = "Look and feel") {
+                    SettingsCard {
+                        SettingsHubRow(
+                            icon = Icons.Rounded.Palette,
+                            title = "Appearance",
+                            value = "$themeLabel, $paletteName",
+                            onClick = { onOpenPage(SettingsPage.APPEARANCE) }
+                        )
+                        SettingsDivider()
+                        SettingsHubRow(
+                            icon = Icons.Rounded.PlayCircle,
+                            title = "Player",
+                            value = playerStyleLabel,
+                            onClick = { onOpenPage(SettingsPage.PLAYER) }
+                        )
+                    }
+                }
+            }
+
+            item {
+                SettingsSection(title = "Playback and content") {
+                    SettingsCard {
+                        SettingsHubRow(
+                            icon = Icons.Rounded.GraphicEq,
+                            title = "Playback and quality",
+                            value = "${musicQualityLabel(musicQualityWifi)} music, " +
+                                "${videoQualityLabel(videoQualityWifi)} video on Wi-Fi",
+                            onClick = { onOpenPage(SettingsPage.PLAYBACK) }
+                        )
+                        SettingsDivider()
+                        SettingsHubRow(
+                            icon = Icons.Rounded.VideoLibrary,
+                            title = "Content and feeds",
+                            value = contentValue,
+                            onClick = { onOpenPage(SettingsPage.CONTENT) }
+                        )
+                        SettingsDivider()
+                        SettingsHubRow(
+                            icon = Icons.Rounded.Subscriptions,
+                            title = "Subscriptions",
+                            value = subscriptionSourceLabel(subscriptionSource),
+                            onClick = { onOpenPage(SettingsPage.SUBSCRIPTIONS) }
+                        )
+                    }
+                }
+            }
+
+            item {
+                SettingsSection(title = "System") {
+                    SettingsCard {
+                        SettingsHubRow(
+                            icon = Icons.Rounded.Folder,
+                            title = "Storage and cache",
+                            value = storageValue,
+                            onClick = { onOpenPage(SettingsPage.STORAGE) }
+                        )
+                        if (ThemePreferences.SUPPORTS_LIVE_UPDATES) {
+                            SettingsDivider()
+                            SettingsHubRow(
+                                icon = Icons.Rounded.Bolt,
+                                title = "Notifications",
+                                value = notificationsValue,
+                                onClick = { onOpenPage(SettingsPage.NOTIFICATIONS) },
+                                tint = if (!canPostPromoted && (liveDownloadUpdates || livePlaybackUpdates)) {
+                                    SettingsRowDefaults.destructiveTint
+                                } else {
+                                    MaterialTheme.colorScheme.primary
+                                }
+                            )
+                        }
+                        SettingsDivider()
+                        SettingsHubRow(
+                            icon = Icons.Rounded.MusicNote,
+                            title = "Local library",
+                            value = localLibraryValue,
+                            onClick = { onOpenPage(SettingsPage.LOCAL_LIBRARY) }
+                        )
+                        SettingsDivider()
+                        SettingsHubRow(
+                            icon = Icons.Rounded.Security,
+                            title = "Advanced",
+                            value = if (isXiaomiDevice()) {
+                                "Recommended on this device"
+                            } else {
+                                "Scanning and battery fixes"
+                            },
+                            onClick = { onOpenPage(SettingsPage.ADVANCED) },
+                            tint = if (isXiaomiDevice()) {
+                                MaterialTheme.colorScheme.tertiary
+                            } else {
+                                MaterialTheme.colorScheme.primary
+                            }
+                        )
+                    }
+                }
+            }
+
+            item {
+                SettingsSection(title = "About") {
+                    SettingsCard {
+                        SettingsRow(
+                            icon = Icons.Rounded.Info,
+                            title = "Koda",
+                            subtitle = "Version ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
+                            onClick = onShowAbout,
+                            showChevron = true
+                        )
+                    }
+                }
+            }
+
+            item { Spacer(modifier = Modifier.height(32.dp)) }
         }
     }
 }
 
-
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun ExpressiveThemeSelectGroup(
+internal fun ExpressiveThemeSelectGroup(
     currentMode: ThemeMode,
     onModeSelected: (ThemeMode) -> Unit,
     textColor: Color,
@@ -1388,103 +965,15 @@ private fun ExpressiveThemeSelectGroup(
 }
 
 @Composable
-private fun ExpressiveSettingsItem(
-    icon: ImageVector,
-    title: String,
-    subtitle: String,
-    onClick: () -> Unit,
-    textColor: Color,
-    secondaryTextColor: Color,
-    iconTint: Color,
-    showChevron: Boolean = false
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    val isPressed by interactionSource.collectIsPressedAsState()
-    
-    val scale by animateFloatAsState(
-        targetValue = if (isPressed) 0.97f else 1f,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
-        label = "scale"
-    )
-    
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .scale(scale)
-            .clip(RoundedCornerShape(18.dp))
-            .clickable(
-                interactionSource = interactionSource,
-                indication = null,
-                onClick = onClick
-            )
-            .padding(horizontal = 16.dp, vertical = 14.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        // Icon with expressive background
-        Box(
-            modifier = Modifier
-                .size(48.dp)
-                .clip(RoundedCornerShape(14.dp))
-                .background(iconTint.copy(alpha = 0.12f)),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                tint = iconTint,
-                modifier = Modifier.size(26.dp)
-            )
-        }
-
-        Spacer(modifier = Modifier.width(16.dp))
-
-        // Text
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = title,
-                color = textColor,
-                fontSize = 16.sp,
-                fontWeight = FontWeight.SemiBold
-            )
-            Spacer(modifier = Modifier.height(2.dp))
-            Text(
-                text = subtitle,
-                color = secondaryTextColor,
-                fontSize = 13.sp
-            )
-        }
-
-        if (showChevron) {
-            Icon(
-                imageVector = Icons.Rounded.ChevronRight,
-                contentDescription = null,
-                tint = secondaryTextColor,
-                modifier = Modifier.size(24.dp)
-            )
-        }
-    }
-}
-
-@Composable
-private fun SettingsDivider() {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 20.dp, vertical = 4.dp)
-            .height(1.dp)
-            .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
-    )
-}
-
-@Composable
-private fun ExpressiveAccountItem(
+internal fun ExpressiveAccountItem(
     sessionManager: SessionManager,
     textColor: Color,
     secondaryTextColor: Color
 ) {
     val userAvatar = sessionManager.getUserAvatar()
     val userName = sessionManager.getUserName()
-    
+    val connectedColor = MaterialTheme.colorScheme.primary
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -1497,7 +986,7 @@ private fun ExpressiveAccountItem(
             modifier = Modifier
                 .size(52.dp)
                 .clip(CircleShape)
-                .background(Color(0xFF4CAF50).copy(alpha = 0.12f)),
+                .background(connectedColor.copy(alpha = 0.12f)),
             contentAlignment = Alignment.Center
         ) {
             if (!userAvatar.isNullOrEmpty()) {
@@ -1513,7 +1002,7 @@ private fun ExpressiveAccountItem(
                 Icon(
                     imageVector = Icons.Rounded.AccountCircle,
                     contentDescription = null,
-                    tint = Color(0xFF4CAF50),
+                    tint = connectedColor,
                     modifier = Modifier.size(32.dp)
                 )
             }
@@ -1539,12 +1028,12 @@ private fun ExpressiveAccountItem(
                 Icon(
                     imageVector = Icons.Rounded.CheckCircle,
                     contentDescription = null,
-                    tint = Color(0xFF4CAF50),
+                    tint = connectedColor,
                     modifier = Modifier.size(14.dp)
                 )
                 Text(
                     text = "Connected",
-                    color = Color(0xFF4CAF50),
+                    color = connectedColor,
                     fontSize = 13.sp,
                     fontWeight = FontWeight.Medium
                 )
@@ -1553,329 +1042,9 @@ private fun ExpressiveAccountItem(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
-@Composable
-private fun ExpressiveLocalSongsToggleItem(
-    loadLocalSongs: Boolean,
-    onToggle: (Boolean) -> Unit,
-    textColor: Color,
-    secondaryTextColor: Color,
-    accentColor: Color
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    val isPressed by interactionSource.collectIsPressedAsState()
-    
-    val scale by animateFloatAsState(
-        targetValue = if (isPressed) 0.97f else 1f,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
-        label = "scale"
-    )
-    
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .scale(scale)
-            .clip(RoundedCornerShape(18.dp))
-            .clickable(
-                interactionSource = interactionSource,
-                indication = null
-            ) { onToggle(!loadLocalSongs) }
-            .padding(horizontal = 16.dp, vertical = 14.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        // Icon
-        Box(
-            modifier = Modifier
-                .size(48.dp)
-                .clip(RoundedCornerShape(14.dp))
-                .background(accentColor.copy(alpha = 0.12f)),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = Icons.Rounded.Folder,
-                contentDescription = null,
-                tint = accentColor,
-                modifier = Modifier.size(26.dp)
-            )
-        }
-
-        Spacer(modifier = Modifier.width(16.dp))
-
-        // Text
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = "Load Local Songs",
-                color = textColor,
-                fontSize = 16.sp,
-                fontWeight = FontWeight.SemiBold
-            )
-            Spacer(modifier = Modifier.height(2.dp))
-            Text(
-                text = if (loadLocalSongs) "Shows songs from your device" else "YouTube Music only",
-                color = secondaryTextColor,
-                fontSize = 13.sp
-            )
-        }
-
-        // Switch
-        Switch(
-            checked = loadLocalSongs,
-            onCheckedChange = onToggle,
-            colors = SwitchDefaults.colors(
-                checkedThumbColor = Color.White,
-                checkedTrackColor = accentColor,
-                uncheckedThumbColor = Color.White,
-                uncheckedTrackColor = secondaryTextColor.copy(alpha = 0.3f),
-                uncheckedBorderColor = Color.Transparent,
-                checkedBorderColor = Color.Transparent
-            )
-        )
-    }
-}
-
-/**
- * Local only mode: the app stays fully offline — device library only, all
- * YouTube features and network calls disabled.
- */
-@Composable
-private fun ExpressiveLocalOnlyToggleItem(
-    enabled: Boolean,
-    onToggle: (Boolean) -> Unit,
-    textColor: Color,
-    secondaryTextColor: Color,
-    accentColor: Color
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    val isPressed by interactionSource.collectIsPressedAsState()
-
-    val scale by animateFloatAsState(
-        targetValue = if (isPressed) 0.97f else 1f,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
-        label = "scale"
-    )
-
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .scale(scale)
-            .clip(RoundedCornerShape(18.dp))
-            .clickable(
-                interactionSource = interactionSource,
-                indication = null
-            ) { onToggle(!enabled) }
-            .padding(horizontal = 16.dp, vertical = 14.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Box(
-            modifier = Modifier
-                .size(48.dp)
-                .clip(RoundedCornerShape(14.dp))
-                .background(accentColor.copy(alpha = 0.12f)),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = Icons.Rounded.CloudOff,
-                contentDescription = null,
-                tint = accentColor,
-                modifier = Modifier.size(26.dp)
-            )
-        }
-
-        Spacer(modifier = Modifier.width(16.dp))
-
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = "Local Only",
-                color = textColor,
-                fontSize = 16.sp,
-                fontWeight = FontWeight.SemiBold
-            )
-            Spacer(modifier = Modifier.height(2.dp))
-            Text(
-                text = if (enabled) "Offline: device library only, no internet"
-                else "YouTube features enabled",
-                color = secondaryTextColor,
-                fontSize = 13.sp
-            )
-        }
-
-        Switch(
-            checked = enabled,
-            onCheckedChange = onToggle,
-            colors = SwitchDefaults.colors(
-                checkedThumbColor = Color.White,
-                checkedTrackColor = accentColor,
-                uncheckedThumbColor = Color.White,
-                uncheckedTrackColor = secondaryTextColor.copy(alpha = 0.3f),
-                uncheckedBorderColor = Color.Transparent,
-                checkedBorderColor = Color.Transparent
-            )
-        )
-    }
-}
-
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
-@Composable
-private fun ExpressiveAmoledThemeToggleItem(
-    enabled: Boolean,
-    onToggle: (Boolean) -> Unit,
-    textColor: Color,
-    secondaryTextColor: Color,
-    accentColor: Color
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    val isPressed by interactionSource.collectIsPressedAsState()
-
-    val scale by animateFloatAsState(
-        targetValue = if (isPressed) 0.97f else 1f,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
-        label = "scale"
-    )
-
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .scale(scale)
-            .clip(RoundedCornerShape(18.dp))
-            .clickable(
-                interactionSource = interactionSource,
-                indication = null
-            ) { onToggle(!enabled) }
-            .padding(horizontal = 16.dp, vertical = 14.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        // Icon
-        Box(
-            modifier = Modifier
-                .size(48.dp)
-                .clip(RoundedCornerShape(14.dp))
-                .background(accentColor.copy(alpha = 0.12f)),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = Icons.Rounded.Contrast,
-                contentDescription = null,
-                tint = accentColor,
-                modifier = Modifier.size(26.dp)
-            )
-        }
-
-        Spacer(modifier = Modifier.width(16.dp))
-
-        // Text
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = "AMOLED Black",
-                color = textColor,
-                fontSize = 16.sp,
-                fontWeight = FontWeight.SemiBold
-            )
-            Spacer(modifier = Modifier.height(2.dp))
-            Text(
-                text = if (enabled) "Pure black backgrounds in dark theme" else "Standard dark backgrounds",
-                color = secondaryTextColor,
-                fontSize = 13.sp
-            )
-        }
-
-        // Switch
-        Switch(
-            checked = enabled,
-            onCheckedChange = onToggle,
-            colors = SwitchDefaults.colors(
-                checkedThumbColor = Color.White,
-                checkedTrackColor = accentColor,
-                uncheckedThumbColor = Color.White,
-                uncheckedTrackColor = secondaryTextColor.copy(alpha = 0.3f),
-                uncheckedBorderColor = Color.Transparent,
-                checkedBorderColor = Color.Transparent
-            )
-        )
-    }
-}
-
-@Composable
-private fun ExpressiveAmbientBackgroundToggleItem(
-    enabled: Boolean,
-    onToggle: (Boolean) -> Unit,
-    textColor: Color,
-    secondaryTextColor: Color,
-    accentColor: Color
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    val isPressed by interactionSource.collectIsPressedAsState()
-    
-    val scale by animateFloatAsState(
-        targetValue = if (isPressed) 0.97f else 1f,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
-        label = "scale"
-    )
-    
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .scale(scale)
-            .clip(RoundedCornerShape(18.dp))
-            .clickable(
-                interactionSource = interactionSource,
-                indication = null
-            ) { onToggle(!enabled) }
-            .padding(horizontal = 16.dp, vertical = 14.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        // Icon
-        Box(
-            modifier = Modifier
-                .size(48.dp)
-                .clip(RoundedCornerShape(14.dp))
-                .background(accentColor.copy(alpha = 0.12f)),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = Icons.Rounded.Palette,
-                contentDescription = null,
-                tint = accentColor,
-                modifier = Modifier.size(26.dp)
-            )
-        }
-
-        Spacer(modifier = Modifier.width(16.dp))
-
-        // Text
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = "Ambient Background",
-                color = textColor,
-                fontSize = 16.sp,
-                fontWeight = FontWeight.SemiBold
-            )
-            Spacer(modifier = Modifier.height(2.dp))
-            Text(
-                text = if (enabled) "Dynamic colors from album art" else "Solid background",
-                color = secondaryTextColor,
-                fontSize = 13.sp
-            )
-        }
-
-        // Switch
-        Switch(
-            checked = enabled,
-            onCheckedChange = onToggle,
-            colors = SwitchDefaults.colors(
-                checkedThumbColor = Color.White,
-                checkedTrackColor = accentColor,
-                uncheckedThumbColor = Color.White,
-                uncheckedTrackColor = secondaryTextColor.copy(alpha = 0.3f),
-                uncheckedBorderColor = Color.Transparent,
-                checkedBorderColor = Color.Transparent
-            )
-        )
-    }
-}
-
 @OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
 @Composable
-private fun ExpressiveVideoModeToggleItem(
+internal fun ExpressiveVideoModeToggleItem(
     enabled: Boolean,
     onToggle: (Boolean) -> Unit,
     textColor: Color,
@@ -1961,343 +1130,14 @@ private fun ExpressiveVideoModeToggleItem(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
-@Composable
-private fun ExpressiveHomeModeToggleItem(
-    enabled: Boolean,
-    onToggle: (Boolean) -> Unit,
-    textColor: Color,
-    secondaryTextColor: Color,
-    accentColor: Color
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    val isPressed by interactionSource.collectIsPressedAsState()
-
-    val scale by animateFloatAsState(
-        targetValue = if (isPressed) 0.97f else 1f,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
-        label = "scale"
-    )
-
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .scale(scale)
-            .clip(RoundedCornerShape(18.dp))
-            .clickable(
-                interactionSource = interactionSource,
-                indication = null
-            ) { onToggle(!enabled) }
-            .padding(horizontal = 16.dp, vertical = 14.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        // Icon
-        Box(
-            modifier = Modifier
-                .size(48.dp)
-                .clip(RoundedCornerShape(14.dp))
-                .background(accentColor.copy(alpha = 0.12f)),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = Icons.Rounded.ToggleOn,
-                contentDescription = null,
-                tint = accentColor,
-                modifier = Modifier.size(26.dp)
-            )
-        }
-
-        Spacer(modifier = Modifier.width(16.dp))
-
-        // Text
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = "Home Screen Mode Toggle",
-                color = textColor,
-                fontSize = 16.sp,
-                fontWeight = FontWeight.SemiBold
-            )
-            Spacer(modifier = Modifier.height(2.dp))
-            Text(
-                text = if (enabled) "Music/video switch shown in the Home top bar" else "Switch modes from Settings only",
-                color = secondaryTextColor,
-                fontSize = 13.sp
-            )
-        }
-
-        // Switch
-        Switch(
-            checked = enabled,
-            onCheckedChange = onToggle,
-            colors = SwitchDefaults.colors(
-                checkedThumbColor = Color.White,
-                checkedTrackColor = accentColor,
-                uncheckedThumbColor = Color.White,
-                uncheckedTrackColor = secondaryTextColor.copy(alpha = 0.3f),
-                uncheckedBorderColor = Color.Transparent,
-                checkedBorderColor = Color.Transparent
-            )
-        )
-    }
-}
-
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
-@Composable
-private fun ExpressiveTimedCommentsToggleItem(
-    enabled: Boolean,
-    onToggle: (Boolean) -> Unit,
-    textColor: Color,
-    secondaryTextColor: Color,
-    accentColor: Color
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    val isPressed by interactionSource.collectIsPressedAsState()
-
-    val scale by animateFloatAsState(
-        targetValue = if (isPressed) 0.97f else 1f,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
-        label = "scale"
-    )
-
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .scale(scale)
-            .clip(RoundedCornerShape(18.dp))
-            .clickable(
-                interactionSource = interactionSource,
-                indication = null
-            ) { onToggle(!enabled) }
-            .padding(horizontal = 16.dp, vertical = 14.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        // Icon
-        Box(
-            modifier = Modifier
-                .size(48.dp)
-                .clip(RoundedCornerShape(14.dp))
-                .background(accentColor.copy(alpha = 0.12f)),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Rounded.Comment,
-                contentDescription = null,
-                tint = accentColor,
-                modifier = Modifier.size(26.dp)
-            )
-        }
-
-        Spacer(modifier = Modifier.width(16.dp))
-
-        // Text
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = "Timed Comments",
-                color = textColor,
-                fontSize = 16.sp,
-                fontWeight = FontWeight.SemiBold
-            )
-            Spacer(modifier = Modifier.height(2.dp))
-            Text(
-                text = if (enabled) "Timestamped comments briefly appear over videos" else "Adds a comments button to the video player",
-                color = secondaryTextColor,
-                fontSize = 13.sp
-            )
-        }
-
-        // Switch
-        Switch(
-            checked = enabled,
-            onCheckedChange = onToggle,
-            colors = SwitchDefaults.colors(
-                checkedThumbColor = Color.White,
-                checkedTrackColor = accentColor,
-                uncheckedThumbColor = Color.White,
-                uncheckedTrackColor = secondaryTextColor.copy(alpha = 0.3f),
-                uncheckedBorderColor = Color.Transparent,
-                checkedBorderColor = Color.Transparent
-            )
-        )
-    }
-}
-
-/**
- * Opt-in toggle for YouTube Shorts, off by default. The subtitle carries a
- * deliberate warning: short-form feeds are engineered to be compulsive, so
- * the user should choose them consciously rather than get them by default.
- */
-@Composable
-private fun ExpressiveShortsToggleItem(
-    enabled: Boolean,
-    onToggle: (Boolean) -> Unit,
-    textColor: Color,
-    secondaryTextColor: Color,
-    accentColor: Color
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    val isPressed by interactionSource.collectIsPressedAsState()
-
-    val scale by animateFloatAsState(
-        targetValue = if (isPressed) 0.97f else 1f,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
-        label = "scale"
-    )
-
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .scale(scale)
-            .clip(RoundedCornerShape(18.dp))
-            .clickable(
-                interactionSource = interactionSource,
-                indication = null
-            ) { onToggle(!enabled) }
-            .padding(horizontal = 16.dp, vertical = 14.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        // Icon
-        Box(
-            modifier = Modifier
-                .size(48.dp)
-                .clip(RoundedCornerShape(14.dp))
-                .background(accentColor.copy(alpha = 0.12f)),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = Icons.Rounded.Bolt,
-                contentDescription = null,
-                tint = accentColor,
-                modifier = Modifier.size(26.dp)
-            )
-        }
-
-        Spacer(modifier = Modifier.width(16.dp))
-
-        // Text
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = "Shorts",
-                color = textColor,
-                fontSize = 16.sp,
-                fontWeight = FontWeight.SemiBold
-            )
-            Spacer(modifier = Modifier.height(2.dp))
-            Text(
-                text = if (enabled) {
-                    "Shorts shelf shown in video mode. Mind your screen time"
-                } else {
-                    "Off by default. Endless short-form feeds are designed to keep you scrolling"
-                },
-                color = if (enabled) MaterialTheme.colorScheme.error.copy(alpha = 0.9f)
-                    else secondaryTextColor,
-                fontSize = 13.sp
-            )
-        }
-
-        // Switch
-        Switch(
-            checked = enabled,
-            onCheckedChange = onToggle,
-            colors = SwitchDefaults.colors(
-                checkedThumbColor = Color.White,
-                checkedTrackColor = accentColor,
-                uncheckedThumbColor = Color.White,
-                uncheckedTrackColor = secondaryTextColor.copy(alpha = 0.3f),
-                uncheckedBorderColor = Color.Transparent,
-                checkedBorderColor = Color.Transparent
-            )
-        )
-    }
-}
-
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
-@Composable
-private fun ExpressiveSaveHistoryToggleItem(
-    enabled: Boolean,
-    onToggle: (Boolean) -> Unit,
-    textColor: Color,
-    secondaryTextColor: Color,
-    accentColor: Color
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    val isPressed by interactionSource.collectIsPressedAsState()
-    
-    val scale by animateFloatAsState(
-        targetValue = if (isPressed) 0.97f else 1f,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
-        label = "scale"
-    )
-    
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .scale(scale)
-            .clip(RoundedCornerShape(18.dp))
-            .clickable(
-                interactionSource = interactionSource,
-                indication = null
-            ) { onToggle(!enabled) }
-            .padding(horizontal = 16.dp, vertical = 14.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        // Icon
-        Box(
-            modifier = Modifier
-                .size(48.dp)
-                .clip(RoundedCornerShape(14.dp))
-                .background(accentColor.copy(alpha = 0.12f)),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = Icons.Rounded.CheckCircle,
-                contentDescription = null,
-                tint = accentColor,
-                modifier = Modifier.size(26.dp)
-            )
-        }
-
-        Spacer(modifier = Modifier.width(16.dp))
-
-        // Text
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = "Save Watch History",
-                color = textColor,
-                fontSize = 16.sp,
-                fontWeight = FontWeight.SemiBold
-            )
-            Spacer(modifier = Modifier.height(2.dp))
-            Text(
-                text = if (enabled) "Videos saved to your YouTube account" else "Watch history not saved",
-                color = secondaryTextColor,
-                fontSize = 13.sp
-            )
-        }
-
-        // Switch
-        Switch(
-            checked = enabled,
-            onCheckedChange = onToggle,
-            colors = SwitchDefaults.colors(
-                checkedThumbColor = Color.White,
-                checkedTrackColor = accentColor,
-                uncheckedThumbColor = Color.White,
-                uncheckedTrackColor = secondaryTextColor.copy(alpha = 0.3f),
-                uncheckedBorderColor = Color.Transparent,
-                checkedBorderColor = Color.Transparent
-            )
-        )
-    }
-}
-
-private data class PlayerStyleOption(
+internal data class PlayerStyleOption(
     val style: PlayerStyle,
     val label: String,
     val subtitle: String,
     val icon: androidx.compose.ui.graphics.vector.ImageVector
 )
 
-private val playerStyleOptions = listOf(
+internal val playerStyleOptions = listOf(
     PlayerStyleOption(PlayerStyle.CLASSIC, "Classic", "Button controls for playback", Icons.Rounded.PlayCircle),
     PlayerStyleOption(PlayerStyle.GESTURE, "Gesture", "Swipe album art to navigate", Icons.Rounded.SwipeRight),
     PlayerStyleOption(PlayerStyle.EDITORIAL, "Editorial", "Two-tone magazine layout", Icons.Rounded.Newspaper),
@@ -2310,7 +1150,7 @@ private val playerStyleOptions = listOf(
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
-private fun ExpressivePlayerStyleSelectItem(
+internal fun ExpressivePlayerStyleSelectItem(
     currentStyle: PlayerStyle,
     onStyleSelected: (PlayerStyle) -> Unit,
     textColor: Color,
@@ -2392,11 +1232,11 @@ private fun ExpressivePlayerStyleSelectItem(
 }
 
 /** Human-readable label for a stored default video quality value. */
-private fun videoQualityLabel(value: String): String =
+internal fun videoQualityLabel(value: String): String =
     if (value == ThemePreferences.VIDEO_QUALITY_AUTO) "Auto (Highest)" else value
 
 /** Human-readable label for a stored music quality value. */
-private fun musicQualityLabel(value: String): String = when (value) {
+internal fun musicQualityLabel(value: String): String = when (value) {
     ThemePreferences.MUSIC_QUALITY_LOW -> "Data Saver"
     ThemePreferences.MUSIC_QUALITY_NORMAL -> "Normal"
     else -> "High"
@@ -2410,14 +1250,14 @@ private fun musicQualityOptionLabel(value: String): String = when (value) {
 }
 
 /** Short label for the stored "which subscriptions to show" value. */
-private fun subscriptionSourceLabel(value: String): String = when (value) {
+internal fun subscriptionSourceLabel(value: String): String = when (value) {
     ThemePreferences.SUBSCRIPTIONS_LOCAL -> "On this device"
     ThemePreferences.SUBSCRIPTIONS_YOUTUBE -> "YouTube account"
     else -> "Everything you follow"
 }
 
 /** Short label for the stored "where Subscribe writes" value. */
-private fun subscribeTargetLabel(value: String): String = when (value) {
+internal fun subscribeTargetLabel(value: String): String = when (value) {
     ThemePreferences.SUBSCRIPTIONS_LOCAL -> "This device only"
     ThemePreferences.SUBSCRIPTIONS_YOUTUBE -> "YouTube account"
     ThemePreferences.SUBSCRIPTIONS_BOTH -> "Device and YouTube"
@@ -2447,7 +1287,7 @@ private fun subscribeTargetOptionLabel(value: String): Pair<String, String> = wh
 }
 
 /** One subscription-routing picker the Settings screen can open. */
-private enum class SubscriptionDialogTarget(
+internal enum class SubscriptionDialogTarget(
     val title: String,
     val description: String
 ) {
@@ -2586,7 +1426,7 @@ private fun SubscriptionRoutingDialog(
 }
 
 /** One per-network quality picker the Settings screen can open. */
-private enum class QualityDialogTarget(
+internal enum class QualityDialogTarget(
     val title: String,
     val description: String,
     val isMusic: Boolean
@@ -2931,85 +1771,6 @@ private fun AboutDetailRow(
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun ExpressiveFolderExclusionItem(
-    excludedFoldersCount: Int,
-    onClick: () -> Unit,
-    textColor: Color,
-    secondaryTextColor: Color,
-    accentColor: Color
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    val isPressed by interactionSource.collectIsPressedAsState()
-    
-    val scale by animateFloatAsState(
-        targetValue = if (isPressed) 0.97f else 1f,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
-        label = "scale"
-    )
-    
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .scale(scale)
-            .clip(RoundedCornerShape(18.dp))
-            .clickable(
-                interactionSource = interactionSource,
-                indication = null,
-                onClick = onClick
-            )
-            .padding(horizontal = 16.dp, vertical = 14.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        // Icon
-        Box(
-            modifier = Modifier
-                .size(48.dp)
-                .clip(RoundedCornerShape(14.dp))
-                .background(
-                    if (excludedFoldersCount > 0) Color(0xFFE57373).copy(alpha = 0.12f)
-                    else accentColor.copy(alpha = 0.12f)
-                ),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = if (excludedFoldersCount > 0) Icons.Rounded.FolderOff else Icons.Rounded.Folder,
-                contentDescription = null,
-                tint = if (excludedFoldersCount > 0) Color(0xFFE57373) else accentColor,
-                modifier = Modifier.size(26.dp)
-            )
-        }
-
-        Spacer(modifier = Modifier.width(16.dp))
-
-        // Text
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = "Excluded Folders",
-                color = textColor,
-                fontSize = 16.sp,
-                fontWeight = FontWeight.SemiBold
-            )
-            Spacer(modifier = Modifier.height(2.dp))
-            Text(
-                text = if (excludedFoldersCount == 0) "All folders included"
-                       else "$excludedFoldersCount folder${if (excludedFoldersCount > 1) "s" else ""} hidden",
-                color = secondaryTextColor,
-                fontSize = 13.sp
-            )
-        }
-
-        // Chevron
-        Icon(
-            imageVector = Icons.Rounded.ChevronRight,
-            contentDescription = null,
-            tint = secondaryTextColor,
-            modifier = Modifier.size(24.dp)
-        )
-    }
-}
-
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
-@Composable
 private fun FolderExclusionDialog(
     availableFolders: List<FolderInfo>,
     excludedFolders: Set<String>,
@@ -3196,7 +1957,8 @@ private fun FolderItem(
     accentColor: Color
 ) {
     val interactionSource = remember { MutableInteractionSource() }
-    
+    val excludedColor = MaterialTheme.colorScheme.error
+
     Surface(
         modifier = Modifier
             .fillMaxWidth()
@@ -3207,7 +1969,7 @@ private fun FolderItem(
                 onClick = onToggle
             ),
         shape = RoundedCornerShape(12.dp),
-        color = if (isExcluded) Color(0xFFE57373).copy(alpha = 0.08f) else Color.Transparent
+        color = if (isExcluded) excludedColor.copy(alpha = 0.08f) else Color.Transparent
     ) {
         Row(
             modifier = Modifier
@@ -3220,7 +1982,7 @@ private fun FolderItem(
                 checked = isExcluded,
                 onCheckedChange = { onToggle() },
                 colors = CheckboxDefaults.colors(
-                    checkedColor = Color(0xFFE57373),
+                    checkedColor = excludedColor,
                     uncheckedColor = secondaryTextColor.copy(alpha = 0.5f),
                     checkmarkColor = Color.White
                 )
@@ -3232,7 +1994,7 @@ private fun FolderItem(
             Icon(
                 imageVector = if (isExcluded) Icons.Rounded.FolderOff else Icons.Rounded.Folder,
                 contentDescription = null,
-                tint = if (isExcluded) Color(0xFFE57373) else accentColor,
+                tint = if (isExcluded) excludedColor else accentColor,
                 modifier = Modifier.size(24.dp)
             )
             
@@ -3242,7 +2004,7 @@ private fun FolderItem(
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = folder.displayName,
-                    color = if (isExcluded) Color(0xFFE57373) else textColor,
+                    color = if (isExcluded) excludedColor else textColor,
                     fontSize = 14.sp,
                     fontWeight = FontWeight.Medium,
                     maxLines = 1,
@@ -3477,89 +2239,7 @@ private fun ShortsButtonShapeToggle(
     }
 }
 
-@Composable
-private fun ExpressiveOemToggleItem(
-    icon: ImageVector,
-    title: String,
-    subtitle: String,
-    enabled: Boolean,
-    onToggle: (Boolean) -> Unit,
-    textColor: Color,
-    secondaryTextColor: Color,
-    accentColor: Color
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    val isPressed by interactionSource.collectIsPressedAsState()
-    
-    val scale by animateFloatAsState(
-        targetValue = if (isPressed) 0.97f else 1f,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
-        label = "scale"
-    )
-    
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .scale(scale)
-            .clip(RoundedCornerShape(18.dp))
-            .clickable(
-                interactionSource = interactionSource,
-                indication = null
-            ) { onToggle(!enabled) }
-            .padding(horizontal = 16.dp, vertical = 14.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        // Icon
-        Box(
-            modifier = Modifier
-                .size(48.dp)
-                .clip(RoundedCornerShape(14.dp))
-                .background(accentColor.copy(alpha = 0.12f)),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                tint = accentColor,
-                modifier = Modifier.size(26.dp)
-            )
-        }
-
-        Spacer(modifier = Modifier.width(16.dp))
-
-        // Text
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = title,
-                color = textColor,
-                fontSize = 16.sp,
-                fontWeight = FontWeight.SemiBold
-            )
-            Spacer(modifier = Modifier.height(2.dp))
-            Text(
-                text = subtitle,
-                color = secondaryTextColor,
-                fontSize = 13.sp
-            )
-        }
-
-        // Switch
-        Switch(
-            checked = enabled,
-            onCheckedChange = onToggle,
-            colors = SwitchDefaults.colors(
-                checkedThumbColor = Color.White,
-                checkedTrackColor = accentColor,
-                uncheckedThumbColor = Color.White,
-                uncheckedTrackColor = secondaryTextColor.copy(alpha = 0.3f),
-                uncheckedBorderColor = Color.Transparent,
-                checkedBorderColor = Color.Transparent
-            )
-        )
-    }
-}
-
-private fun isXiaomiDevice(): Boolean {
+internal fun isXiaomiDevice(): Boolean {
     val manufacturer = android.os.Build.MANUFACTURER.lowercase()
     val brand = android.os.Build.BRAND.lowercase()
     return manufacturer.contains("xiaomi") || brand.contains("xiaomi") || 

--- a/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsSearch.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/settings/SettingsSearch.kt
@@ -1,0 +1,632 @@
+package com.ivor.ivormusic.ui.settings
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.Comment
+import androidx.compose.material.icons.automirrored.rounded.Logout
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
+import androidx.compose.material.icons.rounded.AccountCircle
+import androidx.compose.material.icons.rounded.Bolt
+import androidx.compose.material.icons.rounded.BookmarkAdd
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.CloudOff
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Contrast
+import androidx.compose.material.icons.rounded.Cookie
+import androidx.compose.material.icons.rounded.FilterList
+import androidx.compose.material.icons.rounded.FlashOn
+import androidx.compose.material.icons.rounded.Folder
+import androidx.compose.material.icons.rounded.FolderOff
+import androidx.compose.material.icons.rounded.GraphicEq
+import androidx.compose.material.icons.rounded.HdrOn
+import androidx.compose.material.icons.rounded.Info
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.NotInterested
+import androidx.compose.material.icons.rounded.Palette
+import androidx.compose.material.icons.rounded.PlayCircle
+import androidx.compose.material.icons.rounded.Save
+import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material.icons.rounded.SearchOff
+import androidx.compose.material.icons.rounded.Security
+import androidx.compose.material.icons.rounded.SignalCellularAlt
+import androidx.compose.material.icons.rounded.Subscriptions
+import androidx.compose.material.icons.rounded.ToggleOn
+import androidx.compose.material.icons.rounded.VideoLibrary
+import androidx.compose.material.icons.rounded.Visibility
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Settings search.
+ *
+ * The screen carries about fifty individual settings, and people do not know
+ * what they are called - they know what they want. So the index carries
+ * synonyms alongside each title ("offline" finds Local Only, "battery" finds
+ * the OEM fix, "data saver" finds music quality), and the matcher tolerates
+ * partial words, transposed words and typos rather than demanding the exact
+ * string.
+ *
+ * Each entry owns an [action] instead of just a destination, so results that
+ * are really a picker (music quality, subscribe target) can open that picker
+ * directly rather than dropping you on a page to hunt for the row.
+ */
+internal data class SettingsSearchEntry(
+    val id: String,
+    val title: String,
+    /** Where it lives, shown under the result so the location is learnable. */
+    val category: String,
+    val icon: ImageVector,
+    /** Extra words people actually type. Never shown. */
+    val keywords: List<String> = emptyList(),
+    val action: () -> Unit
+)
+
+/* ------------------------------------------------------------------ */
+/* Matching                                                            */
+/* ------------------------------------------------------------------ */
+
+private fun normalize(text: String): String =
+    text.lowercase().map { if (it.isLetterOrDigit()) it else ' ' }.joinToString("")
+
+/** Levenshtein distance, bailing out once it cannot beat [limit]. */
+private fun editDistance(a: String, b: String, limit: Int): Int {
+    if (a == b) return 0
+    if (kotlin.math.abs(a.length - b.length) > limit) return limit + 1
+    var previous = IntArray(b.length + 1) { it }
+    var current = IntArray(b.length + 1)
+    for (i in 1..a.length) {
+        current[0] = i
+        var best = current[0]
+        for (j in 1..b.length) {
+            val cost = if (a[i - 1] == b[j - 1]) 0 else 1
+            current[j] = min(
+                min(current[j - 1] + 1, previous[j] + 1),
+                previous[j - 1] + cost
+            )
+            best = min(best, current[j])
+        }
+        if (best > limit) return limit + 1
+        val swap = previous
+        previous = current
+        current = swap
+    }
+    return previous[b.length]
+}
+
+/** True when every character of [token] appears in [word], in order. */
+private fun isSubsequence(token: String, word: String): Boolean {
+    var t = 0
+    for (c in word) {
+        if (t < token.length && token[t] == c) t++
+    }
+    return t == token.length
+}
+
+/**
+ * Scores one token against a field. Higher is better, null means no match.
+ *
+ * The tiers are deliberate: a word that starts with what you typed is what you
+ * meant far more often than a word that merely contains it, and a typo match
+ * should never outrank a real one.
+ */
+private fun scoreToken(token: String, field: String): Int? {
+    if (token.isEmpty()) return null
+    val words = field.split(' ').filter { it.isNotEmpty() }
+
+    if (field.startsWith(token)) return 120
+    words.forEachIndexed { index, word ->
+        if (word.startsWith(token)) return 100 - min(index, 8)
+    }
+    if (field.contains(token)) return 70
+
+    // "amld" -> "amoled": compact subsequences beat scattered ones.
+    words.forEach { word ->
+        if (token.length >= 3 && isSubsequence(token, word)) {
+            return max(30, 55 - (word.length - token.length))
+        }
+    }
+
+    // Outright typos: "quailty" -> "quality".
+    if (token.length >= 4) {
+        val limit = if (token.length <= 5) 1 else 2
+        words.forEach { word ->
+            if (word.length >= 3 && editDistance(token, word, limit) <= limit) return 35
+        }
+    }
+    return null
+}
+
+/**
+ * Scores a whole query against an entry, or null if any token fails to match
+ * anywhere. Every token must land somewhere - an AND, not an OR, because
+ * "cache size" returning everything that mentions "size" is noise.
+ */
+internal fun scoreSettingsEntry(query: String, entry: SettingsSearchEntry): Int? {
+    val tokens = normalize(query).split(' ').filter { it.isNotEmpty() }
+    if (tokens.isEmpty()) return null
+
+    val title = normalize(entry.title)
+    val category = normalize(entry.category)
+    val keywords = normalize(entry.keywords.joinToString(" "))
+
+    var total = 0
+    for (token in tokens) {
+        // A title hit is worth far more than the same hit in a synonym.
+        val best = listOfNotNull(
+            scoreToken(token, title)?.let { it * 3 },
+            scoreToken(token, keywords)?.let { it * 2 },
+            scoreToken(token, category)
+        ).maxOrNull() ?: return null
+        total += best
+    }
+    // Nudge shorter titles up: an exact-ish hit on "Shorts" beats the same hit
+    // buried in a longer name.
+    return total - title.length / 8
+}
+
+/** Best matches first, capped so the list stays scannable. */
+internal fun searchSettings(
+    query: String,
+    entries: List<SettingsSearchEntry>,
+    limit: Int = 12
+): List<SettingsSearchEntry> {
+    if (query.isBlank()) return emptyList()
+    return entries
+        .mapNotNull { entry -> scoreSettingsEntry(query, entry)?.let { entry to it } }
+        .sortedByDescending { it.second }
+        .take(limit)
+        .map { it.first }
+}
+
+/* ------------------------------------------------------------------ */
+/* The index                                                           */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Every setting the screen owns, with the words people reach for.
+ *
+ * The synonym lists are the working part. "Battery" is the word for the OEM
+ * fix, "offline" is the word for Local Only, "bitrate" is the word for music
+ * quality - none of those appear in the titles.
+ */
+internal fun buildSettingsSearchIndex(
+    onOpenPage: (SettingsPage) -> Unit,
+    onOpenQualityPicker: (QualityDialogTarget) -> Unit,
+    onOpenRoutingPicker: (SubscriptionDialogTarget) -> Unit,
+    onShowAbout: () -> Unit,
+    onShowShortsButtons: () -> Unit,
+    onOpenFolderExclusion: () -> Unit,
+    onNavigateToColorPalette: () -> Unit,
+    onNavigateToSubscriptions: () -> Unit,
+    onNavigateToNotInterested: () -> Unit,
+    supportsLiveUpdates: Boolean
+): List<SettingsSearchEntry> = buildList {
+    fun entry(
+        id: String,
+        title: String,
+        category: String,
+        icon: ImageVector,
+        keywords: List<String>,
+        action: () -> Unit
+    ) = add(SettingsSearchEntry(id, title, category, icon, keywords, action))
+
+    // Account
+    entry(
+        "account", "Account", "Account", Icons.Rounded.AccountCircle,
+        listOf("sign in", "signin", "login", "google", "youtube", "profile", "connect")
+    ) { onOpenPage(SettingsPage.ACCOUNT) }
+    entry(
+        "watch_history", "Save Watch History", "Account", Icons.Rounded.CheckCircle,
+        listOf("history", "watched", "incognito", "private", "tracking")
+    ) { onOpenPage(SettingsPage.ACCOUNT) }
+    entry(
+        "cookies", "Replace Session Cookies", "Account", Icons.Rounded.Cookie,
+        listOf("cookie", "session", "token", "auth", "stale", "expired")
+    ) { onOpenPage(SettingsPage.ACCOUNT) }
+    entry(
+        "sign_out", "Sign Out", "Account", Icons.AutoMirrored.Rounded.Logout,
+        listOf("logout", "log out", "disconnect", "remove account")
+    ) { onOpenPage(SettingsPage.ACCOUNT) }
+
+    // Appearance
+    entry(
+        "theme", "Theme", "Appearance", Icons.Rounded.Contrast,
+        listOf("dark", "light", "system", "night", "day", "mode")
+    ) { onOpenPage(SettingsPage.APPEARANCE) }
+    entry(
+        "palette", "Color palette", "Appearance", Icons.Rounded.Palette,
+        listOf("colour", "accent", "dynamic", "material you", "monet", "wallpaper", "scheme")
+    ) { onNavigateToColorPalette() }
+    entry(
+        "amoled", "AMOLED Black", "Appearance", Icons.Rounded.Contrast,
+        listOf("oled", "pure black", "true black", "battery saving", "deep dark")
+    ) { onOpenPage(SettingsPage.APPEARANCE) }
+    entry(
+        "ambient", "Ambient Background", "Appearance", Icons.Rounded.Palette,
+        listOf("album art", "artwork", "background", "blur", "glow")
+    ) { onOpenPage(SettingsPage.APPEARANCE) }
+
+    // Player
+    entry(
+        "player_style", "Player Style", "Player", Icons.Rounded.PlayCircle,
+        listOf(
+            "layout", "skin", "look", "classic", "gesture", "editorial", "canvas",
+            "poster", "bento", "sticker", "morph", "dial"
+        )
+    ) { onOpenPage(SettingsPage.PLAYER) }
+    entry(
+        "artwork_colors", "Album Art Colors", "Player", Icons.Rounded.Palette,
+        listOf("artwork", "colour", "buttons", "tint", "cover")
+    ) { onOpenPage(SettingsPage.PLAYER) }
+
+    // Playback and quality
+    entry(
+        "crossfade", "Crossfade", "Playback and quality", Icons.Rounded.GraphicEq,
+        listOf("fade", "blend", "transition", "overlap", "gapless")
+    ) { onOpenPage(SettingsPage.PLAYBACK) }
+    entry(
+        "autoqueue", "Auto-load Queue", "Playback and quality",
+        Icons.AutoMirrored.Rounded.QueueMusic,
+        listOf("queue", "autoplay", "radio", "recommended", "keep playing", "endless")
+    ) { onOpenPage(SettingsPage.PLAYBACK) }
+    entry(
+        "music_q_wifi", "Music quality on Wi-Fi", "Playback and quality",
+        Icons.Rounded.MusicNote,
+        listOf("bitrate", "audio", "sound", "data saver", "high", "normal", "kbps")
+    ) { onOpenQualityPicker(QualityDialogTarget.MUSIC_WIFI) }
+    entry(
+        "music_q_mobile", "Music quality on mobile data", "Playback and quality",
+        Icons.Rounded.SignalCellularAlt,
+        listOf("bitrate", "audio", "cellular", "data saver", "roaming", "kbps")
+    ) { onOpenQualityPicker(QualityDialogTarget.MUSIC_MOBILE) }
+    entry(
+        "video_q_wifi", "Video quality on Wi-Fi", "Playback and quality",
+        Icons.Rounded.VideoLibrary,
+        listOf("resolution", "1080p", "720p", "480p", "4k", "2160", "default quality")
+    ) { onOpenQualityPicker(QualityDialogTarget.VIDEO_WIFI) }
+    entry(
+        "video_q_mobile", "Video quality on mobile data", "Playback and quality",
+        Icons.Rounded.SignalCellularAlt,
+        listOf("resolution", "cellular", "data", "1080p", "720p", "roaming")
+    ) { onOpenQualityPicker(QualityDialogTarget.VIDEO_MOBILE) }
+    entry(
+        "hdr", "Prefer HDR Videos", "Playback and quality", Icons.Rounded.HdrOn,
+        listOf("hdr", "high dynamic range", "hlg", "dolby", "colour depth")
+    ) { onOpenPage(SettingsPage.PLAYBACK) }
+
+    // Content and feeds
+    entry(
+        "local_only", "Local Only", "Content and feeds", Icons.Rounded.CloudOff,
+        listOf("offline", "airplane", "no internet", "disable youtube", "private", "data off")
+    ) { onOpenPage(SettingsPage.CONTENT) }
+    entry(
+        "content_mode", "Content Mode", "Content and feeds", Icons.Rounded.VideoLibrary,
+        listOf("video mode", "music mode", "switch", "youtube videos")
+    ) { onOpenPage(SettingsPage.CONTENT) }
+    entry(
+        "home_toggle", "Home Screen Mode Toggle", "Content and feeds", Icons.Rounded.ToggleOn,
+        listOf("home", "header", "switcher", "quick toggle")
+    ) { onOpenPage(SettingsPage.CONTENT) }
+    entry(
+        "timed_comments", "Timed Comments", "Content and feeds",
+        Icons.AutoMirrored.Rounded.Comment,
+        listOf("comments", "seek bar", "timeline", "timestamps")
+    ) { onOpenPage(SettingsPage.CONTENT) }
+    entry(
+        "shorts", "Shorts", "Content and feeds", Icons.Rounded.Bolt,
+        listOf("shorts", "reels", "short videos", "hide shorts", "vertical")
+    ) { onOpenPage(SettingsPage.CONTENT) }
+    entry(
+        "shorts_buttons", "Shorts Buttons", "Content and feeds", Icons.Rounded.Visibility,
+        listOf("hide buttons", "like", "share", "overlay", "actions")
+    ) { onShowShortsButtons() }
+    entry(
+        "not_interested", "Not Recommended", "Content and feeds", Icons.Rounded.NotInterested,
+        listOf(
+            "blocked", "hidden", "not interested", "blocklist", "dont recommend",
+            "blocked channels", "unhide"
+        )
+    ) { onNavigateToNotInterested() }
+
+    // Subscriptions
+    entry(
+        "manage_subs", "Manage Subscriptions", "Subscriptions", Icons.Rounded.Subscriptions,
+        listOf(
+            "import", "export", "opml", "takeout", "newpipe", "pipepipe", "groups",
+            "channels", "follow", "backup"
+        )
+    ) { onNavigateToSubscriptions() }
+    entry(
+        "subs_source", "Subscriptions Shown", "Subscriptions", Icons.Rounded.FilterList,
+        listOf("source", "feed", "which", "local", "account", "merged")
+    ) { onOpenRoutingPicker(SubscriptionDialogTarget.SOURCE) }
+    entry(
+        "subs_target", "Subscribe Saves To", "Subscriptions", Icons.Rounded.BookmarkAdd,
+        listOf("target", "where", "device", "account", "save subscriptions")
+    ) { onOpenRoutingPicker(SubscriptionDialogTarget.TARGET) }
+    entry(
+        "fast_subs", "Fast Subscription Refresh", "Subscriptions", Icons.Rounded.Bolt,
+        listOf("rss", "refresh", "speed", "data usage", "feed slow", "duration badges")
+    ) { onOpenPage(SettingsPage.SUBSCRIPTIONS) }
+
+    // Storage
+    entry(
+        "cache_music", "Cache Music", "Storage and cache", Icons.Rounded.Save,
+        listOf("cache", "store", "replay", "offline songs", "buffer")
+    ) { onOpenPage(SettingsPage.STORAGE) }
+    entry(
+        "cache_size", "Max Cache Size", "Storage and cache", Icons.Rounded.Folder,
+        listOf("size", "limit", "storage", "space", "mb", "gb", "how much")
+    ) { onOpenPage(SettingsPage.STORAGE) }
+    entry(
+        "clear_cache", "Clear Cache", "Storage and cache", Icons.Rounded.FolderOff,
+        listOf("clear", "delete", "free space", "wipe", "clean", "reset storage")
+    ) { onOpenPage(SettingsPage.STORAGE) }
+
+    // Notifications - only where the platform can promote an ongoing notification
+    if (supportsLiveUpdates) {
+        entry(
+            "live_download", "Live download updates", "Notifications", Icons.Rounded.Bolt,
+            listOf("notification", "status bar", "chip", "download progress", "live update")
+        ) { onOpenPage(SettingsPage.NOTIFICATIONS) }
+        entry(
+            "live_playback", "Live playback updates", "Notifications", Icons.Rounded.GraphicEq,
+            listOf("notification", "now playing", "status bar", "chip", "live update")
+        ) { onOpenPage(SettingsPage.NOTIFICATIONS) }
+    }
+
+    // Local library
+    entry(
+        "local_songs", "Load Local Songs", "Local library", Icons.Rounded.Folder,
+        listOf("device", "files", "mp3", "sd card", "my music", "scan", "offline")
+    ) { onOpenPage(SettingsPage.LOCAL_LIBRARY) }
+    entry(
+        "excluded_folders", "Excluded Folders", "Local library", Icons.Rounded.FolderOff,
+        listOf("exclude", "ignore", "hide folder", "ringtones", "whatsapp", "recordings")
+    ) { onOpenFolderExclusion() }
+
+    // Advanced
+    entry(
+        "compat_scan", "High Compatibility Scanning", "Advanced", Icons.Rounded.Security,
+        listOf(
+            "mediastore", "hyperos", "miui", "xiaomi", "redmi", "poco",
+            "missing music", "songs not showing", "scan"
+        )
+    ) { onOpenPage(SettingsPage.ADVANCED) }
+    entry(
+        "battery", "Ignore Battery Optimizations", "Advanced", Icons.Rounded.FlashOn,
+        listOf(
+            "battery", "background", "playback stops", "killed", "doze",
+            "optimisation", "keep alive"
+        )
+    ) { onOpenPage(SettingsPage.ADVANCED) }
+
+    // About
+    entry(
+        "about", "About Koda", "About", Icons.Rounded.Info,
+        listOf("version", "update", "changelog", "github", "licence", "build")
+    ) { onShowAbout() }
+}
+
+/* ------------------------------------------------------------------ */
+/* UI                                                                  */
+/* ------------------------------------------------------------------ */
+
+@Composable
+internal fun SettingsSearchField(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val focusManager = LocalFocusManager.current
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(28.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = Icons.Rounded.Search,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(22.dp)
+        )
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        Box(modifier = Modifier.weight(1f)) {
+            if (query.isEmpty()) {
+                Text(
+                    text = "Search settings",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 16.sp
+                )
+            }
+            BasicTextField(
+                value = query,
+                onValueChange = onQueryChange,
+                singleLine = true,
+                textStyle = TextStyle(
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontSize = 16.sp
+                ),
+                cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                keyboardActions = KeyboardActions(
+                    onSearch = { focusManager.clearFocus() }
+                ),
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+
+        if (query.isNotEmpty()) {
+            Spacer(modifier = Modifier.width(8.dp))
+            Box(
+                modifier = Modifier
+                    .size(28.dp)
+                    .clip(RoundedCornerShape(14.dp))
+                    .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                    .clickable {
+                        onQueryChange("")
+                        focusManager.clearFocus()
+                    },
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Close,
+                    contentDescription = "Clear search",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(16.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+internal fun SettingsSearchResultRow(
+    entry: SettingsSearchEntry,
+    onClick: () -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.97f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
+        label = "resultScale"
+    )
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .scale(scale)
+            .clip(RoundedCornerShape(18.dp))
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick
+            )
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(44.dp)
+                .clip(RoundedCornerShape(13.dp))
+                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = entry.icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(24.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = entry.title,
+                color = MaterialTheme.colorScheme.onBackground,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = entry.category,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 13.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+/** Shown when a query matches nothing - names the query so it reads as an answer. */
+@Composable
+internal fun SettingsSearchEmptyState(query: String) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 48.dp, horizontal = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(64.dp)
+                .clip(RoundedCornerShape(20.dp))
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.SearchOff,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(30.dp)
+            )
+        }
+        Text(
+            text = "No settings match \"$query\"",
+            color = MaterialTheme.colorScheme.onBackground,
+            fontSize = 16.sp,
+            fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.Center
+        )
+        Text(
+            text = "Try a shorter word, or what the setting does rather than its name.",
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontSize = 13.sp,
+            lineHeight = 18.sp,
+            textAlign = TextAlign.Center
+        )
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/LiveChatPanel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/LiveChatPanel.kt
@@ -67,7 +67,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
@@ -362,9 +361,15 @@ fun LiveChatPanel(
  * Neither dress of [LiveChatPanel] fits a full-bleed portrait video: the
  * portrait one covers the stream outright, and the compact one docks against a
  * side that does not exist once the video is the whole screen. This is a
- * read-only ticker instead - the newest messages riding a gradient that fades
- * up into the frame, older ones dimming as they climb - so chat stays legible
- * without putting a slab of surface color over what the user came to watch.
+ * read-only ticker instead - the newest messages fading up into the frame,
+ * older ones dimming as they climb - so chat stays legible without putting a
+ * slab of surface color over what the user came to watch.
+ *
+ * The scrim behind it belongs to the caller, not to this composable. The
+ * vertical live player stacks a title and a channel row above the ticker, and
+ * a gradient that started here would leave those two sitting on bare video -
+ * one scrim spanning the whole bottom stack is both more legible and one less
+ * darkening to compound.
  *
  * Read-only is the point: sending, scrolling back and the jump-to-latest pill
  * all still belong to the full panel, which [onOpenFullChat] opens.
@@ -378,7 +383,7 @@ fun LiveChatOverlay(
     modifier: Modifier = Modifier,
     maxVisible: Int = 5,
 ) {
-    // A stream with chat turned off should cost the viewer nothing - no scrim,
+    // A stream with chat turned off should cost the viewer nothing - no ticker,
     // no empty state, just video.
     if (isAvailable == false) return
 
@@ -386,16 +391,7 @@ fun LiveChatOverlay(
         messages.takeLast(maxVisible).asReversed()
     }
 
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .background(
-                Brush.verticalGradient(
-                    listOf(Color.Transparent, Color.Black.copy(alpha = 0.65f))
-                )
-            )
-            .padding(top = 32.dp),
-    ) {
+    Column(modifier = modifier.fillMaxWidth()) {
         LazyColumn(
             // Reversed so the newest message sits at the visual bottom and the
             // list grows upward into the fade. Scrolling is the full panel's
@@ -422,11 +418,15 @@ fun LiveChatOverlay(
 
         Spacer(Modifier.height(10.dp))
 
+        // The one control in the ticker, so it is the one thing here that wears
+        // the app's colors rather than the video's. Everything above it is text
+        // on a frame and stays white; this is a surface, and a surface that
+        // ignored the palette is what made the whole screen read as foreign.
         Surface(
             onClick = onOpenFullChat,
             shape = CircleShape,
-            color = Color.White.copy(alpha = 0.16f),
-            contentColor = Color.White,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.9f),
+            contentColor = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier
                 .padding(horizontal = 16.dp)
                 .fillMaxWidth(),
@@ -434,21 +434,30 @@ fun LiveChatOverlay(
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
-                modifier = Modifier.padding(horizontal = 18.dp, vertical = 12.dp),
+                modifier = Modifier.padding(start = 18.dp, end = 8.dp, top = 8.dp, bottom = 8.dp),
             ) {
                 Text(
                     text = if (canSend) "Say something..." else "Open live chat",
                     style = MaterialTheme.typography.bodyMedium,
-                    color = Color.White.copy(alpha = 0.85f),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(1f),
                 )
-                Icon(
-                    Icons.AutoMirrored.Rounded.Send,
-                    contentDescription = "Open live chat",
-                    modifier = Modifier.size(18.dp),
-                )
+                Box(
+                    modifier = Modifier
+                        .size(32.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.primary),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        Icons.AutoMirrored.Rounded.Send,
+                        contentDescription = "Open live chat",
+                        tint = MaterialTheme.colorScheme.onPrimary,
+                        modifier = Modifier.size(16.dp),
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VerticalLivePlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VerticalLivePlayerContent.kt
@@ -4,12 +4,23 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.annotation.OptIn
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -17,29 +28,47 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.outlined.ThumbUp
 import androidx.compose.material.icons.rounded.ClosedCaption
 import androidx.compose.material.icons.rounded.ClosedCaptionOff
 import androidx.compose.material.icons.rounded.CloseFullscreen
+import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.material.icons.rounded.ThumbUp
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ContainedLoadingIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.FilledIconButton
-import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialShapes
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.toShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -49,6 +78,8 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
+import coil.compose.AsyncImage
+import com.ivor.ivormusic.data.LikeStatus
 import com.ivor.ivormusic.data.LiveChatMessage
 import com.ivor.ivormusic.data.VideoItem
 import com.ivor.ivormusic.data.VttCue
@@ -78,6 +109,18 @@ private const val MAX_ACCEPTABLE_CROP = 0.25f
  *
  * Controls hide themselves; chat does not. Chat is the reason people sit on a
  * live stream, and making them tap to see it would be the wrong default.
+ *
+ * **Chrome is tonal, content is white.** Every control here - the chrome
+ * buttons, the grouped cluster, the floating scrubber, the chat entry - is a
+ * ColorScheme surface, the same bargain [com.ivor.ivormusic.ui.shorts]'s
+ * overlay makes, so this screen actually changes with the user's palette,
+ * AMOLED and dynamic color. It previously painted itself in black scrims and
+ * white icons throughout, which rendered identically under all 27 palettes and
+ * was the whole reason it did not look like the rest of the app. What stays
+ * white is only what sits directly on the frame with no surface under it: the
+ * title, the channel name, the chat ticker text and the captions. Those are
+ * legibility over arbitrary video, and the same exception the caption overlay
+ * and [LiveChatOverlay] already document.
  */
 @OptIn(UnstableApi::class, ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -102,6 +145,8 @@ fun VerticalLivePlayerContent(
     captionCues: List<VttCue>,
     /** Null until the first frame decodes; drives the fill-vs-fit decision. */
     videoAspectRatio: Float?,
+    isSubscribed: Boolean,
+    likeStatus: LikeStatus,
     onPlayPause: () -> Unit,
     onSeek: (Float) -> Unit,
     onSeekBackward: () -> Unit,
@@ -112,6 +157,8 @@ fun VerticalLivePlayerContent(
     onOpenFullChat: () -> Unit,
     onCaptionsClick: () -> Unit,
     onSettings: () -> Unit,
+    onSubscribeClick: () -> Unit,
+    onLikeClick: () -> Unit,
     onRetry: (() -> Unit)? = null,
     onMinimizeDragDelta: (Float) -> Unit = {},
     onMinimizeDragRelease: (Float) -> Unit = {},
@@ -145,6 +192,26 @@ fun VerticalLivePlayerContent(
             }
         }
     }
+
+    // A stream with chat off draws no ticker, so the bottom stack shrinks to
+    // the title and channel row and the scrim has to shrink with it - a
+    // 420dp gradient under 100dp of content reads as a dirty screen.
+    //
+    // isChatAvailable is null until the first poll answers, so this settles a
+    // second or two into the stream rather than at composition; animated,
+    // because a scrim and the captions above it jumping by 180dp mid-watch is
+    // the kind of snap the rest of the app does not do. The default Dp spring
+    // is non-bouncy, which matters here - an overshoot would drive a height
+    // negative.
+    val chatShowing = isChatAvailable != false
+    val bottomScrimHeight by animateDpAsState(
+        targetValue = if (chatShowing) 420.dp else 240.dp,
+        label = "liveBottomScrim"
+    )
+    val captionBottomPadding by animateDpAsState(
+        targetValue = if (chatShowing) 310.dp else 130.dp,
+        label = "liveCaptionInset"
+    )
 
     Box(modifier = modifier.fillMaxSize().background(Color.Black)) {
         PlayerGestureSurface(
@@ -183,6 +250,32 @@ fun VerticalLivePlayerContent(
                 modifier = Modifier.fillMaxSize()
             )
 
+            // Scrims. Tonal chrome still needs something behind it: a daylight
+            // IRL stream or a white-background broadcast washes out a 0.9-alpha
+            // surface, and the top row had no scrim at all before this.
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .fillMaxWidth()
+                    .height(170.dp)
+                    .background(
+                        Brush.verticalGradient(
+                            listOf(Color.Black.copy(alpha = 0.55f), Color.Transparent)
+                        )
+                    )
+            )
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .height(bottomScrimHeight)
+                    .background(
+                        Brush.verticalGradient(
+                            listOf(Color.Transparent, Color.Black.copy(alpha = 0.7f))
+                        )
+                    )
+            )
+
             // Lifted clear of the chat ticker rather than sitting behind it -
             // but only as far as the ticker actually reaches. A stream with
             // chat turned off draws none of it, and captions stranded in the
@@ -190,16 +283,22 @@ fun VerticalLivePlayerContent(
             CaptionOverlay(
                 cues = captionCues,
                 player = exoPlayer,
-                bottomPadding = if (isChatAvailable == false) 96.dp else 300.dp,
+                bottomPadding = captionBottomPadding,
                 compact = true
             )
 
             if (hasError) ErrorOverlay(errorMessage, onRetry)
 
-            if (isLoading || (isBuffering && !showControls)) {
-                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    androidx.compose.material3.ContainedLoadingIndicator()
-                }
+            // Only while the controls are down. With them up the play/pause
+            // button draws its own shape-morphing loader, and two spinners on
+            // one frame is just noise.
+            AnimatedVisibility(
+                visible = (isLoading || isBuffering) && !showControls && !hasError,
+                enter = fadeIn(),
+                exit = fadeOut(),
+                modifier = Modifier.align(Alignment.Center)
+            ) {
+                ContainedLoadingIndicator()
             }
 
             // Top chrome: always up. The back and collapse affordances are the
@@ -214,11 +313,12 @@ fun VerticalLivePlayerContent(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                FilledIconButton(
+                IconButton(
                     onClick = onBack,
-                    colors = IconButtonDefaults.filledIconButtonColors(
-                        containerColor = Color.Black.copy(0.4f),
-                        contentColor = Color.White
+                    colors = IconButtonDefaults.iconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+                            .copy(alpha = 0.9f),
+                        contentColor = MaterialTheme.colorScheme.onSurface
                     ),
                     shapes = stableShapes
                 ) {
@@ -231,74 +331,76 @@ fun VerticalLivePlayerContent(
                     modifier = Modifier.weight(1f)
                 )
 
-                FilledTonalIconButton(
-                    onClick = onCaptionsClick,
-                    colors = IconButtonDefaults.filledTonalIconButtonColors(
-                        containerColor = if (captionsActive) {
-                            MaterialTheme.colorScheme.primary
-                        } else {
-                            Color.Black.copy(0.4f)
-                        },
-                        contentColor = if (captionsActive) {
-                            MaterialTheme.colorScheme.onPrimary
-                        } else {
-                            Color.White
-                        }
-                    ),
-                    shapes = stableShapes
+                // Three loose circles read as a browser toolbar. One container
+                // holding all three reads as a control cluster, costs one scrim
+                // instead of three, and keeps the row from spanning the frame.
+                Surface(
+                    shape = RoundedCornerShape(24.dp),
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.9f),
+                    contentColor = MaterialTheme.colorScheme.onSurface,
                 ) {
-                    Icon(
-                        if (captionsActive) Icons.Rounded.ClosedCaption else Icons.Rounded.ClosedCaptionOff,
-                        contentDescription = "Captions"
-                    )
-                }
-
-                FilledIconButton(
-                    onClick = onSettings,
-                    colors = IconButtonDefaults.filledIconButtonColors(
-                        containerColor = Color.Black.copy(0.4f),
-                        contentColor = Color.White
-                    ),
-                    shapes = stableShapes
-                ) {
-                    Icon(Icons.Rounded.Settings, "Quality")
-                }
-
-                // The way back to the watch page: comments, related, the
-                // description. The counterpart button on that page returns here.
-                FilledIconButton(
-                    onClick = onExitToPage,
-                    colors = IconButtonDefaults.filledIconButtonColors(
-                        containerColor = Color.Black.copy(0.4f),
-                        contentColor = Color.White
-                    ),
-                    shapes = stableShapes
-                ) {
-                    Icon(Icons.Rounded.CloseFullscreen, "Show video details")
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp),
+                    ) {
+                        // Shape carries the state as well as color: a filled
+                        // circle that only changes hue is the least legible
+                        // toggle available on top of moving video.
+                        ChromeToggleButton(
+                            icon = if (captionsActive) {
+                                Icons.Rounded.ClosedCaption
+                            } else {
+                                Icons.Rounded.ClosedCaptionOff
+                            },
+                            contentDescription = "Captions",
+                            active = captionsActive,
+                            onClick = onCaptionsClick,
+                        )
+                        ChromeGroupButton(
+                            icon = Icons.Rounded.Settings,
+                            contentDescription = "Quality",
+                            onClick = onSettings,
+                        )
+                        ChromeGroupButton(
+                            // The way back to the watch page: comments, related,
+                            // the description. The counterpart button on that
+                            // page returns here.
+                            icon = Icons.Rounded.CloseFullscreen,
+                            contentDescription = "Show video details",
+                            onClick = onExitToPage,
+                        )
+                    }
                 }
             }
 
-            // Play/pause and the seek bar are the parts that earn their keep by
-            // disappearing - they are only wanted when the user reaches for them.
+            // Play/pause is the part that earns its keep by disappearing - it is
+            // only wanted when the user reaches for it.
             AnimatedVisibility(
                 visible = showControls,
-                enter = fadeIn(),
+                enter = fadeIn(spring(stiffness = Spring.StiffnessMedium)),
                 exit = fadeOut(),
                 modifier = Modifier.fillMaxSize()
             ) {
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(Color.Black.copy(alpha = 0.35f))
-                ) {
-                    Box(modifier = Modifier.align(Alignment.Center)) {
-                        ExpressivePlayPauseButton(
-                            isPlaying = isPlaying,
-                            isBuffering = isBuffering,
-                            onClick = onPlayPause
-                        )
-                    }
-                }
+                        .background(Color.Black.copy(alpha = 0.28f))
+                )
+            }
+            AnimatedVisibility(
+                visible = showControls,
+                enter = scaleIn(
+                    animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
+                    initialScale = 0.8f
+                ) + fadeIn(),
+                exit = scaleOut(targetScale = 0.8f) + fadeOut(),
+                modifier = Modifier.align(Alignment.Center)
+            ) {
+                ExpressivePlayPauseButton(
+                    isPlaying = isPlaying,
+                    isBuffering = isBuffering,
+                    onClick = onPlayPause
+                )
             }
 
             Column(
@@ -316,18 +418,94 @@ fun VerticalLivePlayerContent(
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.padding(horizontal = 16.dp)
                 )
+
+                // Subscribe and like are the two things people actually reach
+                // for on a live stream, and before this both meant leaving the
+                // layout for the watch page first.
                 if (video.channelName.isNotBlank()) {
-                    Text(
-                        text = video.channelName,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = Color.White.copy(alpha = 0.75f),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.padding(horizontal = 16.dp)
-                    )
+                    Spacer(Modifier.height(10.dp))
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(38.dp)
+                                .clip(MaterialShapes.Cookie9Sided.toShape())
+                                .background(
+                                    MaterialTheme.colorScheme.surfaceContainerHigh
+                                        .copy(alpha = 0.85f)
+                                ),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            if (!video.channelIconUrl.isNullOrBlank()) {
+                                AsyncImage(
+                                    model = video.channelIconUrl,
+                                    contentDescription = null,
+                                    modifier = Modifier.fillMaxSize(),
+                                    contentScale = ContentScale.Crop,
+                                )
+                            } else {
+                                Icon(
+                                    Icons.Rounded.Person,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSurface,
+                                    modifier = Modifier.size(20.dp),
+                                )
+                            }
+                        }
+                        Text(
+                            text = video.channelName,
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.SemiBold,
+                            color = Color.White,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Button(
+                            onClick = onSubscribeClick,
+                            colors = if (isSubscribed) {
+                                ButtonDefaults.buttonColors(
+                                    containerColor = MaterialTheme.colorScheme.secondaryContainer
+                                        .copy(alpha = 0.92f),
+                                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                                )
+                            } else {
+                                ButtonDefaults.buttonColors(
+                                    containerColor = MaterialTheme.colorScheme.primary,
+                                    contentColor = MaterialTheme.colorScheme.onPrimary
+                                )
+                            },
+                            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 6.dp),
+                            modifier = Modifier.height(36.dp),
+                        ) {
+                            Text(
+                                text = if (isSubscribed) "Subscribed" else "Subscribe",
+                                style = MaterialTheme.typography.labelMedium,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                        }
+                        ChromeToggleButton(
+                            icon = if (likeStatus == LikeStatus.LIKE) {
+                                Icons.Rounded.ThumbUp
+                            } else {
+                                Icons.Outlined.ThumbUp
+                            },
+                            contentDescription = "Like",
+                            active = likeStatus == LikeStatus.LIKE,
+                            onClick = onLikeClick,
+                            size = 36.dp,
+                            inactiveContainer = MaterialTheme.colorScheme.surfaceContainerHigh
+                                .copy(alpha = 0.9f),
+                        )
+                    }
                 }
 
-                Spacer(Modifier.height(8.dp))
+                Spacer(Modifier.height(12.dp))
 
                 LiveChatOverlay(
                     messages = chatMessages,
@@ -338,28 +516,50 @@ fun VerticalLivePlayerContent(
 
                 AnimatedVisibility(
                     visible = showControls,
-                    enter = fadeIn(),
-                    exit = fadeOut(),
+                    enter = slideInVertically(
+                        animationSpec = spring(
+                            dampingRatio = Spring.DampingRatioMediumBouncy,
+                            stiffness = Spring.StiffnessMediumLow
+                        ),
+                        initialOffsetY = { it }
+                    ) + fadeIn(),
+                    exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
                 ) {
-                    Row(
+                    // Floated and inset rather than a full-bleed black band.
+                    // The band was the last piece of chrome still reading as a
+                    // letterbox bar rather than as a control surface.
+                    Surface(
+                        shape = RoundedCornerShape(28.dp),
+                        color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.92f),
+                        contentColor = MaterialTheme.colorScheme.onSurface,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .background(Color.Black.copy(alpha = 0.65f))
-                            .padding(horizontal = 16.dp, vertical = 10.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                            .padding(horizontal = 12.dp, vertical = 10.dp),
                     ) {
-                        PlayerSeekBar(
-                            progress = progress,
-                            bufferedProgress = bufferedProgress,
-                            onSeek = onSeek,
-                            modifier = Modifier.weight(1f),
-                            durationMs = duration
-                        )
-                        LiveEdgeChip(
-                            atLiveEdge = duration <= 0L || progress >= LIVE_EDGE_THRESHOLD,
-                            onClick = onSeekToLive
-                        )
+                        Row(
+                            modifier = Modifier.padding(
+                                start = 16.dp,
+                                end = 10.dp,
+                                top = 4.dp,
+                                bottom = 4.dp
+                            ),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(10.dp)
+                        ) {
+                            PlayerSeekBar(
+                                progress = progress,
+                                bufferedProgress = bufferedProgress,
+                                onSeek = onSeek,
+                                modifier = Modifier.weight(1f),
+                                durationMs = duration,
+                                onTonalSurface = true
+                            )
+                            LiveEdgeChip(
+                                atLiveEdge = duration <= 0L || progress >= LIVE_EDGE_THRESHOLD,
+                                onClick = onSeekToLive,
+                                contentTint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
                     }
                 }
 
@@ -369,3 +569,106 @@ fun VerticalLivePlayerContent(
     }
 }
 
+/**
+ * One button inside the grouped top-right cluster. Transparent, because the
+ * group's own container is the surface - a container per button is what made
+ * the row read as three separate widgets.
+ */
+@Composable
+private fun ChromeGroupButton(
+    icon: ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .size(40.dp)
+            .clip(CircleShape)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDescription,
+            tint = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.size(22.dp),
+        )
+    }
+}
+
+/**
+ * A toggle that says so with its shape: a circle when off, a
+ * [MaterialShapes.Cookie9Sided] filled with secondaryContainer when on, with
+ * the icon popping on a bouncy spring as it flips. Same treatment the Shorts
+ * action rail uses, and the reason is the same - a container that only changes
+ * hue is hard to read at a glance on top of moving video.
+ *
+ * [inactiveContainer] defaults to transparent for use inside the grouped
+ * cluster, which supplies its own surface; a standalone one passes a container.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun ChromeToggleButton(
+    icon: ImageVector,
+    contentDescription: String,
+    active: Boolean,
+    onClick: () -> Unit,
+    size: androidx.compose.ui.unit.Dp = 40.dp,
+    inactiveContainer: Color = Color.Transparent,
+) {
+    val iconScale = remember { Animatable(1f) }
+    var isInitial by remember { mutableStateOf(true) }
+
+    LaunchedEffect(active) {
+        // The composable enters with whatever state the video arrived in;
+        // popping on that would flash every control on every video change.
+        if (isInitial) {
+            isInitial = false
+            return@LaunchedEffect
+        }
+        if (active) {
+            iconScale.snapTo(0.55f)
+            iconScale.animateTo(
+                targetValue = 1f,
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioMediumBouncy,
+                    stiffness = Spring.StiffnessMedium
+                )
+            )
+        }
+    }
+
+    val containerColor by animateColorAsState(
+        targetValue = if (active) {
+            MaterialTheme.colorScheme.secondaryContainer
+        } else {
+            inactiveContainer
+        },
+        label = "chromeToggleContainer"
+    )
+
+    Box(
+        modifier = Modifier
+            .size(size)
+            .clip(if (active) MaterialShapes.Cookie9Sided.toShape() else CircleShape)
+            .background(containerColor)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDescription,
+            tint = if (active) {
+                MaterialTheme.colorScheme.onSecondaryContainer
+            } else {
+                MaterialTheme.colorScheme.onSurface
+            },
+            modifier = Modifier
+                .size(size * 0.55f)
+                .graphicsLayer {
+                    scaleX = iconScale.value
+                    scaleY = iconScale.value
+                },
+        )
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
@@ -55,6 +55,7 @@ import androidx.core.view.WindowInsetsControllerCompat
 import androidx.media3.common.util.UnstableApi
 import coil.compose.AsyncImage
 import com.ivor.ivormusic.data.CaptionTrack
+import com.ivor.ivormusic.data.LikeStatus
 import com.ivor.ivormusic.data.VideoChapter
 import com.ivor.ivormusic.data.VideoItem
 import com.ivor.ivormusic.data.VideoQuality
@@ -581,6 +582,10 @@ fun VideoPlayerContent(
                     captionsActive = selectedCaption != null,
                     captionCues = captionCues,
                     videoAspectRatio = videoAspectRatio,
+                    // Account OR device subscription, same as everywhere else -
+                    // engagement.isSubscribed only knows about the account.
+                    isSubscribed = isSubscribedToChannel,
+                    likeStatus = engagement?.likeStatus ?: LikeStatus.INDIFFERENT,
                     onPlayPause = { viewModel.togglePlayPause() },
                     onSeek = { newProgress -> exoPlayer.seekTo((newProgress * duration).toLong()) },
                     onSeekBackward = { seekBy(-VideoPlayerViewModel.SEEK_STEP_MS) },
@@ -594,6 +599,8 @@ fun VideoPlayerContent(
                         showCaptionsSheet = true
                     },
                     onSettings = { showQualitySheet = true },
+                    onSubscribeClick = { requireSubscribeLogin { viewModel.toggleSubscribe() } },
+                    onLikeClick = { requireLogin { viewModel.toggleLike() } },
                     onRetry = { viewModel.retryPlayback() },
                     onMinimizeDragDelta = onMinimizeDragDelta,
                     onMinimizeDragRelease = onMinimizeDragRelease

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -869,9 +869,18 @@ internal const val LIVE_EDGE_THRESHOLD = 0.995f
  * The "LIVE" marker where a normal video shows its duration. Red and tappable
  * while the viewer is behind, so getting back to the edge is one tap; muted
  * once they are already there.
+ *
+ * [contentTint] is what the chip resolves to when it is *not* at the edge, plus
+ * the label color throughout. It defaults to white because the standard player
+ * puts this straight on the video; the vertical live player sits it inside a
+ * tonal container instead, where white is invisible in a light theme.
  */
 @Composable
-internal fun LiveEdgeChip(atLiveEdge: Boolean, onClick: () -> Unit) {
+internal fun LiveEdgeChip(
+    atLiveEdge: Boolean,
+    onClick: () -> Unit,
+    contentTint: Color = Color.White
+) {
     Surface(
         shape = CircleShape,
         color = Color.Transparent,
@@ -889,12 +898,12 @@ internal fun LiveEdgeChip(atLiveEdge: Boolean, onClick: () -> Unit) {
                     .clip(CircleShape)
                     .background(
                         if (atLiveEdge) MaterialTheme.colorScheme.error
-                        else Color.White.copy(alpha = 0.6f)
+                        else contentTint.copy(alpha = 0.6f)
                     )
             )
             Text(
                 text = "LIVE",
-                color = if (atLiveEdge) Color.White else Color.White.copy(alpha = 0.6f),
+                color = if (atLiveEdge) contentTint else contentTint.copy(alpha = 0.6f),
                 style = MaterialTheme.typography.labelLarge,
                 fontWeight = FontWeight.Bold
             )
@@ -908,6 +917,12 @@ internal fun LiveEdgeChip(atLiveEdge: Boolean, onClick: () -> Unit) {
  * The actual seek fires once, on release (onValueChangeFinished). The 500ms
  * progress poll from the parent is ignored during the drag to avoid the thumb
  * fighting the finger.
+ *
+ * [onTonalSurface] switches the track and tick colors from the white-on-video
+ * set to ColorScheme roles. The standard player draws this straight onto the
+ * frame, where white is the only thing that reads on any video; the vertical
+ * live player floats it inside a surfaceContainer, where white would disappear
+ * in a light theme.
  */
 @Composable
 internal fun PlayerSeekBar(
@@ -916,10 +931,27 @@ internal fun PlayerSeekBar(
     modifier: Modifier = Modifier,
     bufferedProgress: Float = 0f,
     chapters: List<VideoChapter> = emptyList(),
-    durationMs: Long = 0L
+    durationMs: Long = 0L,
+    onTonalSurface: Boolean = false
 ) {
     var isScrubbing by remember { mutableStateOf(false) }
     var scrubValue by remember { mutableFloatStateOf(0f) }
+
+    val bufferedColor = if (onTonalSurface) {
+        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f)
+    } else {
+        Color.White.copy(alpha = 0.35f)
+    }
+    val inactiveTrackColor = if (onTonalSurface) {
+        MaterialTheme.colorScheme.surfaceVariant
+    } else {
+        Color.White.copy(0.3f)
+    }
+    val tickColor = if (onTonalSurface) {
+        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.85f)
+    } else {
+        Color.Black.copy(alpha = 0.85f)
+    }
 
     Box(modifier = modifier) {
         // Buffered-ahead indicator: a soft white bar from the start to the
@@ -931,7 +963,7 @@ internal fun PlayerSeekBar(
             Canvas(modifier = Modifier.matchParentSize()) {
                 val centerY = size.height / 2f
                 drawLine(
-                    color = Color.White.copy(alpha = 0.35f),
+                    color = bufferedColor,
                     start = Offset(0f, centerY),
                     end = Offset(bufferedProgress.coerceIn(0f, 1f) * size.width, centerY),
                     strokeWidth = 4.dp.toPx(),
@@ -953,7 +985,7 @@ internal fun PlayerSeekBar(
             colors = SliderDefaults.colors(
                 thumbColor = MaterialTheme.colorScheme.primary,
                 activeTrackColor = MaterialTheme.colorScheme.primary,
-                inactiveTrackColor = Color.White.copy(0.3f)
+                inactiveTrackColor = inactiveTrackColor
             ),
             modifier = Modifier.fillMaxWidth()
         )
@@ -970,7 +1002,7 @@ internal fun PlayerSeekBar(
                     if (fraction > 0.001f && fraction < 0.999f) {
                         val x = fraction * size.width
                         drawLine(
-                            color = Color.Black.copy(alpha = 0.85f),
+                            color = tickColor,
                             start = Offset(x, centerY - half),
                             end = Offset(x, centerY + half),
                             strokeWidth = stroke


### PR DESCRIPTION
The full-bleed vertical live layout painted itself entirely in `Color.Black.copy(0.4f)` scrims and white icons, so it rendered byte-identical under all 27 palettes, AMOLED and dynamic color — which is what "doesn't look like the rest of the app" actually meant. The Shorts overlay already solves the same problem (chrome on top of arbitrary video) with translucent `surfaceContainerHigh` and `MaterialShapes`. This puts the live player on the same footing.

**Chrome is tonal, content stays white.** Every control is now a ColorScheme surface. White survives only where something sits directly on the frame with no surface under it — the title, the channel name, the chat ticker text, the captions. That's legibility over arbitrary video, and the same exception `CaptionOverlay` and `LiveChatOverlay` already document.

## What changed

**`VerticalLivePlayerContent.kt`**
- Three loose right-hand circles become one grouped container — a cluster, not a browser toolbar, and one scrim instead of three.
- New `ChromeToggleButton`: CC and Like morph circle → `MaterialShapes.Cookie9Sided` with a bouncy icon pop, the Shorts action-rail treatment. A container that only changes hue is the least legible toggle available on moving video. The pop is suppressed on first composition so controls don't flash on every video change.
- Top scrim added — it was absent, so white icons over a daylight IRL stream had nothing behind them. The bottom scrim now spans the whole bottom stack instead of starting at the chat ticker, which had left the title and channel row on bare video. It animates, because `isChatAvailable` is null until the first poll answers and it was going to snap 180dp mid-watch.
- Seek bar floats in an inset rounded container. The full-bleed black band was the last piece of chrome still reading as a letterbox bar.
- New channel row: cookie-clipped avatar (Person icon fallback), name, Subscribe, Like. Both actions previously required exiting to the watch page. Subscribe binds to `isSubscribedToChannel` (account OR device), never `engagement.isSubscribed`.
- Controls spring in; the standalone loader now shows only while controls are down, since the play/pause button draws its own.

**`LiveChatPanel.kt`** — `LiveChatOverlay` gives up its own gradient (the caller owns one scrim for the whole stack now, so nothing double-darkens); the chat entry pill goes from frosted white glass to a tonal container with a primary send affordance.

**`VideoPlayerScreen.kt`** — two additive params, both defaulted to current behaviour so the standard player is untouched: `PlayerSeekBar(onTonalSurface)` and `LiveEdgeChip(contentTint)`.

**`VideoPlayerContent.kt`** — passes subscription and like state through the existing `requireLogin` / `requireSubscribeLogin` wrappers.

## Deliberately not done

- **Collapsing the scrubber at the live edge.** It's the only way to seek backward on a DVR stream once you're caught up — a functional regression dressed as polish.
- **A wavy scrubber.** It fights the buffered-ahead bar drawn over it, and a video scrubber reading as a progress meter is worse than the design tie-in is worth.

## Verification

**Not compiled or run on a device.** Per `CLAUDE.md` I don't invoke Gradle unless asked, so this is unverified by the compiler — worth a `compileDebugKotlin` and a look at a real vertical live stream before merge. Worth eyeballing specifically: the channel row on a narrow phone (avatar + name + Subscribe + Like is a tight row at 360dp, the name has `weight(1f)` and ellipsis), and the bottom scrim on a stream with chat turned off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADALtEau9X9vxrVmePwkSr
