### PR TITLE
Full-height expanded player on Android 11/12, and local-file lyrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ On Android 11 specifically, wallpaper-based dynamic color is unavailable, since 
 - **Like tracks straight from the player.** Liked songs appear immediately and are stored locally, no login required.
 - **Sleep timer** in all eight player styles, each in its own idiom, with a live countdown and a visible armed state. It lives with playback rather than the screen, so leaving the app does not cancel it. There is a duration mode that fades out over five seconds rather than cutting the audio dead, and an **end of this track** mode.
 - **Library sort that persists** across launches, including **Most played** and **Recently added**, each showing what it sorted on ("12 plays", "3d ago") so the order never reads as arbitrary.
-- **Multi-provider lyrics** with word-, line-, and plain-text fallbacks. Real word timings render as smooth letter-by-letter highlighting in every player style.
+- **Local and multi-provider lyrics**. Local songs prefer matching `.lrc`/`.ttml` sidecars or embedded lyric tags and continue to show them offline; online providers supply word-, line-, and plain-text fallbacks. Real word timings render as smooth letter-by-letter highlighting in every player style.
 - **Listening statistics**: songs played, artists explored, liked-song count, top artist, top songs and artists, daily / weekly / monthly play charts, a listening streak, and recent searches.
 - **Local audio playback** with MediaStore scanning, per-folder exclusion, and a high-compatibility scan mode for devices where MediaStore misses files.
 - **Last-played song restoration** so the player comes back where you left it.
@@ -420,7 +420,7 @@ app/src/main/java/com/ivor/ivormusic/
 │   ├── NotInterestedActions # Local hide plus best-effort account feedback
 │   ├── RecommendationEngine # Local taste profile and queue continuation
 │   ├── StatsRepository      # Listening statistics
-│   ├── LyricsRepository     # Multi-provider timed and plain lyrics
+│   ├── LyricsRepository     # Local-first, multi-provider timed and plain lyrics
 │   ├── UpdateRepository     # In-app updates from GitHub Releases
 │   ├── SessionManager       # The active profile's session cookies
 │   ├── ProfileManager       # Profile roster: YouTube accounts and local ones

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -426,6 +426,7 @@ The milestones behind us, kept here so the direction of travel is visible.
 - Playlist management: create, rename, reorder, and delete, with cover art you pick or the app generates from your palette
 - Saving other people's playlists and albums to the library in both music and video mode, stored as live references rather than copies
 - Multi-provider lyrics with TTML, QRC, Enhanced LRC, line and plain-text fallbacks, plus letter-by-letter highlighting from real word timings
+- Full-height expanded music players on Android 11 and 12, measured from the edge-to-edge window rather than the inset-excluding resource configuration
 - In-app video with a personalized feed, chapters, captions, and comments
 - Eight player styles and a 27-palette color system with dynamic color and AMOLED
 - Listening statistics with play charts, streaks, and top artists

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -425,7 +425,7 @@ The milestones behind us, kept here so the direction of travel is visible.
 
 - Playlist management: create, rename, reorder, and delete, with cover art you pick or the app generates from your palette
 - Saving other people's playlists and albums to the library in both music and video mode, stored as live references rather than copies
-- Multi-provider lyrics with TTML, QRC, Enhanced LRC, line and plain-text fallbacks, plus letter-by-letter highlighting from real word timings
+- Local-first lyrics for device songs (`.lrc`/`.ttml` sidecars and embedded tags), multi-provider online fallbacks with TTML, QRC, Enhanced LRC, line and plain text, plus letter-by-letter highlighting from real word timings
 - Full-height expanded music players on Android 11 and 12, measured from the edge-to-edge window rather than the inset-excluding resource configuration
 - In-app video with a personalized feed, chapters, captions, and comments
 - Eight player styles and a 27-palette color system with dynamic color and AMOLED

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -137,6 +137,9 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.androidx.security.crypto)
     implementation(libs.kotlinx.coroutines.guava)
+    // Local files may carry lyrics in ID3, Vorbis/FLAC, MP4 and other tag
+    // formats. Keep that container-specific parsing out of the player.
+    implementation(libs.jaudiotagger)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -37,3 +37,11 @@
 -dontwarn com.yausername.**
 -keep class org.apache.commons.** { *; }
 -dontwarn org.apache.commons.**
+
+# jAudioTagger reads local lyric tags. Its tag bodies are instantiated by
+# identifier and its desktop-only artwork helpers are never used on Android.
+-keep class org.jaudiotagger.tag.id3.framebody.** { *; }
+-keep class org.jaudiotagger.tag.datatype.** { *; }
+-dontwarn java.awt.**
+-dontwarn javax.imageio.**
+-dontwarn javax.swing.**

--- a/app/src/main/java/com/ivor/ivormusic/data/LocalLyricsSource.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/LocalLyricsSource.kt
@@ -1,0 +1,153 @@
+package com.ivor.ivormusic.data
+
+import android.util.Log
+import org.jaudiotagger.audio.AudioFileIO
+import org.jaudiotagger.tag.FieldKey
+import java.io.File
+import java.util.Collections
+import java.util.LinkedHashMap
+
+/** Reads lyrics that travel with a local audio file, without using the network. */
+internal class LocalLyricsSource(
+    private val embeddedLyricsReader: (File) -> String? = ::readEmbeddedLyrics
+) {
+    private class CachedSidecars(val stamp: Long, val files: List<File>)
+
+    /**
+     * Bounded because a shuffle across a library walks through folders without
+     * ever coming back, and holding every one of them would be a leak with a
+     * slow fuse. Access-ordered, so the folder being played out of stays.
+     */
+    private val sidecarCache = Collections.synchronizedMap(
+        object : LinkedHashMap<String, CachedSidecars>(MAX_CACHED_DIRECTORIES, 0.75f, true) {
+            override fun removeEldestEntry(
+                eldest: MutableMap.MutableEntry<String, CachedSidecars>?
+            ): Boolean = size > MAX_CACHED_DIRECTORIES
+        }
+    )
+
+    fun find(song: Song): LyricsResult.Success? {
+        if (song.source != SongSource.LOCAL) return null
+        val audioFile = song.filePath
+            ?.takeIf { it.isNotBlank() }
+            ?.let(::File)
+            ?: return null
+
+        findSidecar(audioFile)?.let { sidecar ->
+            readSidecar(sidecar)?.let(LyricsParser::parse)?.let { parsed ->
+                return parsed.toResult("Local ${sidecar.extension.uppercase()}")
+            }
+        }
+
+        val embedded = runCatching { embeddedLyricsReader(audioFile) }
+            .onFailure { Log.w(TAG, "Could not read embedded lyrics from ${audioFile.name}", it) }
+            .getOrNull()
+            ?.takeIf { it.isNotBlank() && it.length <= MAX_EMBEDDED_LYRICS_CHARS }
+
+        return embedded
+            ?.let(LyricsParser::parse)
+            ?.toResult("Embedded lyrics")
+    }
+
+    private fun findSidecar(audioFile: File): File? {
+        val parent = audioFile.parentFile ?: return null
+        val stem = audioFile.nameWithoutExtension
+
+        // Avoid listing the directory in the common case. Shared storage is
+        // case-insensitive, so on a phone this probe is the whole answer and
+        // costs one stat per extension.
+        SIDECAR_EXTENSIONS.forEach { extension ->
+            File(parent, "$stem.$extension").takeIf(File::isFile)?.let { return it }
+        }
+
+        // The fallback makes matching case-insensitive for files copied from
+        // case-sensitive hosts, and has to honor the same extension preference
+        // the probe above does: readdir order is arbitrary, so taking the first
+        // candidate would let the filesystem decide whether Track.LRC or
+        // Track.TTML wins.
+        val candidates = sidecarsIn(parent)
+        if (candidates.isEmpty()) return null
+        return SIDECAR_EXTENSIONS.firstNotNullOfOrNull { extension ->
+            candidates.firstOrNull { candidate ->
+                candidate.extension.equals(extension, ignoreCase = true) &&
+                    candidate.nameWithoutExtension.equals(stem, ignoreCase = true)
+            }
+        }
+    }
+
+    /**
+     * The lyric files sitting in [directory], remembered until the directory
+     * itself changes.
+     *
+     * Most libraries carry no sidecars at all, which is exactly the case that
+     * reaches the listing: without this, every track change lists the whole
+     * music folder again to find nothing, and these are the devices that keep
+     * thousands of files on an SD card. Keyed on `lastModified` so a sidecar
+     * dropped in while the app is running is still picked up - adding or
+     * removing a file bumps its directory's timestamp.
+     */
+    private fun sidecarsIn(directory: File): List<File> {
+        val stamp = directory.lastModified()
+        sidecarCache[directory.path]?.takeIf { it.stamp == stamp }?.let { return it.files }
+
+        val files = runCatching {
+            directory.listFiles { candidate: File ->
+                candidate.isFile && candidate.extension.lowercase() in SIDECAR_EXTENSIONS
+            }?.toList()
+        }.onFailure {
+            Log.w(TAG, "Could not list ${directory.name} for lyric sidecars", it)
+        }.getOrNull().orEmpty()
+
+        sidecarCache[directory.path] = CachedSidecars(stamp, files)
+        return files
+    }
+
+    private fun readSidecar(file: File): String? = runCatching {
+        if (file.length() !in 1..MAX_SIDECAR_BYTES) return@runCatching null
+        decodeSidecar(file.readBytes())
+    }.onFailure {
+        Log.w(TAG, "Could not read lyric sidecar ${file.name}", it)
+    }.getOrNull()
+
+    /**
+     * Decode a lyric sidecar, honoring a byte order mark.
+     *
+     * UTF-8 is the right default and the only encoding [LyricsParser] strips a
+     * BOM for, but Windows editors save "Unicode" .lrc files as UTF-16 with
+     * one, and reading those as UTF-8 does not fail. It yields a string of
+     * replacement characters that no longer looks like LRC, so it parses as
+     * plain text: the player shows a screen of garbage *and*, because a local
+     * hit stops the search, never falls through to the embedded tag or a
+     * provider. Sniffing two bytes is the whole fix. A file without a mark is
+     * UTF-8, which is what every lyric tool other than Notepad writes.
+     */
+    private fun decodeSidecar(bytes: ByteArray): String = when {
+        bytes.size >= 2 && bytes[0] == 0xFF.toByte() && bytes[1] == 0xFE.toByte() ->
+            String(bytes, 2, bytes.size - 2, Charsets.UTF_16LE)
+        bytes.size >= 2 && bytes[0] == 0xFE.toByte() && bytes[1] == 0xFF.toByte() ->
+            String(bytes, 2, bytes.size - 2, Charsets.UTF_16BE)
+        else -> String(bytes, Charsets.UTF_8)
+    }
+
+    private fun ParsedLyrics.toResult(provider: String) = LyricsResult.Success(
+        lines = lines,
+        provider = provider,
+        syncType = syncType
+    )
+
+    private companion object {
+        const val TAG = "LocalLyricsSource"
+        const val MAX_SIDECAR_BYTES = 2L * 1024L * 1024L
+        const val MAX_EMBEDDED_LYRICS_CHARS = 2 * 1024 * 1024
+        const val MAX_CACHED_DIRECTORIES = 8
+        val SIDECAR_EXTENSIONS = listOf("lrc", "ttml")
+
+        fun readEmbeddedLyrics(audioFile: File): String? {
+            if (!audioFile.isFile || !audioFile.canRead()) return null
+            return AudioFileIO.read(audioFile)
+                .tag
+                ?.getFirst(FieldKey.LYRICS)
+                ?.takeIf(String::isNotBlank)
+        }
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/data/LyricsRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/LyricsRepository.kt
@@ -14,13 +14,23 @@ import java.util.LinkedHashMap
 
 /**
  * Fetches the best available lyric format without coupling the player to a
- * particular remote service. Word-timed providers are tried first, followed
- * by line-synced and plain-text fallbacks.
+ * particular remote service.
+ *
+ * Lyrics that travel with a device file are tried before anything on the
+ * network and win outright: they are what the user deliberately put next to
+ * that track, they are the only ones that work offline, and matching a local
+ * file to a provider by title and artist is exactly the guess that fails on
+ * the thinly-tagged rips these are usually paired with. Only then do the
+ * word-timed providers run, followed by line-synced and plain-text fallbacks.
+ *
+ * Local-only mode turns off the providers, not the local read - see
+ * [fetchLyrics]'s `allowRemote`.
  */
 class LyricsRepository internal constructor(
     private val http: LyricsHttpClient = LyricsHttpClient(),
     private val wordProviders: List<RemoteLyricsProvider> = defaultWordLyricsProviders(http),
-    private val fallbackProviders: List<RemoteLyricsProvider> = defaultFallbackLyricsProviders(http)
+    private val fallbackProviders: List<RemoteLyricsProvider> = defaultFallbackLyricsProviders(http),
+    private val localLyricsSource: LocalLyricsSource = LocalLyricsSource()
 ) {
     private companion object {
         const val TAG = "LyricsRepository"
@@ -36,21 +46,16 @@ class LyricsRepository internal constructor(
         }
     )
 
-    suspend fun fetchLyrics(
-        songId: String,
-        title: String,
-        artist: String,
-        album: String = "",
-        durationMs: Long
-    ): LyricsResult = withContext(Dispatchers.IO) {
-        if (title.isBlank()) return@withContext LyricsResult.NotFound
+    suspend fun fetchLyrics(song: Song, allowRemote: Boolean = true): LyricsResult = withContext(Dispatchers.IO) {
+        localLyricsSource.find(song)?.let { return@withContext it }
+        if (!allowRemote || song.title.isBlank()) return@withContext LyricsResult.NotFound
 
         val request = LyricsRequest(
-            songId = songId,
-            title = title.trim(),
-            artist = artist.trim(),
-            album = album.trim(),
-            durationMs = durationMs.coerceAtLeast(0L)
+            songId = song.id,
+            title = song.title.trim(),
+            artist = song.artist.trim(),
+            album = song.album.trim(),
+            durationMs = song.duration.coerceAtLeast(0L)
         )
         val key = request.cacheKey()
         cache[key]?.let { return@withContext it }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/ExpandablePlayer.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/ExpandablePlayer.kt
@@ -23,8 +23,8 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
@@ -88,9 +88,21 @@ fun ExpandablePlayer(
         if (!isExpanded) styleWheel.dismiss()
     }
 
-    val configuration = LocalConfiguration.current
-    val screenHeight = configuration.screenHeightDp.dp
-    val screenWidth = configuration.screenWidthDp.dp
+    // Configuration.screenHeightDp/screenWidthDp exclude the status and
+    // navigation bars on older Android releases even though enableEdgeToEdge
+    // makes our Compose container cover them. A bottom-aligned surface with
+    // that shorter height therefore leaves both inset heights exposed at the
+    // top on Android 11/12. The window container is the space this overlay
+    // actually has to fill.
+    //
+    // Both axes come from it, not just the height: the width is how far the
+    // dismiss gesture throws the collapsed pill, and in landscape (or on a
+    // device that keeps its bar on the side) it is short by the same inset.
+    // VideoPlayerOverlay solves the same problem with BoxWithConstraints; here
+    // the measurement is needed above the layout that would provide it.
+    val windowSize = LocalWindowInfo.current.containerDpSize
+    val screenHeight = windowSize.height
+    val screenWidth = windowSize.width
     val density = LocalDensity.current
     val bottomWindowInsets = WindowInsets.navigationBars
     val bottomInset = with(density) { bottomWindowInsets.getBottom(this).toDp() }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
@@ -1248,20 +1248,15 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
         // response would otherwise land last and show A's lyrics over B.
         lyricsFetchJob?.cancel()
 
-        // Lyrics come from an online API; skip entirely in local-only mode
-        if (themePreferences.isLocalOnlyModeEnabled()) {
-            _lyricsResult.value = LyricsResult.NotFound
-            return
-        }
         _lyricsResult.value = LyricsResult.Loading
 
         lyricsFetchJob = viewModelScope.launch {
             val result = lyricsRepository.fetchLyrics(
-                songId = song.id,
-                title = song.title,
-                artist = song.artist,
-                album = song.album ?: "",
-                durationMs = song.duration
+                song = song,
+                // Local lyrics are always checked first. Local-only mode only
+                // disables the provider fallback; it must not disable files
+                // already stored on the device.
+                allowRemote = !themePreferences.isLocalOnlyModeEnabled()
             )
             // Belt and braces for the same race: only apply the result if
             // this is still the song on screen.

--- a/app/src/test/java/com/ivor/ivormusic/data/LocalLyricsSourceTest.kt
+++ b/app/src/test/java/com/ivor/ivormusic/data/LocalLyricsSourceTest.kt
@@ -1,0 +1,147 @@
+package com.ivor.ivormusic.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import kotlinx.coroutines.runBlocking
+
+class LocalLyricsSourceTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun matchingLrcSidecarWinsOverEmbeddedLyrics() {
+        val audio = temporaryFolder.newFile("Track.mp3")
+        temporaryFolder.newFile("Track.lrc").writeText("[00:01.00]Sidecar line")
+        val source = LocalLyricsSource { "Embedded line" }
+
+        val result = source.find(localSong(audio))!!
+
+        assertEquals("Local LRC", result.provider)
+        assertEquals(LyricsSyncType.LINE, result.syncType)
+        assertEquals("Sidecar line", result.lines.single().text)
+    }
+
+    @Test
+    fun matchingTtmlSidecarIsParsed() {
+        val audio = temporaryFolder.newFile("Track.flac")
+        temporaryFolder.newFile("Track.ttml").writeText(
+            """<tt xmlns="http://www.w3.org/ns/ttml"><body><p begin="1s">TTML line</p></body></tt>"""
+        )
+
+        val result = LocalLyricsSource { null }.find(localSong(audio))!!
+
+        assertEquals("Local TTML", result.provider)
+        assertEquals("TTML line", result.lines.single().text)
+    }
+
+    @Test
+    fun embeddedLyricsAreUsedWithoutSidecar() {
+        val audio = temporaryFolder.newFile("Track.ogg")
+
+        val result = LocalLyricsSource { "First line\nSecond line" }.find(localSong(audio))!!
+
+        assertEquals("Embedded lyrics", result.provider)
+        assertEquals(LyricsSyncType.PLAIN, result.syncType)
+        assertEquals(listOf("First line", "Second line"), result.lines.map { it.text })
+    }
+
+    @Test
+    fun utf16SidecarsAreDecodedRatherThanShownAsGarbage() {
+        val audio = temporaryFolder.newFile("Track.mp3")
+        // What a Windows editor writes when asked for "Unicode": UTF-16LE
+        // behind a BOM. Read as UTF-8 this is replacement characters that
+        // still parse as plain text, so the failure is a screenful of garbage
+        // rather than a miss, and it stops the search before the fallbacks.
+        temporaryFolder.newFile("Track.lrc")
+            .writeBytes(byteArrayOf(0xFF.toByte(), 0xFE.toByte()) +
+                "[00:01.00]Encoded line".toByteArray(Charsets.UTF_16LE))
+
+        val result = LocalLyricsSource { null }.find(localSong(audio))!!
+
+        assertEquals("Encoded line", result.lines.single().text)
+        assertEquals(LyricsSyncType.LINE, result.syncType)
+    }
+
+    @Test
+    fun unparseableSidecarFallsThroughToEmbeddedLyrics() {
+        val audio = temporaryFolder.newFile("Track.mp3")
+        temporaryFolder.newFile("Track.ttml").writeText("<tt><body></body></tt>")
+
+        val result = LocalLyricsSource { "Embedded line" }.find(localSong(audio))!!
+
+        assertEquals("Embedded lyrics", result.provider)
+        assertEquals("Embedded line", result.lines.single().text)
+    }
+
+    @Test
+    fun youtubeSongsNeverReadLocalFiles() {
+        val audio = temporaryFolder.newFile("Track.mp3")
+        var embeddedRead = false
+        val source = LocalLyricsSource {
+            embeddedRead = true
+            "Lyrics"
+        }
+
+        val result = source.find(localSong(audio).copy(source = SongSource.YOUTUBE))
+
+        assertNull(result)
+        assertEquals(false, embeddedRead)
+    }
+
+    @Test
+    fun repositoryReturnsLocalLyricsBeforeCallingRemoteProviders() = runBlocking {
+        val audio = temporaryFolder.newFile("Track.mp3")
+        temporaryFolder.newFile("Track.lrc").writeText("[00:01.00]Stored here")
+        var remoteCalled = false
+        val remote = recordingProvider { remoteCalled = true }
+        val repository = LyricsRepository(
+            wordProviders = listOf(remote),
+            fallbackProviders = emptyList()
+        )
+
+        val result = repository.fetchLyrics(localSong(audio)) as LyricsResult.Success
+
+        assertEquals("Stored here", result.lines.single().text)
+        assertEquals(false, remoteCalled)
+    }
+
+    @Test
+    fun localOnlyRequestDoesNotCallRemoteProvidersWhenLocalLyricsAreMissing() = runBlocking {
+        val audio = temporaryFolder.newFile("Track.mp3")
+        var remoteCalled = false
+        val remote = recordingProvider { remoteCalled = true }
+        val repository = LyricsRepository(
+            wordProviders = listOf(remote),
+            fallbackProviders = listOf(remote),
+            localLyricsSource = LocalLyricsSource { null }
+        )
+
+        val result = repository.fetchLyrics(localSong(audio), allowRemote = false)
+
+        assertEquals(LyricsResult.NotFound, result)
+        assertEquals(false, remoteCalled)
+    }
+
+    private fun recordingProvider(onFetch: () -> Unit) = object : RemoteLyricsProvider {
+        override val name = "test"
+        override val priority = 0
+
+        override suspend fun fetch(request: LyricsRequest): ParsedLyrics? {
+            onFetch()
+            return ParsedLyrics(listOf(LrcLine(0L, "Remote")), LyricsSyncType.LINE)
+        }
+    }
+
+    private fun localSong(file: java.io.File) = Song(
+        id = "1",
+        title = "Track",
+        artist = "Artist",
+        album = "Album",
+        duration = 120_000L,
+        source = SongSource.LOCAL,
+        filePath = file.absolutePath
+    )
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ palette = "1.0.0"
 kotlinxSerializationJson = "1.7.3"
 coroutinesGuava = "1.10.1"
 desugarJdkLibs = "2.1.5"
+jaudiotagger = "3.0.1"
 
 
 [libraries]
@@ -57,6 +58,7 @@ newpipe-extractor = { group = "com.github.TeamNewPipe", name = "NewPipeExtractor
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
 kotlinx-coroutines-guava = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-guava", version.ref = "coroutinesGuava" }
+jaudiotagger = { group = "net.jthink", name = "jaudiotagger", version.ref = "jaudiotagger" }
 # The runtime half of kotlinx.serialization. The kotlin-serialization plugin only
 # supplies the compiler side; every @Serializable model and every Json.decode call
 # in data/ needs this on the classpath. It used to arrive transitively through


### PR DESCRIPTION
## What this changes

Two fixes reported from the same device, a Galaxy A02 on Android 11.

**The expanded music player now fills the window on Android 11 and 12.** It was leaving a strip at the top uncovered, showing whatever screen was behind it.

**Local songs now show the lyrics that travel with the file.** A matching `.lrc` or `.ttml` sidecar, or an embedded tag, read before anything on the network.

Fixes #198
Fixes #199

## Why

**#198.** `Configuration.screenHeightDp` and `screenWidthDp` exclude the status and navigation bars on those releases, while `enableEdgeToEdge` has our Compose container covering both. A bottom-aligned surface given that shorter height stops both inset heights short of the top, which is exactly the gap in the report — on the reporter's 720×1600 screen the exposed strip measures the status bar plus the navigation bar. Both axes now come off the window container. `VideoPlayerOverlay` already hit this and solved it with `BoxWithConstraints` when the same strip showed up in fullscreen landscape; here the measurement is needed above the layout that would provide it, so it reads the window directly.

The width matters as well as the height, which is the part that was still missing: it is how far the dismiss gesture throws the collapsed pill, and it is short by the same inset in landscape and on any device that parks its bar on the side.

**#199.** There was no local path at all. Every lookup was a provider search keyed on title, artist, album and duration — the guess most likely to miss on the thinly-tagged rips these files usually are, and one that cannot run with no network. So a song with an `.lrc` sitting next to it showed nothing, online or off. Local files now run first and win outright: they are what the user deliberately put next to that track, and they are the only ones that work offline. jaudiotagger carries the container-specific tag parsing rather than the player growing its own.

Local-only mode was a related bug of its own — it returned `NotFound` before looking at anything, so the one mode that most needs files on the device was the one that never read them. It now disables the providers, not the local read.

## States handled

- **Loading:** unchanged — `LyricsResult.Loading` is still set before the fetch, and the local read is on `Dispatchers.IO` like the rest.
- **Empty:** a sidecar that parses to nothing falls through to the embedded tag, and an embedded tag that parses to nothing falls through to the providers. `LyricsParser.parse` already rejects a result with no non-blank lines, so an empty file cannot become an empty lyrics screen.
- **Error / offline:** offline is the case this exists for. Local lyrics never touch the network; a local song with none still falls through to the providers and reports their failure as it did before.
- **Signed out:** neither path needs an account.
- **Long titles, missing artwork:** untouched by both changes.
- **Missing file / unreadable / no sidecar:** every read is a `runCatching` returning null into the next fallback. A song whose `filePath` is blank or whose file is gone is skipped rather than failed.
- **Player styles:** all eight already apply `statusBarsPadding()` at the top and `navigationBarsPadding()` at the bottom, so the taller surface moves the background out to the edges without moving any chrome under a system bar.

## Deliberately not done

- **`VerticalLivePlayerContent.kt:177` has the same `Configuration`-vs-window mismatch** and feeds the zoom-vs-letterbox decision for vertical live streams. Working the numbers on the reporter's screen, it only flips the outcome for sources between roughly 0.60 and 0.66 aspect — real but narrow, and a different pipeline. Left for its own change.
- **`VideoPlayerContent.kt:261` is also `Configuration`-based and was left alone on purpose.** Its height cap is a budget against the watch page's content area, not the window, so the inset-excluding number is the right one there.
- **Downloaded songs carry no `filePath`,** only a `uri`, so they never reach the local reader. Correct today — they have no sidecars — but it means the `source == LOCAL` gate is really "has a file path".
- **Local hits are not cached** the way provider results are, so it is one file read and parse per track change. Cheap, on the IO dispatcher, and re-reading is what picks up an edited sidecar.
- **The embedded-lyrics size cap is checked after jaudiotagger has materialised the tag value,** so it bounds what gets parsed rather than what gets read.
- **The status bar's icon appearance still follows the app theme rather than the artwork scheme.** Now that the player covers the status bar on 11/12 as it always did on 13+, that is at least consistent across releases; the artwork scheme derives from the theme's light/dark base, so contrast holds. Pre-existing either way.
- **No version bump** — leaving `versionCode` / `versionName` for whoever cuts 4.6.

## Screenshots or recording

Not captured — this was written and reviewed without a device attached. The gap is visible in the screenshot on #198, and the fix wants a look on an Android 11 or 12 emulator before merge.

## Checklist

- [ ] Builds with `./gradlew assembleDebug` — **not run**
- [ ] Run on a device or emulator, not just compiled — **not run**
- [x] No hardcoded colors; everything resolves through `ColorScheme`
- [x] Material 3 Expressive components used before standard M3, springs for touch-driven motion
- [x] The signed-out path still works

### If this touches one of these areas

- [x] No new setting, no new player style, no InnerTube parser change
- [x] No cookie dumps, response JSON, or `.probe/` contents committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
