### PR TITLE
Fix music playback before 4.5

### DIFF
--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -428,16 +428,6 @@ fun MusicApp(
         navController.navigate("channel/${android.net.Uri.encode(channelId)}")
     }
 
-    // Surface music playback failures. Before this, a song that could not be
-    // resolved failed silently and the player looked stuck on loading forever.
-    val playbackError by playerViewModel.playbackError.collectAsState()
-    androidx.compose.runtime.LaunchedEffect(playbackError) {
-        playbackError?.let { message ->
-            android.widget.Toast.makeText(context, message, android.widget.Toast.LENGTH_LONG).show()
-            playerViewModel.clearPlaybackError()
-        }
-    }
-
     // Music, video and Shorts are mutually exclusive: whichever pipeline
     // starts playing pauses the other two. System audio focus alone is not
     // reliable between players inside the same app, so this is enforced

--- a/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
@@ -658,65 +658,52 @@ class YouTubeRepository(private val context: Context) {
      * Get the best audio stream URL for a video.
      * Note: These URLs expire, so call this right before playback.
      * @param videoId The YouTube video ID
-     * @return The stream URL or null if not found
-     */
-    /**
-     * Get the best audio stream URL for a video.
-     * Note: These URLs expire, so call this right before playback.
-     * @param videoId The YouTube video ID
      * @return Result containing stream URL or error
      */
     suspend fun getStreamUrl(videoId: String): Result<String> = withContext(Dispatchers.IO) {
         val startMs = System.currentTimeMillis()
 
-        // Primary: direct InnerTube /player calls (ANDROID_VR primary, IOS
-        // fallback — see runPlayerClientChain), with a one-shot visitorData
-        // remint + retry when YouTube's bot check flags the current token
-        // (see resolvePlayerStreamingData).
-        val innerTubeUrl = resolvePlayerStreamingData(videoId)?.let { pickAudioStreamUrl(videoId, it) }
-        if (!innerTubeUrl.isNullOrEmpty()) {
-            android.util.Log.i(
-                "YouTubeRepository",
-                "Resolve[InnerTube] OK videoId=$videoId dt=${System.currentTimeMillis() - startMs}ms",
-            )
-            return@withContext Result.success(innerTubeUrl)
-        }
-
-        // Fallback: NewPipe extractor. The InnerTube /player path degrades over a
-        // session — YouTube's bot check eventually flags this install's visitorData
-        // (LOGIN_REQUIRED / empty streamingData) and even the remint bootstrap can
-        // get flagged, leaving InnerTube resolution dead for hours. NewPipe uses a
-        // different (WEB-based, cookie-signed) extraction that keeps working when
-        // InnerTube doesn't. Video playback already leans on this exact fallback
-        // (getVideoStreamQualities), which is why videos keep playing while music
-        // — previously InnerTube-only — died. A throttled NewPipe stream beats a
-        // hard "Check your connection" failure. See CLAUDE.md InnerTube notes.
+        // Primary: NewPipe's maintained Android/visionOS client chain. Direct
+        // ANDROID_VR URLs can start successfully and then hit GVS's progressive
+        // byte ceiling on long media, which is the same failure that moved video
+        // playback to NewPipe first. Audio must use the maintained path too or a
+        // long song can fail only after it has already been playing for a while.
         val newPipeUrl = resolveAudioUrlViaNewPipe(videoId)
-        val dt = System.currentTimeMillis() - startMs
         if (!newPipeUrl.isNullOrEmpty()) {
             android.util.Log.i(
                 "YouTubeRepository",
-                "Resolve[NewPipe fallback] OK videoId=$videoId dt=${dt}ms",
+                "Resolve[NewPipe] OK videoId=$videoId dt=${System.currentTimeMillis() - startMs}ms",
             )
-            Result.success(newPipeUrl)
+            return@withContext Result.success(newPipeUrl)
+        }
+
+        // Last-resort fallback: the older direct /player chain. It can still
+        // cover a client-specific NewPipe extraction failure, but its progressive
+        // URLs must not be the normal path for the reason above.
+        val innerTubeUrl = resolvePlayerStreamingData(videoId)?.let { pickAudioStreamUrl(videoId, it) }
+        val dt = System.currentTimeMillis() - startMs
+        if (!innerTubeUrl.isNullOrEmpty()) {
+            android.util.Log.i(
+                "YouTubeRepository",
+                "Resolve[InnerTube fallback] OK videoId=$videoId dt=${dt}ms",
+            )
+            Result.success(innerTubeUrl)
         } else {
             android.util.Log.e(
                 "YouTubeRepository",
-                "Resolve FAIL videoId=$videoId all clients exhausted (InnerTube + NewPipe) dt=${dt}ms",
+                "Resolve FAIL videoId=$videoId all clients exhausted (NewPipe + InnerTube) dt=${dt}ms",
             )
             Result.failure(Exception("No audio stream found for $videoId"))
         }
     }
 
     /**
-     * Resolve an audio stream URL through the NewPipe extractor. Used as the
-     * fallback for [getStreamUrl] when the InnerTube /player chain yields no
-     * usable stream (bot-check-flagged visitorData, etc.). Applies the same
-     * per-network music quality policy as [pickAudioStreamUrl] (NewPipe's
-     * averageBitrate is in kbps); falls back to a muxed video+audio stream
-     * (ExoPlayer plays just the audio track) when no audio-only stream is
-     * available. The resulting googlevideo URL is tagged with NewPipe's issuing
-     * client, so playback picks the matching UA via uaForPlaybackUri().
+     * Resolve an audio stream URL through NewPipe's maintained client chain.
+     * Applies the same per-network music quality policy as [pickAudioStreamUrl]
+     * (NewPipe's averageBitrate is in kbps), and falls back to a muxed
+     * video+audio URL when no audio-only URL exists. The resulting googlevideo
+     * URL is tagged with its issuing client, so playback selects the matching
+     * user agent through [uaForPlaybackUri].
      */
     private suspend fun resolveAudioUrlViaNewPipe(videoId: String): String? = withContext(Dispatchers.IO) {
         try {
@@ -726,7 +713,11 @@ class YouTubeRepository(private val context: Context) {
             val streamExtractor = ytService.getStreamExtractor(streamUrl)
             streamExtractor.fetchPage()
 
-            val audioStreams = originalTrackAudioStreams(streamExtractor.audioStreams)
+            // Generated manifest content shares the Stream model with direct
+            // URLs. Only the latter can be handed to Media3 as a URI.
+            val audioStreams = originalTrackAudioStreams(
+                streamExtractor.audioStreams.filter { it.isUrl },
+            )
             when (ThemePreferences.currentMusicQuality(context)) {
                 ThemePreferences.MUSIC_QUALITY_LOW ->
                     audioStreams.minByOrNull { it.averageBitrate }
@@ -740,12 +731,14 @@ class YouTubeRepository(private val context: Context) {
 
             // No audio-only stream — a muxed stream still carries an audio track.
             streamExtractor.videoStreams
-                .mapNotNull { it.content?.takeIf { c -> c.isNotBlank() } }
+                .asSequence()
+                .filter { it.isUrl }
+                .mapNotNull { it.content?.takeIf(String::isNotBlank) }
                 .firstOrNull()
         } catch (e: Exception) {
             android.util.Log.w(
                 "YouTubeRepository",
-                "Resolve[NewPipe fallback] failed videoId=$videoId: ${e.message}",
+                "Resolve[NewPipe] failed videoId=$videoId: ${e.message}",
             )
             null
         }

--- a/app/src/main/java/com/ivor/ivormusic/service/MusicService.kt
+++ b/app/src/main/java/com/ivor/ivormusic/service/MusicService.kt
@@ -127,8 +127,8 @@ class MusicService : MediaLibraryService() {
     companion object {
         private const val TAG = "MusicService"
         private const val PREFETCH_AHEAD_COUNT = 3
-        // Resolution is two InnerTube /player calls at most, each hard-capped at
-        // 8s by OkHttp's callTimeout in YouTubeRepository.
+        // Covers the maintained NewPipe extraction and the direct InnerTube
+        // fallback; their individual requests are also bounded by OkHttp.
         private const val RESOLVE_TIMEOUT_MS = 20_000L
         private const val PLACEHOLDER_PREFIX = "https://placeholder.ivormusic/"
         private const val CACHED_PREFIX = "https://cached.ivormusic/"
@@ -142,13 +142,11 @@ class MusicService : MediaLibraryService() {
         private const val WARM_CACHE_BYTES = 512L * 1024
 
         // Re-resolution attempts before a song is skipped. A dead or expired URL
-        // is fixed by the first retry or not at all, so the general ceiling stays
-        // low. A googlevideo 403 is different in kind: it is a verdict on the
-        // visitorData rather than on the URL, each retry re-rolls that identity,
-        // and roughly half of freshly minted tokens are served (measured August
-        // 2026), so four attempts recover the large majority of songs. Each one
-        // costs a mint plus a /player call, which is cheap next to skipping a
-        // track the user chose.
+        // is fixed by a fresh extraction or not at all, so the general ceiling
+        // stays low. A 403 on the direct InnerTube fallback is different: it is
+        // a verdict on visitorData, so each retry re-rolls that identity. Four
+        // attempts recover the large majority of those fallbacks (measured
+        // August 2026) without applying that expensive recovery to NewPipe URLs.
         private const val MAX_RETRIES = 2
         private const val MAX_FORBIDDEN_RETRIES = 4
 
@@ -740,8 +738,8 @@ class MusicService : MediaLibraryService() {
         }
 
         // 4. Network with Retry
-        // YouTubeRepository retry logic handles NewPipe flakiness. 
-        // We just handle timeout here.
+        // YouTubeRepository owns the NewPipe-first client fallback. This layer
+        // bounds the whole resolution and handles playback-time re-resolution.
         return try {
             val result = withTimeoutOrNull(RESOLVE_TIMEOUT_MS) {
                 youtubeRepository.getStreamUrl(videoId)
@@ -821,14 +819,17 @@ class MusicService : MediaLibraryService() {
 
         // 2. Retry Logic (YouTube songs only)
         val retryCount = retryCounts[videoId] ?: 0
-        // A media-layer 403 means the visitorData this stream was resolved under
-        // is in googlevideo's enforced bucket, and re-resolving under the same
-        // token just rebuilds the same dead URL. Each retry mints a fresh
-        // identity with an independent chance of landing in a served bucket, so
-        // these get their own, higher ceiling: the alternative is skipping a
-        // song the very next attempt would have played.
-        val isMediaForbidden = httpResponseCode(error) == 403
-        val maxRetries = if (isMediaForbidden) MAX_FORBIDDEN_RETRIES else MAX_RETRIES
+        // Only direct InnerTube streams are tied to Koda's visitorData. The
+        // NewPipe-first path uses maintained Android/visionOS clients; a 403
+        // there needs a fresh extraction, not an unrelated identity remint.
+        val issuingClient = try {
+            uri?.getQueryParameter("c")?.uppercase()
+        } catch (_: Exception) {
+            null
+        }
+        val isVisitorDataForbidden = httpResponseCode(error) == 403 &&
+            (issuingClient == "ANDROID_VR" || issuingClient == "IOS")
+        val maxRetries = if (isVisitorDataForbidden) MAX_FORBIDDEN_RETRIES else MAX_RETRIES
 
         if (retryCount < maxRetries) {
             Log.w(TAG, "Error: Retrying ($retryCount/$maxRetries) for $videoId...")
@@ -842,7 +843,7 @@ class MusicService : MediaLibraryService() {
                 // token stays in prefs and is replayed for its whole 6h TTL -
                 // every uncached song failing until the user clears app data.
                 // Mirrors VideoPlayerViewModel.recoverFromSourceError.
-                if (isMediaForbidden) {
+                if (isVisitorDataForbidden) {
                     youtubeRepository.refreshVisitorDataAfterPlaybackFailure()
                     // Everything prefetchUpcomingSongs resolved was signed with
                     // the token just discarded, so the rest of the queue is

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
@@ -55,16 +55,6 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
     private val _isBuffering = MutableStateFlow(false)
     val isBuffering: StateFlow<Boolean> = _isBuffering.asStateFlow()
 
-    // One-shot user-facing playback error message. The UI shows it (toast) and
-    // calls clearPlaybackError(). Without this, resolution/network failures
-    // were completely silent and the player sat on the buffering spinner.
-    private val _playbackError = MutableStateFlow<String?>(null)
-    val playbackError: StateFlow<String?> = _playbackError.asStateFlow()
-
-    fun clearPlaybackError() {
-        _playbackError.value = null
-    }
-
     /**
      * Snapshot the current queue, index, and position for resume-on-reopen.
      * Controller state is read on the caller (main) thread; the file write
@@ -377,12 +367,6 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
                     // Clearing here guarantees the spinner can't outlive a
                     // playback that is never going to start.
                     _isBuffering.value = false
-                    val title = _currentSong.value?.title
-                    _playbackError.value = if (title != null) {
-                        "Couldn't play \"$title\". Check your connection and try again."
-                    } else {
-                        "Playback failed. Check your connection and try again."
-                    }
                 }
 
                 override fun onShuffleModeEnabledChanged(shuffleModeEnabled: Boolean) {


### PR DESCRIPTION
## What this changes

- Removes the one-shot music playback error state and the random Toast shown for recoverable Media3 errors.
- Resolves music through NewPipe 0.26.5 first, matching the maintained client path already adopted by video playback.
- Keeps direct InnerTube as a last-resort fallback instead of accepting its long-media progressive URLs first.
- Rejects generated NewPipe stream content where Media3 requires a real URL.
- Limits visitorData reminting to 403s from direct InnerTube streams; NewPipe failures now get a fresh extraction without clearing the whole queue identity.

## Why

The latest video fix moved VOD playback to NewPipe first because direct ANDROID_VR URLs can begin normally and then hit a progressive byte ceiling on long media. Music still preferred that old direct path, so long songs carried the same risk. Music errors were also surfaced immediately as Toasts even though MusicService retries or skips them itself, producing noisy messages during otherwise recoverable playback.

## Testing

Not run at the maintainer request. The GitHub Actions APK will be tested manually before release.