### PR TITLE
fix: keep loading indicators mutually exclusive

### DIFF
--- a/app/src/main/java/com/ivor/ivormusic/ui/video/SubscriptionsContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/SubscriptionsContent.kt
@@ -331,7 +331,7 @@ fun SubscriptionsContent(
         // Full channel list
         showChannelList -> {
             ExpressivePullToRefresh(
-                isRefreshing = isChannelsLoading,
+                isRefreshing = isChannelsLoading && channels.isNotEmpty(),
                 onRefresh = { viewModel.loadSubscriptions(force = true) },
                 modifier = Modifier.fillMaxSize()
             ) {
@@ -422,7 +422,7 @@ fun SubscriptionsContent(
         // Default: subscriptions feed with the channel avatar rail
         else -> {
             ExpressivePullToRefresh(
-                isRefreshing = isFeedLoading,
+                isRefreshing = isFeedLoading && feed.isNotEmpty(),
                 onRefresh = {
                     viewModel.loadSubscriptionFeed(force = true)
                     viewModel.loadSubscriptions(force = true)

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoHistoryScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoHistoryScreen.kt
@@ -134,7 +134,7 @@ fun VideoHistoryContent(
     }
 
     ExpressivePullToRefresh(
-        isRefreshing = isHistoryLoading,
+        isRefreshing = isHistoryLoading && historyVideos.isNotEmpty(),
         onRefresh = { viewModel.loadYouTubeHistory() },
         modifier = Modifier.fillMaxSize()
     ) {

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoLibraryScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoLibraryScreen.kt
@@ -208,7 +208,7 @@ private fun LibraryRoot(
     }
 
     ExpressivePullToRefresh(
-        isRefreshing = isPlaylistsLoading,
+        isRefreshing = isPlaylistsLoading && playlists.isNotEmpty(),
         onRefresh = onRefresh,
         modifier = Modifier.fillMaxSize()
     ) {


### PR DESCRIPTION
Closes #105

## Summary

Guards the pull-to-refresh `isRefreshing` bindings so they are only active when the list already has content, matching the existing `VideoHomeContent.kt` pattern. The centered loading indicator owns the first load; the pull-to-refresh spinner owns every refresh after it.

Changed:
- `SubscriptionsContent.kt`: channels and feed bindings
- `VideoHistoryScreen.kt`: history binding
- `VideoLibraryScreen.kt`: playlists binding

`LibraryScreen.kt` is left untouched because no paired centered indicator was confirmed there.

## Verification

- `ANDROID_HOME=$HOME/Library/Android/sdk JAVA_HOME=/opt/homebrew/opt/openjdk@17 ./gradlew :app:compileDebugKotlin --console=plain` passes.
- `git diff --check` passes.

Signed off with DCO.