### PR TITLE
Add Tiles, a rhythm-board player style charted from the audio analysis

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -197,9 +197,9 @@ Two families, each doing a specific job:
 
 ---
 
-## Eight players, one design language
+## Nine players, one design language
 
-The player styles are the clearest demonstration that Expressive is a construction material rather than a coat of paint. Each is an independent layout (roughly 11,900 lines across the player package), and none of them re-implements theming, motion, or shape. They all draw from the same system.
+The player styles are the clearest demonstration that Expressive is a construction material rather than a coat of paint. Each is an independent layout (roughly 14,100 lines across the player package), and none of them re-implements theming, motion, or shape. They all draw from the same system.
 
 | Style | Idea |
 |---|---|
@@ -211,8 +211,9 @@ The player styles are the clearest demonstration that Expressive is a constructi
 | Sticker | Die-cut sticker with drag, peel, squash-and-stretch |
 | Morph | Living hero shape cycling organic cuts while playing |
 | Dial | Rotary tick-ring instrument spun to scrub |
+| Tiles | Four-lane rhythm board charted from the track's own tempo analysis |
 
-Eight visually distinct players share one theme, one motion scheme, and one shape library. That is the point of a design system, and it is why adding a ninth style is a contained piece of work while replacing the design language is not.
+Nine visually distinct players share one theme, one motion scheme, and one shape library. That is the point of a design system, and it is why adding a tenth style is a contained piece of work while replacing the design language is not. Tiles is the clearest case: it is a playable rhythm board, and it still needed no color, no motion curve and no shape of its own - it is set in the Editorial dress, two flat tones and a serif, because that dress was already there to be used.
 
 **The same reasoning runs the other way, and `ui/channel/CreatorHeader.kt` is where it shows.** A creator's channel page in video mode and their artist page in music mode are two screens over genuinely different content - an upload feed and a discography - so they are two screens. But they are one person, and a viewer arriving from either mode should not feel like they arrived at two different people, so the identity is one shared component: banner, avatar, verified tick, counts, and a slot the two screens fill differently (Subscribe and Share on one side, Play, Shuffle and Radio on the other). **Share the part that must not differ; do not share the part that genuinely does.** Two headers maintained separately drift until the same name has two avatars and two follower counts, and nothing fails when they do.
 
@@ -227,7 +228,7 @@ If Koda's look is not to your taste, a lot is already adjustable in Settings bef
 - **Color palette:** wallpaper-based dynamic color, or any of the 29 fixed palettes
 - **Album Art Colors:** recolor the expanded player from the current cover art
 - **Ambient artwork background** and the optional chromatic-mist effect
-- **Player style:** eight full layouts, switchable from the style wheel
+- **Player style:** nine full layouts, switchable from the style wheel
 - **Home mode toggle:** reshape Home, Search, and Library between music and video
 
 Between palettes, theme modes, and player styles, that is a very large number of distinct looks without touching the design language underneath.
@@ -240,7 +241,7 @@ Between palettes, theme modes, and player styles, that is a very large number of
 
 The reasons are practical, not stubborn:
 
-1. **It is not a theme, it is the app.** 49 files use Expressive-only APIs directly. Replacing the design language means rewriting every screen, both players, all eight player styles, both music homes, onboarding, and settings. Roughly 60,000 lines of UI code.
+1. **It is not a theme, it is the app.** 51 files use Expressive-only APIs directly. Replacing the design language means rewriting every screen, both players, all nine player styles, both music homes, onboarding, and settings. Roughly 60,000 lines of UI code.
 2. **Two design languages means two apps.** Every future feature would need building twice, and every bug would need reproducing twice. In a project this size that is not a sustainable trade.
 3. **The design is the differentiator.** There are many capable NewPipe-based players. What Koda offers on top of the same extraction stack is this interface. Making it generic removes the reason to choose it.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -437,7 +437,7 @@ The milestones behind us, kept here so the direction of travel is visible.
 - Saving other people's playlists and albums to the library in both music and video mode, stored as live references rather than copies
 - Synced lyrics from LRCLIB, scrolling in time with playback
 - In-app video with a personalized feed, chapters, captions, and comments
-- Eight player styles and a 27-palette color system with dynamic color and AMOLED
+- Nine player styles and a 27-palette color system with dynamic color and AMOLED
 - Listening statistics with play charts, streaks, and top artists
 - Offline downloads for music and video, written to the system Downloads folder
 - Live streams with live chat, including a full-screen player for vertical broadcasts
@@ -464,10 +464,16 @@ The milestones behind us, kept here so the direction of travel is visible.
 - Swipe on the song title and artist to change tracks, in every player style, on one shared gesture contract that the album-cover swipe now also runs on
 - Genuine two-player crossfade: configurable equal-power overlap on natural changes and a short 500ms overlap on manual skips, shared by app controls, queue taps, Bluetooth and Android Auto
 - AutoMix transition planner: transient-aware beat grids at both ends, pickup-preserving downbeat alignment, bounded tempo correction, separate intro/outro harmonic checks, and a clock-verified two-player handoff that abandons unsafe overlaps
+- Tiles, a four-lane rhythm player style charted from the tempo, downbeat and key the app already measures for AutoMix, with holds, bar-numbered downbeat tiles, per-track best scores and a sync calibration
 
 Crossfade alternates two fully configured ExoPlayers while keeping one logical queue visible through the media session. The standby must reach `STATE_READY` before either volume moves; a failed resolution or buffer deadline keeps the outgoing track alive and falls back to a short ramp only when overlap is impossible. Both players share audio focus, the pinned audio-session id, loudness correction and ducking. Cancellation is an abort, never a swap, and shuffled playback asks the player for its real next index instead of assuming timeline order.
 
 The song-information swipe is worth recording for what the work actually turned out to be. The request read as "add the gesture to one more area", and the survey found something else: **the swipe had been hand-rolled per style, and three of the eight had never got one.** Classic, Bento and Dial had prev/next buttons and nothing else, Morph had drifted to a 100dp threshold against everyone else's 90dp, and there was no single place that would have made any of that visible. So the fix was a shared contract (`ui/player/SwipeToSkip.kt`: one `rememberSwipeToSkip`, `Modifier.swipeToSkip`, `Modifier.swipeToSkipFollow`) that the artwork gestures were migrated onto, rather than a ninth copy of the same twenty lines. **A rule that lives only in prose is a rule that will be missed by whoever adds the next style**; this one is now a function it is easier to call than to reimplement.
+
+Tiles is worth recording for the opposite reason: **almost none of it was new work.** A rhythm game needs a beat map, and `AudioProfiler` had been writing one for every track played since AutoMix shipped - tempo and its confidence, the first beat and downbeat, the same measured independently at the outro, the key, where the audio starts and where it fades. All of that existed to decide how to overlap two songs, and nothing read it anywhere else. `data/TileChart.kt` turns it into a chart with no decode, no request and no new analysis, and the outro anchor earns its keep a second time: two independently measured downbeats a whole track apart are a tempo fit, which is what keeps the last minute of a long song on the grid instead of a few hundred milliseconds adrift.
+
+Two decisions are the load-bearing ones. **Playback is never a consequence of play** - a miss costs score and the streak and nothing else - because Magic Tiles' game-over is right for a game and wrong for the player somebody keeps their music in. And **a chart is never faked**: a track with no confident tempo says so and offers Freestyle as an explicit choice, because tiles that do not match the music read as the app being broken rather than as a track it has not measured yet. The corollaries are all of the same shape: seeking past a passage skips those tiles rather than missing them, pausing abandons a held tile rather than breaking it, and the run survives the player being collapsed.
+
 
 Two things stayed deliberately un-unified. **Sticker keeps its peel** - the art is thrown off the canvas and the next one slapped on, which is that style's identity and is not a spring-back - and **Gesture's title swipe steps the queue** rather than calling the ViewModel's skip, because its carousel follows `currentIndex` and would otherwise disagree with the gesture that moved it. Same direction, same commit, different animation. The mini player was left alone: horizontal there already means dismiss, and splitting one 64dp bar between dismiss and skip is a coin flip every time.
 

--- a/app/src/main/java/com/ivor/ivormusic/data/AudioProfileStore.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/AudioProfileStore.kt
@@ -108,6 +108,20 @@ class AudioProfileStore(context: Context) {
         loaded()
     }
 
+    /**
+     * Re-read the file, picking up profiles written by another instance.
+     *
+     * The map is loaded once and kept, which is right for the player service
+     * that also writes it - but every other holder news up its own store (there
+     * is no DI here), and the analysis for the track playing right now is
+     * normally written *after* a reader has already loaded. Without this, a
+     * consumer that starts before the profile lands never sees it at all.
+     */
+    suspend fun reload() {
+        mutex.withLock { cache = null }
+        loaded()
+    }
+
     private companion object {
         const val TAG = "AudioProfileStore"
         const val FILE_NAME = "audio_profiles.json"

--- a/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
@@ -379,6 +379,53 @@ class ThemePreferences(context: Context) {
                 ?: VIDEO_QUALITY_AUTO
 
         /**
+         * The Tiles player's own two settings, set from its tuning sheet rather
+         * than the Settings screen and read fresh by it, the same trade
+         * [KEY_DOWNLOAD_VIDEO_QUALITY] makes: they only mean anything inside
+         * one player style, and a Settings row for them would be a control the
+         * reader has no context for.
+         *
+         * [KEY_TILES_SYNC_OFFSET] is milliseconds of audio output latency, and
+         * it is a per-device physical fact rather than a taste: the position
+         * the player reports is what the decoder has produced, and the sound
+         * reaches the ear some milliseconds later. Judging a tap against the
+         * raw position marks a player who is exactly in time as late by that
+         * much, on every single tile. It is the difference between the board
+         * feeling tight and feeling broken, so it is adjustable and it is
+         * remembered.
+         */
+        private const val KEY_TILES_DIFFICULTY = "tiles_difficulty"
+        private const val KEY_TILES_SYNC_OFFSET = "tiles_sync_offset_ms"
+
+        /** Sensible bounds for the sync slider; well past any real device latency. */
+        const val TILES_SYNC_OFFSET_MIN_MS = -150
+        const val TILES_SYNC_OFFSET_MAX_MS = 400
+
+        fun currentTilesDifficulty(context: Context): String? =
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .getString(KEY_TILES_DIFFICULTY, null)
+
+        fun setTilesDifficulty(context: Context, key: String) {
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .edit().putString(KEY_TILES_DIFFICULTY, key).apply()
+        }
+
+        fun currentTilesSyncOffsetMs(context: Context): Int =
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .getInt(KEY_TILES_SYNC_OFFSET, 0)
+                .coerceIn(TILES_SYNC_OFFSET_MIN_MS, TILES_SYNC_OFFSET_MAX_MS)
+
+        fun setTilesSyncOffsetMs(context: Context, offsetMs: Int) {
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .edit()
+                .putInt(
+                    KEY_TILES_SYNC_OFFSET,
+                    offsetMs.coerceIn(TILES_SYNC_OFFSET_MIN_MS, TILES_SYNC_OFFSET_MAX_MS)
+                )
+                .apply()
+        }
+
+        /**
          * Static fresh read of the active palette id, for the playlist cover
          * generator. It runs when a playlist is created or renamed, long after
          * the Settings screen changed the palette through its own
@@ -1195,5 +1242,7 @@ enum class PlayerStyle {
     /** Living hero shape that cycles organic cuts while playing */
     MORPH,
     /** Rotary instrument: a tick-ring dial spun to scrub */
-    DIAL
+    DIAL,
+    /** Rhythm board: four lanes of tiles charted from the track's own analysis */
+    TILES
 }

--- a/app/src/main/java/com/ivor/ivormusic/data/TileChart.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/TileChart.kt
@@ -1,0 +1,409 @@
+package com.ivor.ivormusic.data
+
+import kotlin.math.abs
+import kotlin.math.roundToInt
+import kotlin.math.roundToLong
+import kotlin.random.Random
+
+/** Lanes on the Tiles board. Four is the genre's shape and a thumb's reach. */
+const val TILE_LANES = 4
+
+/**
+ * What a single tile asks of the player.
+ *
+ * Three kinds rather than one, because a chart of identical taps has no shape:
+ * the bar line should feel different from the beats inside it, and a held note
+ * is the only way a sustained passage reads as sustained.
+ */
+enum class TileKind {
+    /** One tap on the beat. The body of every chart. */
+    TAP,
+
+    /** A tap on the bar's downbeat. Worth double, printed differently. */
+    ACCENT,
+
+    /** Press and stay down until the tail clears the line. */
+    HOLD
+}
+
+/**
+ * One playable tile.
+ *
+ * [startMs] and [endMs] are absolute positions in the track, so the chart is a
+ * pure function of the song and survives seeking, pausing and re-entry without
+ * any notion of "when the game started".
+ */
+data class Tile(
+    val lane: Int,
+    val startMs: Long,
+    val endMs: Long,
+    val kind: TileKind,
+    /**
+     * How long the tile is on screen, expressed as travel time rather than
+     * pixels so the board can be any height.
+     *
+     * A tap is a chunky fixed block, except where the next tile in the same
+     * lane arrives sooner - two tiles that overlap on screen cannot be aimed
+     * at separately, so the earlier one is shortened rather than drawn over.
+     */
+    val drawLenMs: Long,
+    /** Bar number from the first downbeat, printed on accent tiles. */
+    val bar: Int
+) {
+    val isHold: Boolean get() = kind == TileKind.HOLD
+    val holdLengthMs: Long get() = (endMs - startMs).coerceAtLeast(0L)
+}
+
+/**
+ * How busy the chart is.
+ *
+ * The target is notes per second rather than a subdivision, because a
+ * subdivision means something different at 80 BPM than at 170 and a chart that
+ * is comfortable for one tempo is unplayable or empty at the other.
+ */
+enum class TileDifficulty(
+    val key: String,
+    val label: String,
+    val targetNotesPerSecond: Float
+) {
+    CHILL("chill", "Chill", 1.5f),
+    STANDARD("standard", "Standard", 2.4f),
+    RUSH("rush", "Rush", 3.4f);
+
+    companion object {
+        fun from(key: String?): TileDifficulty =
+            entries.firstOrNull { it.key == key } ?: STANDARD
+    }
+}
+
+/**
+ * A generated beat map for one track.
+ *
+ * [bpm] and [keyLabel] are carried for the masthead: the analysis is the reason
+ * this player can exist, so the numbers behind the chart are printed rather
+ * than hidden.
+ */
+data class TileChart(
+    val songId: String,
+    val tiles: List<Tile>,
+    val bpm: Float?,
+    val keyLabel: String?,
+    val difficulty: TileDifficulty,
+    /** True when no confident tempo was measured and the grid is assumed. */
+    val isFreestyle: Boolean,
+    val beatMs: Double,
+    val firstDownbeatMs: Long
+) {
+    val isEmpty: Boolean get() = tiles.isEmpty()
+
+    /** First tile at or after [positionMs]; [tiles].size when the chart is spent. */
+    fun indexAtOrAfter(positionMs: Long): Int {
+        var low = 0
+        var high = tiles.size
+        while (low < high) {
+            val mid = (low + high) / 2
+            if (tiles[mid].startMs < positionMs) low = mid + 1 else high = mid
+        }
+        return low
+    }
+}
+
+/**
+ * Turns an [AudioProfile] into a playable chart.
+ *
+ * **The app already measures every track it plays** - tempo, the first beat and
+ * downbeat, the key, where the audio actually starts and how it ends - for
+ * AutoMix. That measurement is the whole basis of this: nothing here decodes
+ * audio, makes a request or costs anything at play time beyond a few hundred
+ * objects, and a track that has never been profiled simply has no chart rather
+ * than a wrong one.
+ *
+ * Everything is derived from the song id, so a chart is identical on every
+ * replay. A rhythm game whose notes move between attempts cannot be practised,
+ * and a best score against a chart that changed means nothing.
+ */
+object TileChartFactory {
+
+    /** Below this the head tempo estimate is a guess, not a grid. */
+    private const val MIN_TEMPO_CONFIDENCE = 0.18f
+
+    /** The outro anchor only corrects drift when it agrees with the head. */
+    private const val MIN_OUTRO_CONFIDENCE = 0.3f
+    private const val MAX_DRIFT_CORRECTION = 0.06
+
+    /** Eight slots to the bar: the chart is written in eighth notes. */
+    private const val SLOTS_PER_BAR = 8
+    private const val BEATS_PER_BAR = 4
+
+    /** Assumed tempo for a freestyle chart, which the user opts into knowingly. */
+    private const val FREESTYLE_BPM = 120f
+
+    /** How long a tap tile is on screen, before crowding shortens it. */
+    private const val TAP_DRAW_MS = 340L
+
+    /** A gap of at least this many beats can become a held note. */
+    private const val HOLD_MIN_GAP_BEATS = 2.0
+    private const val HOLD_MAX_BEATS = 4.0
+    private const val HOLD_CHANCE = 0.55f
+
+    /** Guard against a runaway grid on a bad duration or a silly tempo. */
+    private const val MAX_TILES = 4000
+
+    /**
+     * Rhythms available to a bar, indexed by how many notes they contain.
+     *
+     * Written out rather than generated so every bar is a rhythm somebody would
+     * actually play: the accents fall where a listener expects them, and the
+     * rests are where a phrase breathes. Picking the group by density and the
+     * member by seed is what keeps a four-minute chart from being a metronome.
+     */
+    private val PATTERNS: Map<Int, List<Int>> = mapOf(
+        1 to listOf("x-------"),
+        2 to listOf("x---x---", "x-----x-", "x--x----"),
+        3 to listOf("x---x-x-", "x-x---x-", "x--x--x-", "x---xx--"),
+        4 to listOf("x-x-x-x-", "x-x-x--x", "x--xx-x-", "x-xx--x-"),
+        5 to listOf("x-x-x-xx", "x-xxx-x-", "xx-x-x-x", "x-x-xxx-"),
+        6 to listOf("xx-xx-xx", "x-xxx-xx", "xxx-xx-x", "xx-xxx-x"),
+        7 to listOf("xxxx-xxx", "xx-xxxxx", "xxxxx-xx"),
+        8 to listOf("xxxxxxxx")
+    ).mapValues { (_, patterns) -> patterns.map(::maskOf) }
+
+    private fun maskOf(pattern: String): Int {
+        var mask = 0
+        pattern.forEachIndexed { slot, char -> if (char == 'x') mask = mask or (1 shl slot) }
+        return mask
+    }
+
+    private val PITCH_NAMES = listOf(
+        "C", "C♯", "D", "D♯", "E", "F", "F♯", "G", "G♯", "A", "A♯", "B"
+    )
+
+    /**
+     * @param freestyle when true, a track with no measured tempo still gets a
+     *   chart on an assumed 4/4 grid. Off by default: tiles that do not match
+     *   the music are worse than no tiles, so this is only ever the user's
+     *   explicit choice.
+     * @return null when there is nothing honest to generate.
+     */
+    fun build(
+        songId: String,
+        durationMs: Long,
+        profile: AudioProfile?,
+        difficulty: TileDifficulty,
+        freestyle: Boolean = false
+    ): TileChart? {
+        if (durationMs <= 0L) return null
+
+        val measuredBpm = profile?.bpm?.takeIf {
+            it > 0f && profile.tempoConfidence >= MIN_TEMPO_CONFIDENCE
+        }
+        if (measuredBpm == null && !freestyle) return null
+
+        val isFreestyle = measuredBpm == null
+        val bpm = measuredBpm ?: FREESTYLE_BPM
+        var beatMs = 60_000.0 / bpm
+        // The head window measures the intro. Anchoring the far end of the grid
+        // on the independently measured outro downbeat turns two point
+        // estimates into a tempo fit, which is what keeps the last minute of a
+        // long track in time instead of a few hundred milliseconds adrift.
+        val firstDownbeat = if (isFreestyle) 0L else (profile?.downbeatOffsetMs ?: 0L)
+        if (!isFreestyle && profile != null) {
+            beatMs = correctedBeat(profile, beatMs, firstDownbeat, durationMs)
+        }
+        val barMs = beatMs * BEATS_PER_BAR
+        if (barMs <= 0.0) return null
+
+        val firstSound = (profile?.leadInSilenceMs ?: 0L).coerceAtLeast(0L)
+        val startMs = (firstDownbeat.toDouble() + barMs * kotlin.math.ceil(
+            ((firstSound + 200L) - firstDownbeat).coerceAtLeast(0L) / barMs
+        )).roundToLong()
+        val endMs = chartEnd(profile, durationMs)
+        if (endMs - startMs < barMs) return null
+
+        val notesPerBar = (difficulty.targetNotesPerSecond * (barMs / 1000.0))
+            .roundToInt()
+            .coerceIn(1, SLOTS_PER_BAR)
+        val slotMs = barMs / SLOTS_PER_BAR
+        val seed = songId.hashCode().toLong() * 31 + difficulty.ordinal
+
+        val raw = ArrayList<RawNote>(256)
+        var barIndex = 0
+        var barStart = startMs.toDouble()
+        while (barStart < endMs && raw.size < MAX_TILES) {
+            val random = Random(seed * 8191 + barIndex)
+            // A bar of rest every so often. A chart with no gaps reads as noise
+            // and gives the player nowhere to recover a dropped combo.
+            val rests = !isFreestyle && barIndex > 0 && barIndex % 8 == 7
+            if (!rests) {
+                val group = PATTERNS[notesPerBar] ?: PATTERNS.getValue(4)
+                val mask = group[random.nextInt(group.size)]
+                for (slot in 0 until SLOTS_PER_BAR) {
+                    if (mask and (1 shl slot) == 0) continue
+                    val at = (barStart + slot * slotMs).roundToLong()
+                    if (at < startMs || at > endMs) continue
+                    raw.add(
+                        RawNote(
+                            startMs = at,
+                            isDownbeat = slot == 0,
+                            bar = barIndex + 1
+                        )
+                    )
+                }
+            }
+            barIndex++
+            barStart = startMs + barIndex * barMs
+        }
+        if (raw.isEmpty()) return null
+
+        val tiles = assign(raw, beatMs, endMs, seed)
+        if (tiles.isEmpty()) return null
+
+        return TileChart(
+            songId = songId,
+            tiles = tiles,
+            bpm = if (isFreestyle) null else bpm,
+            keyLabel = keyLabel(profile),
+            difficulty = difficulty,
+            isFreestyle = isFreestyle,
+            beatMs = beatMs,
+            firstDownbeatMs = firstDownbeat
+        )
+    }
+
+    /**
+     * Fit the beat length to the outro downbeat when the tail measurement is
+     * both confident and consistent with the head.
+     *
+     * A tail estimate that disagrees by more than a few percent is a half- or
+     * double-time reading rather than drift, and following it would put the
+     * whole back half of the chart on the wrong grid.
+     */
+    private fun correctedBeat(
+        profile: AudioProfile,
+        beatMs: Double,
+        firstDownbeatMs: Long,
+        durationMs: Long
+    ): Double {
+        if (profile.outroTempoConfidence < MIN_OUTRO_CONFIDENCE) return beatMs
+        if (profile.outroDownbeatLeadMs <= 0L) return beatMs
+        val target = durationMs - profile.outroDownbeatLeadMs
+        val span = target - firstDownbeatMs
+        val barMs = beatMs * BEATS_PER_BAR
+        if (span < barMs * 8) return beatMs
+        val bars = (span / barMs).roundToInt()
+        if (bars < 8) return beatMs
+        val corrected = span.toDouble() / bars / BEATS_PER_BAR
+        if (abs(corrected - beatMs) / beatMs > MAX_DRIFT_CORRECTION) return beatMs
+        return corrected
+    }
+
+    /**
+     * Where the chart stops.
+     *
+     * A track that fades out should not be asking for taps through the fade,
+     * and one that is cut off mid-phrase has no outro to protect.
+     */
+    private fun chartEnd(profile: AudioProfile?, durationMs: Long): Long {
+        if (profile == null) return durationMs - 800L
+        if (profile.endsAbruptly) return durationMs - 300L
+        val quiet = maxOf(profile.tailFadeMs, profile.outroLeadMs, 800L)
+        return durationMs - quiet
+    }
+
+    /**
+     * Lanes, holds and draw lengths in one pass.
+     *
+     * Lane choice is seeded rather than random so the chart is stable, and
+     * constrained rather than free: a lane still under a held tile cannot be
+     * asked for, and the same lane is not demanded three times in a row at
+     * speed, because both are unplayable rather than merely hard.
+     */
+    private fun assign(
+        raw: List<RawNote>,
+        beatMs: Double,
+        endMs: Long,
+        seed: Long
+    ): List<Tile> {
+        val holdEnds = LongArray(TILE_LANES) { Long.MIN_VALUE }
+        val lanes = IntArray(raw.size) { -1 }
+        val holdUntil = LongArray(raw.size) { 0L }
+        var previousLane = -1
+        var repeats = 0
+
+        raw.forEachIndexed { index, note ->
+            val random = Random(seed * 131 + index)
+            val next = raw.getOrNull(index + 1)
+            val gap = ((next?.startMs ?: endMs) - note.startMs).coerceAtLeast(0L)
+
+            val makeHold = !note.isDownbeat &&
+                gap >= (beatMs * HOLD_MIN_GAP_BEATS) &&
+                random.nextFloat() < HOLD_CHANCE
+            val holdEnd = if (makeHold) {
+                val length = (gap - beatMs * 0.5).coerceAtMost(beatMs * HOLD_MAX_BEATS)
+                note.startMs + length.roundToLong().coerceAtLeast(1L)
+            } else 0L
+
+            val free = (0 until TILE_LANES).filter { holdEnds[it] < note.startMs }
+                .ifEmpty { (0 until TILE_LANES).toList() }
+            val tight = gap <= beatMs * 0.75
+            val avoid = when {
+                previousLane < 0 -> -1
+                repeats >= 2 -> previousLane
+                tight -> previousLane
+                else -> -1
+            }
+            val choices = free.filterNot { it == avoid }.ifEmpty { free }
+            val lane = choices[random.nextInt(choices.size)]
+
+            repeats = if (lane == previousLane) repeats + 1 else 0
+            previousLane = lane
+            lanes[index] = lane
+            holdUntil[index] = holdEnd
+            if (holdEnd > 0L) holdEnds[lane] = holdEnd
+        }
+
+        // A tap is drawn as a chunky block, shortened when the same lane is
+        // asked for again before the block would have cleared: two overlapping
+        // blocks in one lane are one long smear to aim at.
+        val nextInLane = LongArray(raw.size) { Long.MAX_VALUE }
+        val seenAfter = LongArray(TILE_LANES) { Long.MAX_VALUE }
+        for (index in raw.indices.reversed()) {
+            nextInLane[index] = seenAfter[lanes[index]]
+            seenAfter[lanes[index]] = raw[index].startMs
+        }
+
+        return raw.mapIndexed { index, note ->
+            val holdEnd = holdUntil[index]
+            val room = nextInLane[index].let {
+                if (it == Long.MAX_VALUE) TAP_DRAW_MS else ((it - note.startMs) * 0.8).toLong()
+            }
+            Tile(
+                lane = lanes[index],
+                startMs = note.startMs,
+                endMs = if (holdEnd > 0L) holdEnd else note.startMs,
+                kind = when {
+                    holdEnd > 0L -> TileKind.HOLD
+                    note.isDownbeat -> TileKind.ACCENT
+                    else -> TileKind.TAP
+                },
+                drawLenMs = if (holdEnd > 0L) {
+                    holdEnd - note.startMs
+                } else {
+                    room.coerceIn(90L, TAP_DRAW_MS)
+                },
+                bar = note.bar
+            )
+        }
+    }
+
+    /** "F# MINOR", or null when the key estimate was not worth printing. */
+    private fun keyLabel(profile: AudioProfile?): String? {
+        val pitch = profile?.keyPitchClass ?: return null
+        val mode = profile.keyMode ?: return null
+        if (profile.keyConfidence <= 0f) return null
+        val name = PITCH_NAMES.getOrNull(((pitch % 12) + 12) % 12) ?: return null
+        return "$name ${mode.uppercase()}"
+    }
+
+    private data class RawNote(val startMs: Long, val isDownbeat: Boolean, val bar: Int)
+}

--- a/app/src/main/java/com/ivor/ivormusic/data/TileScoreStore.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/TileScoreStore.kt
@@ -1,0 +1,140 @@
+package com.ivor.ivormusic.data
+
+import android.content.Context
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * What one run through a track scored.
+ *
+ * Kept as a whole rather than as a bare number so the result card can say
+ * *why* a run was good, and so a later best can be compared on accuracy when
+ * the scores tie.
+ */
+@Serializable
+data class TileRunResult(
+    val songId: String,
+    val difficulty: String,
+    val score: Int = 0,
+    val maxCombo: Int = 0,
+    val perfect: Int = 0,
+    val great: Int = 0,
+    val good: Int = 0,
+    val missed: Int = 0,
+    /** Tiles the run actually judged. Seeking past tiles does not count them. */
+    val judged: Int = 0,
+    val updatedAt: Long = 0L
+) {
+    /**
+     * Weighted accuracy, zero to one.
+     *
+     * A near-miss is worth something and a miss is worth nothing, which is what
+     * separates a sloppy clear from a clean one; a flat hit rate cannot.
+     */
+    val accuracy: Float
+        get() = if (judged <= 0) 0f else {
+            ((perfect * 1f) + (great * 0.7f) + (good * 0.35f)) / judged
+        }
+
+    /** Full-combo: every tile judged, none missed, and at least one tile judged. */
+    val isFullCombo: Boolean get() = judged > 0 && missed == 0
+
+    val grade: String
+        get() = when {
+            judged <= 0 -> "-"
+            accuracy >= 0.95f && isFullCombo -> "S"
+            accuracy >= 0.9f -> "A"
+            accuracy >= 0.78f -> "B"
+            accuracy >= 0.6f -> "C"
+            else -> "D"
+        }
+
+    /** Score first, accuracy as the tiebreak. */
+    fun beats(other: TileRunResult?): Boolean {
+        if (other == null) return true
+        if (score != other.score) return score > other.score
+        return accuracy > other.accuracy
+    }
+}
+
+/**
+ * Best run per track and difficulty.
+ *
+ * Device-wide rather than per profile, alongside stats and downloads: a score
+ * belongs to the person holding the phone, not to whichever YouTube account is
+ * signed in at the time.
+ *
+ * One preference entry per track so a write touches one key instead of
+ * rewriting every score ever set, which matters because this is written on
+ * every track change.
+ */
+class TileScoreStore(context: Context) {
+
+    private val prefs = context.applicationContext
+        .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    private fun keyOf(songId: String, difficulty: TileDifficulty) = "$songId|${difficulty.key}"
+
+    suspend fun best(songId: String, difficulty: TileDifficulty): TileRunResult? =
+        withContext(Dispatchers.IO) {
+            val raw = prefs.getString(keyOf(songId, difficulty), null) ?: return@withContext null
+            runCatching { json.decodeFromString<TileRunResult>(raw) }.getOrNull()
+        }
+
+    /**
+     * Record [result] when it beats what is stored.
+     *
+     * @return the run's own result when it became the new best, null otherwise,
+     *   so the caller can say so without a second read.
+     */
+    suspend fun submit(result: TileRunResult): TileRunResult? = withContext(Dispatchers.IO) {
+        if (result.judged <= 0) return@withContext null
+        val difficulty = TileDifficulty.from(result.difficulty)
+        val key = keyOf(result.songId, difficulty)
+        val existing = prefs.getString(key, null)
+            ?.let { raw -> runCatching { json.decodeFromString<TileRunResult>(raw) }.getOrNull() }
+        if (!result.beats(existing)) return@withContext null
+
+        runCatching {
+            prune()
+            prefs.edit()
+                .putString(key, json.encodeToString(TileRunResult.serializer(), result))
+                .apply()
+        }.onFailure { Log.w(TAG, "Could not persist tile score", it) }
+        result
+    }
+
+    /**
+     * Drop the older half once the file grows past the cap.
+     *
+     * Scores are tiny, so this is a runaway guard rather than a policy - the
+     * same trade [AudioProfileStore] makes, and for the same reason: there is
+     * no access ordering to prune by, only the time each was set.
+     */
+    private fun prune() {
+        val all = prefs.all
+        if (all.size <= MAX_ENTRIES) return
+        val ordered = all.entries
+            .mapNotNull { entry ->
+                val raw = entry.value as? String ?: return@mapNotNull null
+                val stamp = runCatching {
+                    json.decodeFromString<TileRunResult>(raw).updatedAt
+                }.getOrDefault(0L)
+                entry.key to stamp
+            }
+            .sortedBy { it.second }
+        val editor = prefs.edit()
+        ordered.take(ordered.size / 2).forEach { editor.remove(it.first) }
+        editor.apply()
+    }
+
+    private companion object {
+        const val TAG = "TileScoreStore"
+        const val PREFS_NAME = "ivor_tile_scores"
+        const val MAX_ENTRIES = 800
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/ExpandablePlayer.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/ExpandablePlayer.kt
@@ -445,6 +445,17 @@ fun ExpandablePlayer(
                                     onArtistClick = onArtistClick
                                 )
                             }
+                            PlayerStyle.TILES -> {
+                                TilesPlayerSheetContent(
+                                    viewModel = viewModel,
+                                    ambientBackground = ambientBackground,
+                                    onCollapse = { onExpandChange(false) },
+                                    onLoadMore = {
+                                        viewModel.loadMoreRecommendations()
+                                    },
+                                    onArtistClick = onArtistClick
+                                )
+                            }
                         }
                         }
                         }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerStyleCatalog.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerStyleCatalog.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Animation
 import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material.icons.rounded.GraphicEq
 import androidx.compose.material.icons.rounded.GridView
 import androidx.compose.material.icons.rounded.Interests
 import androidx.compose.material.icons.rounded.Newspaper
@@ -110,6 +111,10 @@ internal val playerStyleCatalog: List<PlayerStyleInfo> = listOf(
     PlayerStyleInfo(
         PlayerStyle.DIAL, "Dial", "Rotary ring, spin to scrub",
         Icons.Rounded.RadioButtonChecked, MaterialShapes.Sunny
+    ),
+    PlayerStyleInfo(
+        PlayerStyle.TILES, "Tiles", "Play the beat on four lanes",
+        Icons.Rounded.GraphicEq, MaterialShapes.Cookie9Sided
     )
 )
 
@@ -463,6 +468,45 @@ private fun PlayerStylePreview(style: PlayerStyle, modifier: Modifier = Modifier
                     color = art,
                     modifier = Modifier.fillMaxSize(0.9f)
                 )
+            }
+
+            // Four lanes with tiles mid-fall and the line they are aimed at.
+            PlayerStyle.TILES -> Row(
+                modifier = Modifier.fillMaxSize(),
+                horizontalArrangement = Arrangement.spacedBy(3.dp)
+            ) {
+                // Staggered so the preview reads as falling rather than as a
+                // static grid; the third lane carries the long hold.
+                val drops = listOf(0.10f, 0.45f, 0.24f, 0.62f)
+                val lengths = listOf(0.18f, 0.18f, 0.34f, 0.18f)
+                drops.forEachIndexed { index, drop ->
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxHeight()
+                            .clip(RoundedCornerShape(3.dp))
+                            .background(soft.copy(alpha = 0.22f))
+                    ) {
+                        Column(modifier = Modifier.fillMaxSize()) {
+                            Spacer(modifier = Modifier.weight(drop))
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .weight(lengths[index])
+                                    .clip(RoundedCornerShape(3.dp))
+                                    .background(art)
+                            )
+                            Spacer(modifier = Modifier.weight(1f - drop - lengths[index]))
+                        }
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter)
+                                .fillMaxWidth()
+                                .height(2.dp)
+                                .background(line)
+                        )
+                    }
+                }
             }
 
             // Scrub ring with its handle.

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
@@ -1039,6 +1039,18 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
         _progress.value = position
     }
 
+    /**
+     * Playback position right now, for callers that cannot wait for [progress].
+     *
+     * [progress] ticks once a second, which is right for a seek bar and useless
+     * for anything drawn against the beat. `MediaController` extrapolates
+     * locally between the session's own updates, so reading it per frame is
+     * both cheap and smooth. Falls back to the last tick before the controller
+     * connects.
+     */
+    fun playbackPositionMs(): Long =
+        controller?.currentPosition?.coerceAtLeast(0L) ?: _progress.value
+
     // --- Sleep timer ---
     //
     // Owned by MusicService, not by this ViewModel. The timer used to be a

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/TilesGame.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/TilesGame.kt
@@ -1,0 +1,309 @@
+package com.ivor.ivormusic.ui.player
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.ivor.ivormusic.data.TILE_LANES
+import com.ivor.ivormusic.data.TileChart
+import com.ivor.ivormusic.data.TileKind
+import com.ivor.ivormusic.data.TileRunResult
+import kotlin.math.abs
+import kotlin.math.min
+
+/** How close a tap has to be, and what it is worth. */
+enum class TileJudgment(val label: String, val windowMs: Long, val points: Int) {
+    PERFECT("Perfect", 55L, 100),
+    GREAT("Great", 100L, 60),
+    GOOD("Good", 155L, 25),
+    MISS("Miss", Long.MAX_VALUE, 0)
+}
+
+/** Per-tile progress through a run. */
+internal object TileStatus {
+    const val PENDING: Byte = 0
+    const val HELD: Byte = 1
+    const val CLEARED: Byte = 2
+    const val MISSED: Byte = 3
+
+    /** Passed over by a seek: not played, so never counted for or against. */
+    const val SKIPPED: Byte = 4
+}
+
+/**
+ * A run of one chart: what has been hit, what it scored, and what the board
+ * should draw.
+ *
+ * **Playback is never a consequence.** Missing costs score and breaks the
+ * streak, and that is all it does - this is a player style before it is a
+ * game, and a music app that stops your music because your thumb was late is a
+ * worse music app. Every rule below follows from that: nothing here calls the
+ * player, and the clock is playback's, never the game's.
+ */
+@Stable
+class TilesGameState(val chart: TileChart) {
+
+    private val status = ByteArray(chart.tiles.size)
+
+    /** Tile index each lane is currently holding, or -1. */
+    private val heldInLane = IntArray(TILE_LANES) { -1 }
+
+    /** Frame time of the last hit in each lane, for the board's flash. */
+    private val laneFlashAtMs = LongArray(TILE_LANES) { Long.MIN_VALUE }
+
+    /**
+     * First tile whose window has not yet closed. Judging scans forward from
+     * here rather than over the whole chart, so a five-minute track costs the
+     * same per frame as a thirty-second one.
+     */
+    private var scanStart = 0
+
+    private var lastSongTimeMs = Long.MIN_VALUE
+
+    /**
+     * Whether this run has already been written to the score store.
+     *
+     * A run ends either by the track changing or by the chart simply running
+     * out, and both can happen to the same run - the flag is what keeps the
+     * second from re-reporting a result the first already banked.
+     */
+    internal var submitted: Boolean = false
+
+    var score by mutableIntStateOf(0)
+        private set
+    var combo by mutableIntStateOf(0)
+        private set
+    var maxCombo by mutableIntStateOf(0)
+        private set
+    var perfect by mutableIntStateOf(0)
+        private set
+    var great by mutableIntStateOf(0)
+        private set
+    var good by mutableIntStateOf(0)
+        private set
+    var missed by mutableIntStateOf(0)
+        private set
+
+    /** The last judgment, and a serial so a repeat of the same word re-animates. */
+    var lastJudgment by mutableStateOf<TileJudgment?>(null)
+        private set
+    var judgmentSerial by mutableIntStateOf(0)
+        private set
+
+    val judged: Int get() = perfect + great + good + missed
+
+    /** x1 to x4. Rewards a streak without letting one run away with the score. */
+    val multiplier: Int get() = 1 + min(combo / 12, 3)
+
+    internal fun statusOf(index: Int): Byte = status.getOrElse(index) { TileStatus.SKIPPED }
+
+    internal fun laneFlashAt(lane: Int): Long = laneFlashAtMs[lane]
+
+    /**
+     * Resolve everything the clock has carried past.
+     *
+     * A jump - a seek, a track loop, the queue moving on - resyncs instead of
+     * scoring: tiles nobody was shown must not be counted as misses, and the
+     * streak does not survive skipping part of the song either.
+     */
+    fun advance(songTimeMs: Long, scoringEnabled: Boolean) {
+        val previous = lastSongTimeMs
+        lastSongTimeMs = songTimeMs
+        if (previous == Long.MIN_VALUE) {
+            resync(songTimeMs)
+            return
+        }
+        val delta = songTimeMs - previous
+        if (delta < -JUMP_TOLERANCE_MS || delta > JUMP_TOLERANCE_MS) {
+            resync(songTimeMs)
+            return
+        }
+        if (!scoringEnabled) return
+
+        // Holds clear themselves once their tail is past the line: staying down
+        // longer than asked is not a mistake, and forcing an exact release
+        // would punish the player for the animation's own timing.
+        for (lane in 0 until TILE_LANES) {
+            val index = heldInLane[lane]
+            if (index >= 0 && songTimeMs >= chart.tiles[index].endMs) {
+                heldInLane[lane] = -1
+                status[index] = TileStatus.CLEARED
+                award(TileJudgment.PERFECT, chart.tiles[index].holdLengthMs)
+                laneFlashAtMs[lane] = songTimeMs
+            }
+        }
+
+        while (scanStart < chart.tiles.size) {
+            val tile = chart.tiles[scanStart]
+            if (tile.startMs + TileJudgment.GOOD.windowMs >= songTimeMs) break
+            if (status[scanStart] == TileStatus.PENDING) {
+                status[scanStart] = TileStatus.MISSED
+                registerMiss()
+            }
+            scanStart++
+        }
+    }
+
+    /**
+     * Move the cursor to [songTimeMs] without judging anything in between.
+     *
+     * The streak still breaks. Skipping the hard part is not a way to keep a
+     * combo, and a run assembled out of the easy halves of a song is not the
+     * same run as one played through.
+     *
+     * Seeking *backwards* moves the cursor back but leaves tiles already
+     * resolved as they are, so a chorus cannot be replayed for a second helping
+     * of score - the same reason the streak breaks. A missed tile stays a ghost
+     * on the way past either way.
+     */
+    fun resync(songTimeMs: Long) {
+        for (lane in 0 until TILE_LANES) heldInLane[lane] = -1
+        val target = chart.indexAtOrAfter(songTimeMs - TileJudgment.GOOD.windowMs)
+        for (index in scanStart until target) {
+            if (status[index] == TileStatus.PENDING) status[index] = TileStatus.SKIPPED
+        }
+        scanStart = target
+        if (combo != 0) combo = 0
+        lastSongTimeMs = songTimeMs
+    }
+
+    /**
+     * Judge a press in [lane].
+     *
+     * The nearest unresolved tile in the window wins, which is what makes a
+     * fast pair in one lane playable: the first press takes the first tile even
+     * when the second is already on screen.
+     *
+     * A press with nothing in range is ignored rather than penalised. Mashing
+     * cannot score - there is no tile to score against - and a player style
+     * that punishes an exploratory tap teaches people not to touch it.
+     */
+    fun press(lane: Int, songTimeMs: Long): TileJudgment? {
+        if (heldInLane[lane] >= 0) return null
+        var bestIndex = -1
+        var bestDelta = Long.MAX_VALUE
+        var index = scanStart
+        while (index < chart.tiles.size) {
+            val tile = chart.tiles[index]
+            if (tile.startMs - songTimeMs > TileJudgment.GOOD.windowMs) break
+            if (tile.lane == lane && status[index] == TileStatus.PENDING) {
+                val delta = abs(tile.startMs - songTimeMs)
+                if (delta <= TileJudgment.GOOD.windowMs && delta < bestDelta) {
+                    bestDelta = delta
+                    bestIndex = index
+                }
+            }
+            index++
+        }
+        if (bestIndex < 0) return null
+
+        val tile = chart.tiles[bestIndex]
+        val judgment = when {
+            bestDelta <= TileJudgment.PERFECT.windowMs -> TileJudgment.PERFECT
+            bestDelta <= TileJudgment.GREAT.windowMs -> TileJudgment.GREAT
+            else -> TileJudgment.GOOD
+        }
+        laneFlashAtMs[lane] = songTimeMs
+        if (tile.kind == TileKind.HOLD) {
+            status[bestIndex] = TileStatus.HELD
+            heldInLane[lane] = bestIndex
+        } else {
+            status[bestIndex] = TileStatus.CLEARED
+        }
+        award(judgment, accent = tile.kind == TileKind.ACCENT)
+        return judgment
+    }
+
+    /**
+     * Lift in [lane].
+     *
+     * Letting go early is a broken hold: the head was hit, so it does not count
+     * as a miss against accuracy, but the streak goes, because the tile was not
+     * played.
+     */
+    fun release(lane: Int, songTimeMs: Long): Boolean {
+        val index = heldInLane[lane]
+        if (index < 0) return false
+        heldInLane[lane] = -1
+        val tile = chart.tiles[index]
+        return if (songTimeMs >= tile.endMs - HOLD_RELEASE_GRACE_MS) {
+            status[index] = TileStatus.CLEARED
+            award(TileJudgment.PERFECT, tile.holdLengthMs)
+            laneFlashAtMs[lane] = songTimeMs
+            true
+        } else {
+            status[index] = TileStatus.CLEARED
+            good++
+            combo = 0
+            lastJudgment = TileJudgment.GOOD
+            judgmentSerial++
+            false
+        }
+    }
+
+    /**
+     * Let go of every hold without judging it, for a pause or for the player
+     * being put away mid-tile.
+     *
+     * Deliberately not [release]: the clock stopped, so the tail is never going
+     * to reach the line, and charging someone their streak for pausing their
+     * own music would be the game overruling the player it lives inside.
+     */
+    fun abandonHolds() {
+        for (lane in 0 until TILE_LANES) {
+            val index = heldInLane[lane]
+            if (index < 0) continue
+            heldInLane[lane] = -1
+            status[index] = TileStatus.SKIPPED
+        }
+    }
+
+    private fun award(judgment: TileJudgment, holdMs: Long = 0L, accent: Boolean = false) {
+        val base = judgment.points * (if (accent) 2 else 1)
+        val holdBonus = if (holdMs > 0L) (holdMs / 20L).toInt().coerceAtMost(120) else 0
+        score += (base + holdBonus) * multiplier
+        combo++
+        if (combo > maxCombo) maxCombo = combo
+        when (judgment) {
+            TileJudgment.PERFECT -> perfect++
+            TileJudgment.GREAT -> great++
+            TileJudgment.GOOD -> good++
+            TileJudgment.MISS -> Unit
+        }
+        lastJudgment = judgment
+        judgmentSerial++
+    }
+
+    private fun registerMiss() {
+        missed++
+        combo = 0
+        lastJudgment = TileJudgment.MISS
+        judgmentSerial++
+    }
+
+    fun result(): TileRunResult = TileRunResult(
+        songId = chart.songId,
+        difficulty = chart.difficulty.key,
+        score = score,
+        maxCombo = maxCombo,
+        perfect = perfect,
+        great = great,
+        good = good,
+        missed = missed,
+        judged = judged,
+        updatedAt = System.currentTimeMillis()
+    )
+
+    private companion object {
+        /**
+         * Beyond this, the clock moved for a reason other than time passing.
+         * Wide enough to absorb a stall or a slow frame, tight enough that a
+         * real seek is never mistaken for one.
+         */
+        const val JUMP_TOLERANCE_MS = 700L
+
+        /** Letting go this close to the tail still counts as holding it out. */
+        const val HOLD_RELEASE_GRACE_MS = 130L
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/TilesPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/TilesPlayerContent.kt
@@ -1,0 +1,1702 @@
+package com.ivor.ivormusic.ui.player
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material.icons.rounded.Tune
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialShapes
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.LongState
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.changedToDownIgnoreConsumed
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChanged
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.ivor.ivormusic.data.AudioProfile
+import com.ivor.ivormusic.data.AudioProfileStore
+import com.ivor.ivormusic.data.Song
+import com.ivor.ivormusic.data.TILE_LANES
+import com.ivor.ivormusic.data.ThemePreferences
+import com.ivor.ivormusic.data.Tile
+import com.ivor.ivormusic.data.TileChart
+import com.ivor.ivormusic.data.TileChartFactory
+import com.ivor.ivormusic.data.TileDifficulty
+import com.ivor.ivormusic.data.TileKind
+import com.ivor.ivormusic.data.TileRunResult
+import com.ivor.ivormusic.data.TileScoreStore
+import com.ivor.ivormusic.ui.components.SongArtwork
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withFrameNanos
+
+/**
+ * Tiles - the rhythm board.
+ *
+ * Four lanes, tiles falling on the track's own beat, tapped as they cross the
+ * line. It exists because the app already measures every track it plays for
+ * AutoMix - tempo, the first downbeat, the key, where the audio starts and how
+ * it ends - and that measurement is exactly a beat map nobody was reading. See
+ * [TileChartFactory]: no new analysis, no request, no decode.
+ *
+ * **Two rules hold the whole design together.**
+ *
+ * The first: *playback is never a consequence.* Missing a tile costs score and
+ * breaks the streak and does nothing else. Magic Tiles stops the music on a
+ * miss, which is right for a game and wrong for the player you keep your music
+ * in - nobody wants their album to stop because they fumbled while walking. So
+ * the transport, the queue, seeking and the artist link all still work, and the
+ * board is a layer over playback rather than a thing that owns it.
+ *
+ * The second: *never fake the beat.* A chart that does not match what is
+ * playing is worse than no chart, because it reads as the app being broken
+ * rather than as a track it has not measured yet. A track with no confident
+ * tempo says so and offers Freestyle - an assumed 4/4 grid the user turns on
+ * knowingly - rather than quietly guessing.
+ *
+ * The dress is the Editorial one, two flat tones and a serif: the board is set
+ * like a page, the accent tiles carry their bar numbers the way a score carries
+ * measure numbers, and the analysis prints in the credit line under the title.
+ * The one color outside the two-tone contract is `error`, used only for a miss.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun TilesPlayerSheetContent(
+    viewModel: PlayerViewModel,
+    @Suppress("UNUSED_PARAMETER") ambientBackground: Boolean = true,
+    onCollapse: () -> Unit,
+    onLoadMore: () -> Unit = {},
+    onArtistClick: (String) -> Unit = {}
+) {
+    // ambientBackground is ignored on purpose, as it is in Editorial: this is a
+    // flat two-tone surface and a drifting shader behind a board you are aiming
+    // at is noise the player has to look past.
+
+    val context = LocalContext.current
+    val currentSong by viewModel.currentSong.collectAsState()
+    val isPlaying by viewModel.isPlaying.collectAsState()
+    val isBuffering by viewModel.isBuffering.collectAsState()
+    val playWhenReady by viewModel.playWhenReady.collectAsState()
+    val progress by viewModel.progress.collectAsState()
+    val duration by viewModel.duration.collectAsState()
+    val currentQueue by viewModel.currentQueue.collectAsState()
+    val isLoadingMore by viewModel.isLoadingMore.collectAsState()
+
+    val field = MaterialTheme.colorScheme.primaryContainer
+    val accent = MaterialTheme.colorScheme.onPrimaryContainer
+
+    var showQueue by remember { mutableStateOf(false) }
+    var showTuning by remember { mutableStateOf(false) }
+
+    // Both are this player's own, set here and read here, so they follow the
+    // download sheet's pattern rather than the Settings screen's five files.
+    var difficulty by remember {
+        mutableStateOf(TileDifficulty.from(ThemePreferences.currentTilesDifficulty(context)))
+    }
+    var syncOffsetMs by remember {
+        mutableIntStateOf(ThemePreferences.currentTilesSyncOffsetMs(context))
+    }
+
+    val profileStore = remember(context) { AudioProfileStore(context) }
+    val scoreStore = remember(context) { TileScoreStore(context) }
+
+    val songId = currentSong?.id
+    // Which track the user has accepted a guessed grid for. Cleared by the song
+    // changing, because consenting to freestyle on one track is not consenting
+    // to it forever.
+    var freestyleFor by remember { mutableStateOf<String?>(null) }
+    var chartState by remember { mutableStateOf<TilesChartState>(TilesChartState.Loading) }
+
+    LaunchedEffect(songId, duration, difficulty, freestyleFor) {
+        val id = songId
+        if (id == null || duration <= 0L) {
+            chartState = TilesChartState.Loading
+            return@LaunchedEffect
+        }
+        val wantsFreestyle = freestyleFor == id
+        var profile = profileStore.get(id)
+
+        // The service profiles a track shortly after it starts playing, and
+        // this store is a different instance that loaded before that write
+        // landed - hence the reload rather than a second look at the same
+        // in-memory map. Bounded: a track that is never going to be profiled
+        // (metered network, uncached, unreadable audio) must reach an answer
+        // rather than spin.
+        var attempt = 0
+        while (!wantsFreestyle && !profile.hasTempo() && attempt < ANALYSIS_ATTEMPTS) {
+            chartState = TilesChartState.Analysing
+            delay(ANALYSIS_RETRY_MS)
+            profileStore.reload()
+            profile = profileStore.get(id)
+            attempt++
+        }
+
+        val chart = TileChartFactory.build(
+            songId = id,
+            durationMs = duration,
+            profile = profile,
+            difficulty = difficulty,
+            freestyle = wantsFreestyle
+        )
+        chartState = if (chart == null) TilesChartState.NoTempo else TilesChartState.Ready(chart)
+    }
+
+    LaunchedEffect(songId) { freestyleFor = null }
+
+    val chart = (chartState as? TilesChartState.Ready)?.chart
+    val game = remember(chart) { chart?.let(TilesRunCache::forChart) }
+
+    var best by remember { mutableStateOf<TileRunResult?>(null) }
+    var resultCard by remember { mutableStateOf<TilesResultCard?>(null) }
+    var previousGame by remember { mutableStateOf<TilesGameState?>(null) }
+
+    suspend fun submitRun(run: TilesGameState) {
+        if (run.submitted) return
+        val result = run.result()
+        if (result.judged <= 0) return
+        run.submitted = true
+        resultCard = TilesResultCard(result, scoreStore.submit(result) != null)
+    }
+
+    // A run is banked when the track changes and again when the chart simply
+    // runs out, because those are two different endings: the second happens
+    // while the player may be collapsed, and a score you earned by playing a
+    // song to its end should not depend on the screen still being on it.
+    LaunchedEffect(game) {
+        previousGame?.takeIf { it !== game }?.let { submitRun(it) }
+        previousGame = game
+        best = game?.let { scoreStore.best(it.chart.songId, it.chart.difficulty) }
+    }
+
+    LaunchedEffect(resultCard) {
+        if (resultCard != null) {
+            delay(RESULT_CARD_MS)
+            resultCard = null
+        }
+    }
+
+    // Held as state and read only inside the board's draw lambda. Passing the
+    // clock down as a plain value would recompose the whole board - constraints,
+    // Canvas, overlays - sixty times a second; a snapshot read taken in the draw
+    // phase invalidates the drawing alone, which is all that actually changes.
+    val songTime = remember { mutableLongStateOf(0L) }
+
+    // The board's clock. `progress` ticks once a second, which is a seek bar's
+    // resolution, not a beat's; MediaController extrapolates locally, so a
+    // per-frame read is both cheap and smooth.
+    LaunchedEffect(game, isPlaying, syncOffsetMs) {
+        val run = game ?: return@LaunchedEffect
+        if (!isPlaying) return@LaunchedEffect
+        val lastTileEnd = run.chart.tiles.lastOrNull()?.endMs ?: 0L
+        while (isActive) {
+            withFrameNanos { }
+            val now = viewModel.playbackPositionMs() - syncOffsetMs
+            songTime.longValue = now
+            run.advance(now, scoringEnabled = true)
+            if (!run.submitted && now > lastTileEnd + RUN_END_GRACE_MS) submitRun(run)
+        }
+    }
+
+    // Paused, the frame loop is not running, so the board follows `progress`
+    // instead - which is what moves when someone scrubs a paused track.
+    LaunchedEffect(game, isPlaying, progress, syncOffsetMs) {
+        if (isPlaying) return@LaunchedEffect
+        val run = game ?: return@LaunchedEffect
+        run.abandonHolds()
+        val now = progress - syncOffsetMs
+        songTime.longValue = now
+        run.advance(now, scoringEnabled = false)
+    }
+
+    // Putting the player away mid-tile is not a dropped hold.
+    DisposableEffect(game) {
+        onDispose { game?.abandonHolds() }
+    }
+
+    Box(modifier = Modifier
+        .fillMaxSize()
+        .background(field)) {
+        Crossfade(targetState = showQueue, label = "TilesQueueTransition") { queueVisible ->
+            if (queueVisible) {
+                EditorialQueueView(
+                    queue = currentQueue,
+                    currentSong = currentSong,
+                    onSongClick = { song -> viewModel.skipToSong(song) },
+                    onRemoveSong = { index -> viewModel.removeQueueItem(index) },
+                    onMoveSong = { from, to -> viewModel.moveQueueItem(from, to, persist = false) },
+                    onCommitOrder = { viewModel.commitQueueOrder() },
+                    onUndoRemove = { viewModel.undoQueueRemoval() },
+                    onLoadMore = onLoadMore,
+                    isLoadingMore = isLoadingMore,
+                    onCollapse = onCollapse,
+                    onBackToPlayer = { showQueue = false },
+                    field = field,
+                    accent = accent
+                )
+            } else {
+                TilesNowPlaying(
+                    viewModel = viewModel,
+                    currentSong = currentSong,
+                    isPlaying = isPlaying,
+                    isBuffering = isBuffering,
+                    playWhenReady = playWhenReady,
+                    position = progress,
+                    duration = duration,
+                    songTime = songTime,
+                    chartState = chartState,
+                    game = game,
+                    best = best,
+                    resultCard = resultCard,
+                    difficulty = difficulty,
+                    syncOffsetMs = syncOffsetMs,
+                    onDismissResult = { resultCard = null },
+                    onStartFreestyle = { freestyleFor = songId },
+                    onCollapse = onCollapse,
+                    onShowQueue = { showQueue = true },
+                    onShowTuning = { showTuning = true },
+                    onArtistClick = onArtistClick,
+                    field = field,
+                    accent = accent
+                )
+            }
+        }
+    }
+
+    if (showTuning) {
+        TilesTuningSheet(
+            difficulty = difficulty,
+            syncOffsetMs = syncOffsetMs,
+            onDifficultyChange = {
+                difficulty = it
+                ThemePreferences.setTilesDifficulty(context, it.key)
+            },
+            onSyncOffsetChange = {
+                syncOffsetMs = it
+                ThemePreferences.setTilesSyncOffsetMs(context, it)
+            },
+            onDismissRequest = { showTuning = false },
+            field = field,
+            accent = accent
+        )
+    }
+}
+
+private fun AudioProfile?.hasTempo(): Boolean = this?.bpm != null
+
+/**
+ * The run in progress, kept across the player being collapsed.
+ *
+ * The expanded player is removed from composition when it collapses, so
+ * everything held in `remember` goes with it. A score that resets because
+ * somebody dropped to the mini player to check the queue is a score nobody can
+ * be bothered to chase, so one run survives - keyed by the chart it belongs to,
+ * which is what makes changing track or difficulty start a genuinely new one.
+ */
+internal object TilesRunCache {
+    private var key: String? = null
+    private var run: TilesGameState? = null
+
+    fun forChart(chart: TileChart): TilesGameState {
+        val signature = "${chart.songId}|${chart.difficulty.key}|" +
+            "${chart.isFreestyle}|${chart.tiles.size}"
+        val existing = run
+        if (signature == key && existing != null) return existing
+        val fresh = TilesGameState(chart)
+        key = signature
+        run = fresh
+        return fresh
+    }
+}
+
+private sealed interface TilesChartState {
+    /** No track, or its duration is not known yet. */
+    data object Loading : TilesChartState
+
+    /** Waiting on the profile the service writes shortly after playback starts. */
+    data object Analysing : TilesChartState
+
+    /** Measured, and there is no tempo in it worth charting. */
+    data object NoTempo : TilesChartState
+
+    data class Ready(val chart: TileChart) : TilesChartState
+}
+
+private data class TilesResultCard(val result: TileRunResult, val isBest: Boolean)
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun TilesNowPlaying(
+    viewModel: PlayerViewModel,
+    currentSong: Song?,
+    isPlaying: Boolean,
+    isBuffering: Boolean,
+    playWhenReady: Boolean,
+    position: Long,
+    duration: Long,
+    songTime: LongState,
+    chartState: TilesChartState,
+    game: TilesGameState?,
+    best: TileRunResult?,
+    resultCard: TilesResultCard?,
+    difficulty: TileDifficulty,
+    syncOffsetMs: Int,
+    onDismissResult: () -> Unit,
+    onStartFreestyle: () -> Unit,
+    onCollapse: () -> Unit,
+    onShowQueue: () -> Unit,
+    onShowTuning: () -> Unit,
+    onArtistClick: (String) -> Unit,
+    field: Color,
+    accent: Color
+) {
+    val haptics = LocalHapticFeedback.current
+    val playerHaptics = rememberPlayerHaptics()
+
+    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+    // Landscape, and small phones, have no room for the page furniture. The
+    // board is the point of the style, so the credit line goes first and the
+    // masthead loses its artwork rather than the board losing its height.
+    val compact = maxHeight < COMPACT_HEIGHT
+
+    Column(modifier = Modifier.fillMaxSize()) {
+
+        // ========== TOP BAR ==========
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .statusBarsPadding()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            EditorialCircleButton(onClick = onCollapse, accent = accent, field = field, size = 42.dp) {
+                Icon(Icons.Default.KeyboardArrowDown, "Collapse", modifier = Modifier.size(24.dp))
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                EditorialCircleButton(
+                    onClick = onShowTuning,
+                    accent = accent,
+                    field = field,
+                    size = 42.dp
+                ) {
+                    Icon(Icons.Rounded.Tune, "Tiles tuning", modifier = Modifier.size(20.dp))
+                }
+                EditorialCircleButton(
+                    onClick = onShowQueue,
+                    accent = accent,
+                    field = field,
+                    size = 42.dp
+                ) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.QueueMusic,
+                        "Queue",
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+            }
+        }
+
+        // ========== MASTHEAD ==========
+        TilesMasthead(
+            currentSong = currentSong,
+            game = game,
+            best = best,
+            showArtwork = !compact,
+            onNext = { playerHaptics.skip(); viewModel.skipToNext() },
+            onPrevious = { playerHaptics.skip(); viewModel.skipToPrevious() },
+            onArtistClick = onArtistClick,
+            field = field,
+            accent = accent
+        )
+
+        // ========== CREDIT LINE ==========
+        // The measurement is why this player can exist, so it is printed rather
+        // than hidden: tempo, key, and the chart being played against.
+        if (!compact) {
+            TilesCreditLine(
+                chartState = chartState,
+                difficulty = difficulty,
+                syncOffsetMs = syncOffsetMs,
+                onShowTuning = onShowTuning,
+                accent = accent
+            )
+        } else {
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        // ========== BOARD ==========
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .padding(horizontal = 12.dp, vertical = 8.dp)
+        ) {
+            Crossfade(
+                targetState = chartState is TilesChartState.Ready,
+                label = "TilesBoardState"
+            ) { ready ->
+                if (ready && game != null) {
+                    TilesBoard(
+                        game = game,
+                        songTime = songTime,
+                        isPlaying = isPlaying,
+                        nowMs = { viewModel.playbackPositionMs() - syncOffsetMs },
+                        onHit = {
+                            haptics.performHapticFeedback(HapticFeedbackType.SegmentFrequentTick)
+                        },
+                        onResume = {
+                            playerHaptics.playPause(true)
+                            viewModel.togglePlayPause()
+                        },
+                        field = field,
+                        accent = accent
+                    )
+                } else {
+                    TilesBoardPlaceholder(
+                        chartState = chartState,
+                        onStartFreestyle = onStartFreestyle,
+                        accent = accent,
+                        field = field
+                    )
+                }
+            }
+
+            androidx.compose.animation.AnimatedVisibility(
+                visible = resultCard != null,
+                enter = fadeIn() + slideInVertically { -it / 2 },
+                exit = fadeOut(),
+                modifier = Modifier.align(Alignment.TopCenter)
+            ) {
+                resultCard?.let {
+                    TilesResultStrip(
+                        card = it,
+                        onDismiss = onDismissResult,
+                        field = field,
+                        accent = accent
+                    )
+                }
+            }
+        }
+
+        // ========== TRANSPORT ==========
+        TilesTransport(
+            isPlaying = isPlaying,
+            isBuffering = isBuffering,
+            playWhenReady = playWhenReady,
+            position = position,
+            duration = duration,
+            onPlayPause = {
+                playerHaptics.playPause(!isPlaying)
+                viewModel.togglePlayPause()
+            },
+            onNext = { playerHaptics.skip(); viewModel.skipToNext() },
+            onPrevious = { playerHaptics.skip(); viewModel.skipToPrevious() },
+            onSeekTo = { viewModel.seekTo(it) },
+            field = field,
+            accent = accent
+        )
+    }
+    }
+}
+
+/**
+ * Title, artist and the running score on one line.
+ *
+ * The score sits beside the headline rather than over the board, because
+ * anything drawn on the board is something to look past while aiming.
+ */
+@Composable
+private fun TilesMasthead(
+    currentSong: Song?,
+    game: TilesGameState?,
+    best: TileRunResult?,
+    showArtwork: Boolean,
+    onNext: () -> Unit,
+    onPrevious: () -> Unit,
+    onArtistClick: (String) -> Unit,
+    field: Color,
+    accent: Color
+) {
+    val swipeToSkip = rememberSwipeToSkip(onNext = onNext, onPrevious = onPrevious)
+    val styleWheel = LocalPlayerStyleWheelController.current
+    val title = currentSong?.title?.takeIf { !it.startsWith("Unknown") } ?: "Nothing playing"
+    val artist = currentSong?.artist?.takeIf { !it.startsWith("Unknown") } ?: "Unknown Artist"
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp)
+            // The swipe lives here and never on the board: a horizontal drag
+            // during a hold must not skip the track out from under the run.
+            .swipeToSkip(swipeToSkip),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(14.dp)
+    ) {
+        // The board owns tap and long press, so the artwork is what hosts the
+        // style wheel's hold gesture in this style.
+        currentSong?.takeIf { showArtwork }?.let { song ->
+            SongArtwork(
+                song = song,
+                contentDescription = null,
+                modifier = Modifier
+                    .size(52.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(accent.copy(alpha = 0.12f))
+                    .styleWheelHold(styleWheel)
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .swipeToSkipFollow(swipeToSkip)
+                // With the artwork gone there would be nothing left in this
+                // style hosting the style wheel, and the board cannot host it -
+                // a long press there is a held tile.
+                .then(if (showArtwork) Modifier else Modifier.styleWheelHold(styleWheel))
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleLarge.copy(
+                    fontFamily = FontFamily.Serif,
+                    fontStyle = FontStyle.Italic,
+                    fontWeight = FontWeight.Bold
+                ),
+                color = accent,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = artist.uppercase(),
+                style = MaterialTheme.typography.labelSmall.copy(letterSpacing = 1.8.sp),
+                color = accent.copy(alpha = 0.75f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(6.dp))
+                    .clickable(enabled = artist != "Unknown Artist") { onArtistClick(artist) }
+                    .padding(vertical = 2.dp)
+            )
+        }
+
+        TilesScoreBlock(game = game, best = best, field = field, accent = accent)
+    }
+}
+
+@Composable
+private fun TilesScoreBlock(
+    game: TilesGameState?,
+    best: TileRunResult?,
+    field: Color,
+    accent: Color
+) {
+    Column(horizontalAlignment = Alignment.End) {
+        Text(
+            text = "SCORE",
+            style = MaterialTheme.typography.labelSmall.copy(
+                letterSpacing = 2.sp,
+                fontSize = 9.sp
+            ),
+            color = accent.copy(alpha = 0.6f)
+        )
+        AnimatedContent(
+            targetState = game?.score ?: 0,
+            label = "TilesScore"
+        ) { score ->
+            Text(
+                text = formatScore(score),
+                style = MaterialTheme.typography.titleLarge.copy(
+                    fontFamily = FontFamily.Serif,
+                    fontWeight = FontWeight.Bold
+                ),
+                color = accent
+            )
+        }
+        val combo = game?.combo ?: 0
+        val multiplier = game?.multiplier ?: 1
+        // A streak worth naming only once it is one; a permanent "x1" is noise.
+        AnimatedVisibility(visible = combo >= COMBO_VISIBLE_AT) {
+            Surface(
+                shape = RoundedCornerShape(50),
+                color = accent,
+                contentColor = field
+            ) {
+                Text(
+                    text = "$combo  ×$multiplier",
+                    style = MaterialTheme.typography.labelSmall.copy(
+                        fontFamily = FontFamily.Serif,
+                        fontStyle = FontStyle.Italic,
+                        fontWeight = FontWeight.Bold
+                    ),
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp)
+                )
+            }
+        }
+        if (combo < COMBO_VISIBLE_AT && best != null && best.score > 0) {
+            Text(
+                text = "BEST ${formatScore(best.score)}",
+                style = MaterialTheme.typography.labelSmall.copy(
+                    letterSpacing = 1.sp,
+                    fontSize = 9.sp
+                ),
+                color = accent.copy(alpha = 0.55f),
+                maxLines = 1
+            )
+        }
+    }
+}
+
+/** "128 BPM · F♯ MINOR · STANDARD", set as a magazine credit line. */
+@Composable
+private fun TilesCreditLine(
+    chartState: TilesChartState,
+    difficulty: TileDifficulty,
+    syncOffsetMs: Int,
+    onShowTuning: () -> Unit,
+    accent: Color
+) {
+    val chart = (chartState as? TilesChartState.Ready)?.chart
+    val parts = buildList {
+        when {
+            chart == null -> add("NO CHART")
+            chart.isFreestyle -> add("FREESTYLE 120 BPM")
+            else -> {
+                chart.bpm?.let { add("${it.toInt()} BPM") }
+                chart.keyLabel?.let { add(it) }
+            }
+        }
+        add(difficulty.label.uppercase())
+        if (syncOffsetMs != 0) add("${if (syncOffsetMs > 0) "+" else ""}$syncOffsetMs MS")
+    }
+
+    Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp)) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(accent.copy(alpha = 0.22f))
+        )
+        Spacer(modifier = Modifier.height(6.dp))
+        Text(
+            text = parts.joinToString("  ·  "),
+            style = MaterialTheme.typography.labelSmall.copy(
+                letterSpacing = 1.6.sp,
+                fontSize = 10.sp
+            ),
+            color = accent.copy(alpha = 0.7f),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier
+                .clip(RoundedCornerShape(6.dp))
+                .clickable(onClick = onShowTuning)
+                .padding(vertical = 2.dp)
+        )
+    }
+}
+
+/**
+ * The board itself: one Canvas for every tile, and one pointer loop for every
+ * finger.
+ *
+ * Drawn rather than composed. A tile per composable would mean a few dozen
+ * nodes entering and leaving every second at exactly the moment the screen has
+ * the least frame budget to spare, and the whole board is flat rectangles on
+ * one clock - which is what a Canvas is for. The clock is the only state the
+ * draw reads, so it repaints once per frame while playing and not at all while
+ * paused.
+ */
+@Composable
+private fun TilesBoard(
+    game: TilesGameState,
+    songTime: LongState,
+    isPlaying: Boolean,
+    nowMs: () -> Long,
+    onHit: () -> Unit,
+    onResume: () -> Unit,
+    field: Color,
+    accent: Color
+) {
+    val density = LocalDensity.current
+    val chart = game.chart
+    // The pointer loop outlives the composition that started it - it only
+    // restarts when one of its keys changes - so a lambda captured directly
+    // would go on reading the sync offset it was born with. Same trap
+    // `rememberSwipeToSkip` documents, same fix.
+    val currentNow by rememberUpdatedState(nowMs)
+    val currentOnHit by rememberUpdatedState(onHit)
+    val approachMs = remember(chart) {
+        if (chart.difficulty == TileDifficulty.RUSH) RUSH_APPROACH_MS else APPROACH_MS
+    }
+    val missColor = MaterialTheme.colorScheme.error
+    val textMeasurer = rememberTextMeasurer()
+    val barNumberStyle = remember {
+        TextStyle(
+            fontFamily = FontFamily.Serif,
+            fontWeight = FontWeight.Bold,
+            fontSize = 13.sp
+        )
+    }
+    // Measured once per bar number and kept: only a couple of accent tiles are
+    // ever on screen, but measuring inside the draw of every frame is exactly
+    // the kind of work that turns a smooth board into a stuttering one.
+    val barLabels = remember(textMeasurer, barNumberStyle) {
+        mutableMapOf<Int, TextLayoutResult>()
+    }
+
+    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        val boardHeightPx = with(density) { maxHeight.toPx() }
+        val boardWidthPx = with(density) { maxWidth.toPx() }
+        val laneWidthPx = boardWidthPx / TILE_LANES
+        val hitLineY = boardHeightPx * HIT_LINE_FRACTION
+        val cornerPx = with(density) { 9.dp.toPx() }
+        val insetPx = with(density) { 4.dp.toPx() }
+        val hitLineStroke = with(density) { 3.dp.toPx() }
+        val rulePx = with(density) { 1.dp.toPx() }
+        val outlinePx = with(density) { 2.dp.toPx() }
+        val holdHeadPx = with(density) { 26.dp.toPx() }
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .clip(RoundedCornerShape(20.dp))
+                .background(accent.copy(alpha = 0.05f))
+                .semantics {
+                    contentDescription =
+                        "Rhythm board, four lanes. Tap a lane as its tile crosses the line."
+                }
+                // Every change is consumed, which is also what stops a stray
+                // vertical drag on the board from collapsing the whole player
+                // mid-run: the sheet's own drag detector never sees an
+                // unconsumed pointer.
+                .pointerInput(game, isPlaying, laneWidthPx) {
+                    if (!isPlaying) return@pointerInput
+                    awaitPointerEventScope {
+                        val lanes = mutableMapOf<PointerId, Int>()
+                        while (true) {
+                            val event = awaitPointerEvent()
+                            event.changes.forEach { change ->
+                                when {
+                                    change.changedToDownIgnoreConsumed() -> {
+                                        val lane = (change.position.x / laneWidthPx)
+                                            .toInt()
+                                            .coerceIn(0, TILE_LANES - 1)
+                                        lanes[change.id] = lane
+                                        if (game.press(lane, currentNow()) != null) currentOnHit()
+                                        change.consume()
+                                    }
+
+                                    change.changedToUpIgnoreConsumed() -> {
+                                        lanes.remove(change.id)?.let { lane ->
+                                            game.release(lane, currentNow())
+                                        }
+                                        change.consume()
+                                    }
+
+                                    else -> if (change.positionChanged()) change.consume()
+                                }
+                            }
+                            // A pointer that vanishes without an up event -
+                            // cancelled by a parent claiming the gesture, or by
+                            // the window losing focus - would otherwise leave a
+                            // lane held down forever.
+                            val live = event.changes.map { it.id }.toSet()
+                            lanes.keys.filterNot { it in live }.forEach { id ->
+                                lanes.remove(id)?.let { game.release(it, currentNow()) }
+                            }
+                        }
+                    }
+                }
+        ) {
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                // The one snapshot read that drives the repaint.
+                val songTimeMs = songTime.longValue
+                val pxPerMs = hitLineY / approachMs
+                val trailMs = ((size.height - hitLineY) / pxPerMs).toLong()
+
+                for (lane in 1 until TILE_LANES) {
+                    val x = lane * laneWidthPx
+                    drawLine(
+                        color = accent.copy(alpha = 0.14f),
+                        start = Offset(x, 0f),
+                        end = Offset(x, size.height),
+                        strokeWidth = rulePx
+                    )
+                }
+
+                drawRect(
+                    color = accent.copy(alpha = 0.05f),
+                    topLeft = Offset(0f, hitLineY),
+                    size = Size(size.width, size.height - hitLineY)
+                )
+
+                for (lane in 0 until TILE_LANES) {
+                    val since = songTimeMs - game.laneFlashAt(lane)
+                    if (since < 0 || since > LANE_FLASH_MS) continue
+                    val alpha = (1f - since.toFloat() / LANE_FLASH_MS) * 0.3f
+                    drawRect(
+                        color = accent.copy(alpha = alpha),
+                        topLeft = Offset(lane * laneWidthPx, hitLineY - laneWidthPx * 0.2f),
+                        size = Size(laneWidthPx, size.height - hitLineY + laneWidthPx * 0.2f)
+                    )
+                }
+
+                // Back up far enough to catch a long hold that started before
+                // the visible window but is still crossing it.
+                var index = chart.indexAtOrAfter(songTimeMs - trailMs - MAX_TILE_LOOKBACK_MS)
+                while (index < chart.tiles.size) {
+                    val tile = chart.tiles[index]
+                    if (tile.startMs - songTimeMs > approachMs) break
+                    val status = game.statusOf(index)
+                    if (status != TileStatus.CLEARED && status != TileStatus.SKIPPED) {
+                        val bottom = hitLineY - (tile.startMs - songTimeMs) * pxPerMs
+                        val top = bottom - tile.drawLenMs * pxPerMs
+                        if (bottom > -cornerPx && top < size.height) {
+                            drawTile(
+                                tile = tile,
+                                status = status,
+                                left = tile.lane * laneWidthPx + insetPx,
+                                width = laneWidthPx - insetPx * 2,
+                                top = top,
+                                bottom = bottom,
+                                hitLineY = hitLineY,
+                                corner = cornerPx,
+                                holdHead = holdHeadPx,
+                                outline = outlinePx,
+                                accent = accent,
+                                field = field,
+                                missColor = missColor,
+                                barLabel = { bar ->
+                                    barLabels.getOrPut(bar) {
+                                        textMeasurer.measure(
+                                            AnnotatedString(bar.toString()),
+                                            barNumberStyle
+                                        )
+                                    }
+                                }
+                            )
+                        }
+                    }
+                    index++
+                }
+
+                drawLine(
+                    color = accent,
+                    start = Offset(0f, hitLineY),
+                    end = Offset(size.width, hitLineY),
+                    strokeWidth = hitLineStroke
+                )
+            }
+
+            TilesComboGhost(
+                game = game,
+                accent = accent,
+                modifier = Modifier.align(Alignment.Center)
+            )
+
+            TilesJudgmentWord(
+                game = game,
+                missColor = missColor,
+                accent = accent,
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    // Coerced because a short board (landscape, a small phone)
+                    // puts the line within 64dp of the top, and a negative
+                    // padding is a crash rather than a layout.
+                    .padding(top = (maxHeight * HIT_LINE_FRACTION - 64.dp).coerceAtLeast(0.dp))
+            )
+
+            if (!isPlaying) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(field.copy(alpha = 0.9f))
+                        .clickable(onClick = onResume),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = "Paused",
+                            style = MaterialTheme.typography.headlineMedium.copy(
+                                fontFamily = FontFamily.Serif,
+                                fontStyle = FontStyle.Italic,
+                                fontWeight = FontWeight.Bold
+                            ),
+                            color = accent
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = "TAP TO RESUME",
+                            style = MaterialTheme.typography.labelSmall.copy(letterSpacing = 2.sp),
+                            color = accent.copy(alpha = 0.7f)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * One tile.
+ *
+ * A tap is a solid block; a downbeat carries its bar number the way a score
+ * carries measure numbers; a hold is a light column with a solid head, and
+ * fills in as it is held. A missed tile is not removed - it falls on as an
+ * outline, so the player can see what got away rather than only that the streak
+ * broke.
+ */
+private fun DrawScope.drawTile(
+    tile: Tile,
+    status: Byte,
+    left: Float,
+    width: Float,
+    top: Float,
+    bottom: Float,
+    hitLineY: Float,
+    corner: Float,
+    holdHead: Float,
+    outline: Float,
+    accent: Color,
+    field: Color,
+    missColor: Color,
+    barLabel: (Int) -> TextLayoutResult
+) {
+    val radius = CornerRadius(corner, corner)
+    val missed = status == TileStatus.MISSED
+    val held = status == TileStatus.HELD
+    // Once a hold is being held, the part already past the line is spent: it is
+    // drawn as being swallowed by the line rather than sliding on underneath,
+    // which is the only feedback that says "keep holding".
+    val drawBottom = if (held) minOf(bottom, hitLineY) else bottom
+    val height = (drawBottom - top).coerceAtLeast(0f)
+    if (height <= 0f) return
+
+    if (missed) {
+        drawRoundRect(
+            color = missColor.copy(alpha = 0.35f),
+            topLeft = Offset(left, top),
+            size = Size(width, height),
+            cornerRadius = radius,
+            style = Stroke(width = outline)
+        )
+        return
+    }
+
+    when (tile.kind) {
+        TileKind.HOLD -> {
+            drawRoundRect(
+                color = accent.copy(alpha = if (held) 0.8f else 0.4f),
+                topLeft = Offset(left, top),
+                size = Size(width, height),
+                cornerRadius = radius
+            )
+            // The head is what is actually aimed at; without it a long column
+            // gives the eye nothing to time against.
+            if (!held) {
+                val headHeight = minOf(holdHead, height)
+                drawRoundRect(
+                    color = accent,
+                    topLeft = Offset(left, drawBottom - headHeight),
+                    size = Size(width, headHeight),
+                    cornerRadius = radius
+                )
+            }
+        }
+
+        TileKind.ACCENT -> {
+            drawRoundRect(
+                color = accent,
+                topLeft = Offset(left, top),
+                size = Size(width, height),
+                cornerRadius = radius
+            )
+            val label = barLabel(tile.bar)
+            if (height > label.size.height * 1.6f) {
+                drawText(
+                    textLayoutResult = label,
+                    color = field,
+                    topLeft = Offset(
+                        left + (width - label.size.width) / 2f,
+                        top + (height - label.size.height) / 2f
+                    )
+                )
+            }
+        }
+
+        TileKind.TAP -> {
+            drawRoundRect(
+                color = accent,
+                topLeft = Offset(left, top),
+                size = Size(width, height),
+                cornerRadius = radius
+            )
+        }
+    }
+}
+
+/**
+ * The streak, set large and faint behind the falling tiles.
+ *
+ * Its own composable because it reads `combo`, which changes on every single
+ * tile: read from the board directly, that one number would recompose the
+ * board's constraints, Canvas and overlays a few times a second.
+ */
+@Composable
+private fun TilesComboGhost(
+    game: TilesGameState,
+    accent: Color,
+    modifier: Modifier = Modifier
+) {
+    val combo = game.combo
+    AnimatedVisibility(
+        visible = combo >= COMBO_GHOST_AT,
+        enter = fadeIn(),
+        exit = fadeOut(),
+        modifier = modifier
+    ) {
+        Text(
+            text = combo.toString(),
+            style = MaterialTheme.typography.displayLarge.copy(
+                fontFamily = FontFamily.Serif,
+                fontStyle = FontStyle.Italic,
+                fontWeight = FontWeight.Bold
+            ),
+            color = accent.copy(alpha = 0.12f)
+        )
+    }
+}
+
+/** The judgment, set as a pull-quote above the line and gone in half a second. */
+@Composable
+private fun TilesJudgmentWord(
+    game: TilesGameState,
+    missColor: Color,
+    accent: Color,
+    modifier: Modifier = Modifier
+) {
+    var visible by remember { mutableStateOf(false) }
+    val serial = game.judgmentSerial
+    LaunchedEffect(serial) {
+        if (serial == 0) return@LaunchedEffect
+        visible = true
+        delay(JUDGMENT_HOLD_MS)
+        visible = false
+    }
+    val judgment = game.lastJudgment
+    AnimatedVisibility(
+        visible = visible && judgment != null,
+        enter = fadeIn(spring(stiffness = Spring.StiffnessHigh)) +
+            slideInVertically(spring(dampingRatio = Spring.DampingRatioMediumBouncy)) { it / 2 },
+        exit = fadeOut(),
+        modifier = modifier
+    ) {
+        Text(
+            text = judgment?.label.orEmpty(),
+            style = MaterialTheme.typography.headlineSmall.copy(
+                fontFamily = FontFamily.Serif,
+                fontStyle = FontStyle.Italic,
+                fontWeight = FontWeight.Bold
+            ),
+            // The single break from the two-tone contract, and only for a miss:
+            // "Miss" in the same ink as "Perfect" is a word you have to read
+            // instead of a state you can feel.
+            color = if (judgment == TileJudgment.MISS) missColor else accent
+        )
+    }
+}
+
+/**
+ * What the board shows when there is no chart.
+ *
+ * Never a silently empty rectangle: either the analysis has not landed yet, or
+ * this track has no steady tempo in it, and those are different sentences with
+ * different things to offer.
+ */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun TilesBoardPlaceholder(
+    chartState: TilesChartState,
+    onStartFreestyle: () -> Unit,
+    accent: Color,
+    field: Color
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .clip(RoundedCornerShape(20.dp))
+            .background(accent.copy(alpha = 0.05f)),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(28.dp)
+        ) {
+            when (chartState) {
+                TilesChartState.Loading -> {
+                    LoadingIndicator(
+                        modifier = Modifier.size(44.dp),
+                        color = accent,
+                        polygons = listOf(
+                            MaterialShapes.Cookie4Sided,
+                            MaterialShapes.Pill,
+                            MaterialShapes.SoftBurst
+                        )
+                    )
+                }
+
+                TilesChartState.Analysing -> {
+                    LoadingIndicator(
+                        modifier = Modifier.size(44.dp),
+                        color = accent,
+                        polygons = listOf(
+                            MaterialShapes.Cookie4Sided,
+                            MaterialShapes.Pill,
+                            MaterialShapes.SoftBurst
+                        )
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = "Reading the beat",
+                        style = MaterialTheme.typography.headlineSmall.copy(
+                            fontFamily = FontFamily.Serif,
+                            fontStyle = FontStyle.Italic,
+                            fontWeight = FontWeight.Bold
+                        ),
+                        color = accent,
+                        textAlign = TextAlign.Center
+                    )
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Text(
+                        text = "Koda measures a track's tempo the first time you play it. " +
+                            "The board fills in as soon as it lands.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = accent.copy(alpha = 0.7f),
+                        textAlign = TextAlign.Center
+                    )
+                    Spacer(modifier = Modifier.height(18.dp))
+                    TilesTextAction("PLAY FREESTYLE INSTEAD", onStartFreestyle, accent, field)
+                }
+
+                TilesChartState.NoTempo -> {
+                    Text(
+                        text = "No steady beat here",
+                        style = MaterialTheme.typography.headlineSmall.copy(
+                            fontFamily = FontFamily.Serif,
+                            fontStyle = FontStyle.Italic,
+                            fontWeight = FontWeight.Bold
+                        ),
+                        color = accent,
+                        textAlign = TextAlign.Center
+                    )
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Text(
+                        text = "Nothing in this track kept a tempo confidently enough to " +
+                            "chart. Freestyle lays down a steady 4/4 instead, which will " +
+                            "not follow the music.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = accent.copy(alpha = 0.7f),
+                        textAlign = TextAlign.Center
+                    )
+                    Spacer(modifier = Modifier.height(18.dp))
+                    TilesTextAction("PLAY FREESTYLE", onStartFreestyle, accent, field)
+                }
+
+                is TilesChartState.Ready -> Unit
+            }
+        }
+    }
+}
+
+@Composable
+private fun TilesTextAction(
+    label: String,
+    onClick: () -> Unit,
+    accent: Color,
+    field: Color
+) {
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(50),
+        color = accent,
+        contentColor = field
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium.copy(letterSpacing = 1.6.sp),
+            modifier = Modifier.padding(horizontal = 18.dp, vertical = 10.dp)
+        )
+    }
+}
+
+/** The verdict on a finished run, set like a review: a grade and its numbers. */
+@Composable
+private fun TilesResultStrip(
+    card: TilesResultCard,
+    onDismiss: () -> Unit,
+    field: Color,
+    accent: Color
+) {
+    Surface(
+        onClick = onDismiss,
+        shape = RoundedCornerShape(18.dp),
+        color = accent,
+        contentColor = field,
+        modifier = Modifier.padding(8.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 18.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = card.result.grade,
+                style = MaterialTheme.typography.displaySmall.copy(
+                    fontFamily = FontFamily.Serif,
+                    fontStyle = FontStyle.Italic,
+                    fontWeight = FontWeight.Bold
+                )
+            )
+            Column {
+                Text(
+                    text = if (card.isBest) "NEW BEST" else "RUN COMPLETE",
+                    style = MaterialTheme.typography.labelSmall.copy(letterSpacing = 2.sp)
+                )
+                Text(
+                    text = "${formatScore(card.result.score)}  ·  " +
+                        "${(card.result.accuracy * 100).toInt()}%  ·  " +
+                        "×${card.result.maxCombo}",
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        fontFamily = FontFamily.Serif,
+                        fontWeight = FontWeight.Bold
+                    )
+                )
+                if (card.result.isFullCombo) {
+                    Text(
+                        text = "FULL COMBO",
+                        style = MaterialTheme.typography.labelSmall.copy(letterSpacing = 2.sp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** Slim transport, so the board keeps the height. */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun TilesTransport(
+    isPlaying: Boolean,
+    isBuffering: Boolean,
+    playWhenReady: Boolean,
+    position: Long,
+    duration: Long,
+    onPlayPause: () -> Unit,
+    onNext: () -> Unit,
+    onPrevious: () -> Unit,
+    onSeekTo: (Long) -> Unit,
+    field: Color,
+    accent: Color
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .navigationBarsPadding()
+            .padding(horizontal = 20.dp)
+            .padding(bottom = 12.dp)
+    ) {
+        TilesSeekLine(
+            position = position,
+            duration = duration,
+            onSeekTo = onSeekTo,
+            accent = accent
+        )
+        Spacer(modifier = Modifier.height(10.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            EditorialCircleButton(
+                onClick = onPrevious,
+                accent = accent,
+                field = field,
+                size = 52.dp
+            ) {
+                Icon(Icons.Default.SkipPrevious, "Previous", modifier = Modifier.size(26.dp))
+            }
+            Surface(
+                onClick = onPlayPause,
+                modifier = Modifier
+                    .weight(1f)
+                    .height(52.dp),
+                shape = RoundedCornerShape(50),
+                color = accent,
+                contentColor = field
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    if (isBuffering && playWhenReady && !isPlaying) {
+                        LoadingIndicator(
+                            modifier = Modifier.size(28.dp),
+                            color = field,
+                            polygons = listOf(
+                                MaterialShapes.SoftBurst,
+                                MaterialShapes.Pill,
+                                MaterialShapes.Sunny
+                            )
+                        )
+                    } else {
+                        AnimatedContent(targetState = isPlaying, label = "TilesPlayWord") { playing ->
+                            Text(
+                                text = if (playing) "PAUSE" else "PLAY",
+                                style = MaterialTheme.typography.titleMedium.copy(
+                                    fontWeight = FontWeight.Medium,
+                                    letterSpacing = 3.sp
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+            EditorialCircleButton(
+                onClick = onNext,
+                accent = accent,
+                field = field,
+                size = 52.dp
+            ) {
+                Icon(Icons.Default.SkipNext, "Next", modifier = Modifier.size(26.dp))
+            }
+        }
+    }
+}
+
+/**
+ * A printed rule that happens to be the seek bar.
+ *
+ * Scrubbed locally and seeked once on release, like every other style here:
+ * seeking per drag frame rebuffers a streamed track.
+ */
+@Composable
+private fun TilesSeekLine(
+    position: Long,
+    duration: Long,
+    onSeekTo: (Long) -> Unit,
+    accent: Color
+) {
+    var scrubFraction by remember { mutableStateOf<Float?>(null) }
+    val fraction = scrubFraction
+        ?: if (duration > 0L) (position.toFloat() / duration).coerceIn(0f, 1f) else 0f
+    val animated by animateFloatAsState(
+        targetValue = fraction,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioNoBouncy,
+            stiffness = Spring.StiffnessLow
+        ),
+        label = "TilesSeek"
+    )
+    val shown = scrubFraction ?: animated
+
+    Column {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(20.dp)
+                .pointerInput(duration) {
+                    detectTapGestures { offset ->
+                        if (duration > 0L) {
+                            onSeekTo((offset.x / size.width * duration).toLong().coerceIn(0L, duration))
+                        }
+                    }
+                }
+                .pointerInput(duration) {
+                    detectHorizontalDragGestures(
+                        onDragStart = { offset ->
+                            scrubFraction = (offset.x / size.width).coerceIn(0f, 1f)
+                        },
+                        onHorizontalDrag = { change, amount ->
+                            change.consume()
+                            scrubFraction = ((scrubFraction ?: 0f) + amount / size.width)
+                                .coerceIn(0f, 1f)
+                        },
+                        onDragEnd = {
+                            scrubFraction?.let { value ->
+                                if (duration > 0L) onSeekTo((value * duration).toLong())
+                            }
+                            scrubFraction = null
+                        },
+                        onDragCancel = { scrubFraction = null }
+                    )
+                },
+            contentAlignment = Alignment.Center
+        ) {
+            Canvas(modifier = Modifier.fillMaxWidth().height(20.dp)) {
+                val y = size.height / 2f
+                val stroke = 2.dp.toPx()
+                drawLine(
+                    color = accent.copy(alpha = 0.22f),
+                    start = Offset(0f, y),
+                    end = Offset(size.width, y),
+                    strokeWidth = stroke
+                )
+                drawLine(
+                    color = accent,
+                    start = Offset(0f, y),
+                    end = Offset(size.width * shown, y),
+                    strokeWidth = stroke
+                )
+                drawCircle(
+                    color = accent,
+                    radius = 4.dp.toPx(),
+                    center = Offset(size.width * shown, y)
+                )
+            }
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            val shownPosition = scrubFraction?.let { (it * duration).toLong() } ?: position
+            Text(
+                text = formatTime(shownPosition),
+                style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+                color = accent.copy(alpha = 0.65f)
+            )
+            Text(
+                text = formatTime(duration),
+                style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+                color = accent.copy(alpha = 0.65f)
+            )
+        }
+    }
+}
+
+/**
+ * Difficulty and sync, the two things a rhythm player has to be able to change
+ * without leaving the board.
+ */
+@OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+@Composable
+private fun TilesTuningSheet(
+    difficulty: TileDifficulty,
+    syncOffsetMs: Int,
+    onDifficultyChange: (TileDifficulty) -> Unit,
+    onSyncOffsetChange: (Int) -> Unit,
+    onDismissRequest: () -> Unit,
+    field: Color,
+    accent: Color
+) {
+    val sheetState = rememberModalBottomSheetState()
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+        containerColor = field,
+        contentColor = accent
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            Text(
+                text = "Tuning",
+                style = MaterialTheme.typography.headlineSmall.copy(
+                    fontFamily = FontFamily.Serif,
+                    fontStyle = FontStyle.Italic,
+                    fontWeight = FontWeight.Bold
+                ),
+                color = accent
+            )
+
+            Text(
+                text = "DENSITY",
+                style = MaterialTheme.typography.labelSmall.copy(letterSpacing = 2.sp),
+                color = accent.copy(alpha = 0.6f)
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                TileDifficulty.entries.forEach { entry ->
+                    val selected = entry == difficulty
+                    Surface(
+                        onClick = { onDifficultyChange(entry) },
+                        shape = RoundedCornerShape(50),
+                        color = if (selected) accent else Color.Transparent,
+                        contentColor = if (selected) field else accent,
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Text(
+                            text = entry.label.uppercase(),
+                            style = MaterialTheme.typography.labelMedium.copy(letterSpacing = 1.4.sp),
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.padding(vertical = 12.dp)
+                        )
+                    }
+                }
+            }
+            Text(
+                text = "Changing this starts a new run: a score only means something " +
+                    "against the chart it was set on.",
+                style = MaterialTheme.typography.bodySmall,
+                color = accent.copy(alpha = 0.6f)
+            )
+
+            Spacer(modifier = Modifier.height(6.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "SYNC",
+                    style = MaterialTheme.typography.labelSmall.copy(letterSpacing = 2.sp),
+                    color = accent.copy(alpha = 0.6f)
+                )
+                Text(
+                    text = "${if (syncOffsetMs > 0) "+" else ""}$syncOffsetMs ms",
+                    style = MaterialTheme.typography.labelMedium.copy(
+                        fontFamily = FontFamily.Serif,
+                        fontWeight = FontWeight.Bold
+                    ),
+                    color = accent
+                )
+            }
+            Slider(
+                value = syncOffsetMs.toFloat(),
+                onValueChange = { onSyncOffsetChange(it.toInt()) },
+                valueRange = ThemePreferences.TILES_SYNC_OFFSET_MIN_MS.toFloat()..
+                    ThemePreferences.TILES_SYNC_OFFSET_MAX_MS.toFloat(),
+                colors = SliderDefaults.colors(
+                    thumbColor = accent,
+                    activeTrackColor = accent,
+                    inactiveTrackColor = accent.copy(alpha = 0.25f)
+                )
+            )
+            Text(
+                text = "Every phone puts out sound a little after the player says it did. " +
+                    "Raise this if tiles reach the line before you hear the beat, lower " +
+                    "it if you hear the beat first.",
+                style = MaterialTheme.typography.bodySmall,
+                color = accent.copy(alpha = 0.6f)
+            )
+        }
+    }
+}
+
+private fun formatScore(score: Int): String {
+    if (score < 1000) return score.toString()
+    val text = score.toString()
+    return buildString {
+        text.forEachIndexed { index, char ->
+            if (index > 0 && (text.length - index) % 3 == 0) append(',')
+            append(char)
+        }
+    }
+}
+
+private fun formatTime(ms: Long): String {
+    if (ms <= 0L) return "0:00"
+    val totalSeconds = ms / 1000
+    val minutes = totalSeconds / 60
+    val seconds = totalSeconds % 60
+    return "%d:%02d".format(minutes, seconds)
+}
+
+/** How long a tile is on screen before it reaches the line. */
+private const val APPROACH_MS = 1500L
+private const val RUSH_APPROACH_MS = 1250L
+
+/** Where the line sits: low enough to be a thumb's home, high enough to read. */
+private const val HIT_LINE_FRACTION = 0.78f
+
+/** Below this the page furniture is dropped so the board keeps its height. */
+private val COMPACT_HEIGHT = 560.dp
+
+private const val LANE_FLASH_MS = 220L
+private const val JUDGMENT_HOLD_MS = 520L
+private const val RESULT_CARD_MS = 5000L
+private const val COMBO_VISIBLE_AT = 5
+private const val COMBO_GHOST_AT = 10
+
+/** Longest a hold can be, so the draw scan knows how far back to look. */
+private const val MAX_TILE_LOOKBACK_MS = 6000L
+
+/** The chart is spent this long after its last tile, and the run is banked. */
+private const val RUN_END_GRACE_MS = 1200L
+
+private const val ANALYSIS_ATTEMPTS = 6
+private const val ANALYSIS_RETRY_MS = 2500L

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/TilesPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/TilesPlayerContent.kt
@@ -57,6 +57,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -104,7 +105,6 @@ import com.ivor.ivormusic.data.TileScoreStore
 import com.ivor.ivormusic.ui.components.SongArtwork
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
-import kotlinx.coroutines.withFrameNanos
 
 /**
  * Tiles - the rhythm board.
@@ -820,7 +820,11 @@ private fun TilesBoard(
     }
 
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
-        val boardHeightPx = with(density) { maxHeight.toPx() }
+        // Read out here rather than inside the Box below: BoxWithConstraintsScope
+        // extends BoxScope, so the inner Box's receiver shadows this one and
+        // `maxHeight` stops resolving against an implicit receiver.
+        val boardHeight = maxHeight
+        val boardHeightPx = with(density) { boardHeight.toPx() }
         val boardWidthPx = with(density) { maxWidth.toPx() }
         val laneWidthPx = boardWidthPx / TILE_LANES
         val hitLineY = boardHeightPx * HIT_LINE_FRACTION
@@ -978,7 +982,7 @@ private fun TilesBoard(
                     // Coerced because a short board (landscape, a small phone)
                     // puts the line within 64dp of the top, and a negative
                     // padding is a crash rather than a layout.
-                    .padding(top = (maxHeight * HIT_LINE_FRACTION - 64.dp).coerceAtLeast(0.dp))
+                    .padding(top = (boardHeight * HIT_LINE_FRACTION - 64.dp).coerceAtLeast(0.dp))
             )
 
             if (!isPlaying) {


### PR DESCRIPTION
## What this changes

Adds a ninth player style, **Tiles**: a four-lane rhythm board where tiles fall on the track's own beat and are tapped as they cross the line. Three tile kinds — tap, hold, and an accent on each bar's downbeat that carries its bar number the way a score carries measure numbers.

The chart is generated from the `AudioProfile` the app already measures for AutoMix: tempo and its confidence, the first beat and downbeat, the same measured independently at the outro, the key, the lead-in silence and the tail fade. No new analysis, no request, no decode.

New files:

- `data/TileChart.kt` — the chart model and the generator
- `data/TileScoreStore.kt` — best run per track and difficulty, device-wide
- `ui/player/TilesGame.kt` — judging, scoring and the seek/pause rules
- `ui/player/TilesPlayerContent.kt` — the style itself

## Why

The measurement existed to decide how to overlap two songs and nothing else was reading it. A beat map was already being written for every track played and thrown away after the crossfade decision — a rhythm board is what that data is, spent a second time for nothing.

The outro anchor earns its keep twice here. Two independently measured downbeats a whole track apart are a tempo *fit* rather than two point estimates, which is what keeps the last minute of a long song on the grid instead of a few hundred milliseconds adrift. Bounded to a few percent, because a tail estimate that disagrees by more than that is a half- or double-time reading rather than drift, and following it would put the back half of the chart on the wrong grid.

Two decisions shape everything else:

**Playback is never a consequence.** A miss costs score and the streak and nothing else. Magic Tiles' game-over is right for a game and wrong for the player somebody keeps their music in — nobody wants their album to stop because they fumbled while walking. The transport, queue, seeking and artist link all still work; the board is a layer over playback, not a thing that owns it.

**A chart is never faked.** A track with no confident tempo says so and offers Freestyle as an explicit choice, because tiles that do not match the music read as the app being broken rather than as a track it has not measured yet.

## States handled

- **Loading:** no track, or duration not yet known — expressive `LoadingIndicator`, no board.
- **Analysing:** the profile lands shortly *after* playback starts, so the board says "Reading the beat", explains that Koda measures a track the first time you play it, and offers Freestyle for the impatient. Bounded retry — a track that will never be profiled (metered network, uncached, unreadable audio) reaches an answer instead of spinning.
- **No usable tempo:** an honest "No steady beat here", stating plainly that Freestyle lays down a 4/4 that will not follow the music, as an opt-in.
- **Offline / signed out:** nothing here touches the network or a session. Local files profile the same way; the store, the scores and both preferences are device-local.
- **Long titles, missing thumbnail, no artwork colors:** title is one line, ellipsised; artist likewise. The board takes no color from artwork, so a missing cover costs the 52dp thumbnail and nothing else — and the thumbnail is dropped entirely on short screens.
- **Paused:** tiles freeze, taps do not judge, a veil offers "tap to resume". A held tile is abandoned rather than broken — pausing your own music is not a mistake.
- **Seeking:** forward skips those tiles rather than missing them; backwards will not let a chorus be replayed for a second helping of score. The streak breaks either way.
- **Track change / run end:** the run is banked on both, so a score earned by playing a song through does not depend on the screen still being on it.
- **Collapsed mid-run:** the run survives and resumes.
- **Landscape and small screens:** the credit line goes first and the masthead loses its artwork, so the board keeps its height.

## Deliberately not done

- **No difficulty or sync row in Settings.** Both live in the player's own tuning sheet and persist through `ThemePreferences` with no StateFlow, following the `download_video_quality` precedent: they mean nothing outside this one style, and a Settings row for them is a control the reader has no context for. So the five-file threading does not apply and neither does the search index.
- **No swipe-to-skip on the board**, and the style wheel's hold gesture moved to the artwork. A horizontal drag during a hold must not skip the track out from under the run, and a long press on the board is a held tile.
- **No new queue view.** Tiles uses `EditorialQueueView`, keeping the ratio at three queue views across nine styles.
- **No ambient background.** The parameter is accepted and ignored, as in Editorial: a drifting shader behind a board you are aiming at is noise.
- **Not built or run.** `CLAUDE.md` says never to invoke Gradle unless asked, and I was asked not to. Two API references I could not verify by eye (`Icons.Rounded.Piano`, `MaterialShapes.VerySunny`) were swapped for ones already proven in this codebase rather than risk a name that does not exist.

## Screenshots or recording

None — the branch has not been built or run, per the above. This needs a pass on a device before it merges, and the two feel constants (`HIT_LINE_FRACTION` at 0.78 and the 1500ms approach time) are single values at the bottom of `TilesPlayerContent.kt` that are best judged with a thumb rather than by reading.

## Checklist

- [ ] Builds with `./gradlew assembleDebug` — not run, see above
- [ ] Run on a device or emulator, not just compiled — not run, see above
- [x] No hardcoded colors; everything resolves through `ColorScheme`. The board is the Editorial two-tone contract, `primaryContainer` plus `onPrimaryContainer`; the single addition is `error`, used only for a miss, because "Miss" in the same ink as "Perfect" is a word you have to read instead of a state you can feel
- [x] Material 3 Expressive components used before standard M3, springs for touch-driven motion (`LoadingIndicator` with polygons, `MaterialShapes`, bouncy springs on the judgment word; `tween` avoided except where progress is time-tracking)
- [x] The signed-out path still works — nothing here is account-derived

### If this touches one of these areas

- [x] **New player style** added in all four places: the `PlayerStyle` enum, `TilesPlayerContent.kt`, the `when` in `ExpandablePlayer.kt`, and `playerStyleCatalog` — plus the `PlayerStylePreview` wireframe branch, which is an exhaustive `when` and would have failed the build otherwise
- [x] No cookie dumps, response JSON, or `.probe/` contents committed

### Notes on the plumbing

- The board is one `Canvas`, and the clock is read *inside the draw lambda* rather than passed down as a value, so a frame repaints the drawing instead of recomposing constraints, Canvas and overlays sixty times a second. The combo readout is its own composable for the same reason.
- Pointer changes are consumed, which is also what stops a stray vertical drag on the board from collapsing the player mid-run — the sheet's own drag detector never sees an unconsumed pointer. The pointer loop reads its lambdas through `rememberUpdatedState`, since it outlives the composition that started it.
- `PlayerViewModel.playbackPositionMs()` is new because `progress` ticks once a second, which is a seek bar's resolution and not a beat's. `MediaController` extrapolates locally, so a per-frame read is cheap and smooth.
- `AudioProfileStore.reload()` is new because every consumer news up its own store and the profile for the current track normally lands *after* a reader has already loaded the file.
- Sync offset is a per-device physical fact rather than a taste: sound reaches the ear some milliseconds after the position the player reports, so without it a player exactly in time is marked late on every single tile.
- `DESIGN.md` and `ROADMAP.md` updated in the same commit, counts re-derived (nine styles, ~14,100 lines in the player package, 51 files using Expressive-only APIs).


---
_Generated by [Claude Code](https://claude.ai/code/session_012bzPzXyZLZbDGzsjw53uVK)_