### PR TITLE
Reduce release APK size by shrinking unused extractor code

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -27,9 +27,11 @@
 -dontwarn com.google.common.**
 -dontwarn com.google.re2j.**
 
-# Keep NewPipe Extractor classes if they are being stripped too aggressively
--keep class org.schabi.newpipe.extractor.** { *; }
--keep class org.mozilla.javascript.** { *; }
+# NewPipe and Rhino are called through ordinary bytecode. Keeping their entire
+# package trees defeats R8's shrinking and retains extractors and JavaScript
+# internals Koda never reaches. Their warning suppressions above are sufficient;
+# concrete reflective entry points, if any are added later, should get narrow
+# rules from the owning library instead of another package-wide keep.
 
 # youtubedl-android (bundled Python + yt-dlp). The library invokes the Python
 # runtime via JNI/reflection, so its classes must not be renamed or stripped.


### PR DESCRIPTION
## Summary
- remove blanket R8 keep rules for NewPipe Extractor and Rhino
- retain existing warning suppressions while allowing unused extractor and JavaScript internals to be removed
- keep runtime code and dependencies unchanged

## Measured release size
- universal APK: 11,566,600 bytes -> 10,222,884 bytes
- reduction: 1,343,716 bytes (11.6%)
- arm64-v8a APK: 10,172,811 bytes
- armeabi-v7a APK: 10,169,969 bytes

## Verification
- local assembleRelease completed successfully
- local testDebugUnitTest completed successfully
- universal release APK signature verified with apksigner