### PR TITLE
Polish video fullscreen controls and PiP

### DIFF
--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -360,15 +360,16 @@ class MainActivity : ComponentActivity() {
     /**
      * Entering PiP on the way out of the app.
      *
-     * On API 31+ the system does this itself from setAutoEnterEnabled, which
-     * handles the gesture-nav swipe up as well and animates better, so this
-     * only covers Android 11 and 12 where that flag does not exist.
+     * API 31+ is already armed through setAutoEnterEnabled for the smooth
+     * gesture-navigation transition. Keep this explicit path on every version
+     * as an OEM fallback: some Android 16 builds deliver onUserLeaveHint but do
+     * not honor the armed auto-enter flag. enterPictureInPictureMode is safe to
+     * call only while entry has not started, hence both state checks below.
      */
     @Deprecated("Deprecated in Java")
     override fun onUserLeaveHint() {
         super.onUserLeaveHint()
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) return
-        if (!pipEligible || isInPipMode) return
+        if (!pipEligible || isInPipMode || isInPictureInPictureMode) return
         enterPipMode(this, pipVideoAspectRatio, pipVideoBounds)
     }
 

--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -628,10 +628,9 @@ fun MusicApp(
         onOpenChannel = openChannel
     )
 
-    // Drives the PiP window's shape and keeps its transport icons current.
-    // Composed above the early return because everything below it is torn out
-    // the moment PiP starts. Button input itself goes straight to the video
-    // media service and therefore does not depend on this UI lifetime.
+    // Drives the PiP window's shape and its transport controls. Composed above
+    // the early return so the package-scoped receiver remains alive when the
+    // normal app UI is replaced by the dedicated video-only PiP surface.
     com.ivor.ivormusic.ui.video.VideoPipController(viewModel = videoPlayerViewModel)
 
     // In system PiP the app is just a video surface. Returning here keeps the

--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -600,8 +600,7 @@ fun MusicApp(
         onPipStateChanged(
             overlayVideo != null &&
                 isVideoOverlayExpanded &&
-                videoIsPlaying &&
-                pipBounds?.isEmpty == false,
+                videoIsPlaying,
             pipAspectRatio,
             pipBounds
         )

--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -628,10 +628,10 @@ fun MusicApp(
         onOpenChannel = openChannel
     )
 
-    // Drives the PiP window's shape and its transport controls. Composed above
-    // the early return on purpose: everything below it is torn out of the
-    // composition the moment PiP starts, which is what used to unregister the
-    // receiver behind the PiP play/pause button and leave it inert.
+    // Drives the PiP window's shape and keeps its transport icons current.
+    // Composed above the early return because everything below it is torn out
+    // the moment PiP starts. Button input itself goes straight to the video
+    // media service and therefore does not depend on this UI lifetime.
     com.ivor.ivormusic.ui.video.VideoPipController(viewModel = videoPlayerViewModel)
 
     // In system PiP the app is just a video surface. Returning here keeps the

--- a/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
+++ b/app/src/main/java/com/ivor/ivormusic/MainActivity.kt
@@ -103,10 +103,9 @@ class MainActivity : ComponentActivity() {
     // any gap around the video showed app chrome instead of black.
     private var isInPipMode by androidx.compose.runtime.mutableStateOf(false)
 
-    // Set by the video player so onUserLeaveHint can enter PiP with the right
-    // window shape on Android 11, where setAutoEnterEnabled does not exist.
-    private var pipVideoAspectRatio: Float? = null
-    private var pipVideoBounds: android.graphics.Rect? = null
+    // Set by the video player so onUserLeaveHint can enter PiP on Android 11,
+    // where setAutoEnterEnabled does not exist. The controller has already
+    // installed the active surface bounds and the full transport action set.
     private var pipEligible = false
 
     /**
@@ -195,11 +194,7 @@ class MainActivity : ComponentActivity() {
                         pendingSharedLink = pendingSharedLink,
                         isInPipMode = isInPipMode,
                         appTimeLocked = appTimeLocked,
-                        onPipStateChanged = { eligible, aspectRatio, bounds ->
-                            pipEligible = eligible
-                            pipVideoAspectRatio = aspectRatio
-                            pipVideoBounds = bounds
-                        },
+                        onPipStateChanged = { eligible -> pipEligible = eligible },
                         currentThemeMode = themeMode,
                         onThemeModeChange = { themeViewModel.setThemeMode(it) },
                         amoledTheme = amoledTheme,
@@ -370,7 +365,7 @@ class MainActivity : ComponentActivity() {
     override fun onUserLeaveHint() {
         super.onUserLeaveHint()
         if (!pipEligible || isInPipMode || isInPictureInPictureMode) return
-        enterPipMode(this, pipVideoAspectRatio, pipVideoBounds)
+        enterPipMode(this)
     }
 
     /**
@@ -408,7 +403,7 @@ fun MusicApp(
      * only consumer is this overlay.
      */
     appTimeLocked: Boolean = false,
-    onPipStateChanged: (eligible: Boolean, aspectRatio: Float?, bounds: android.graphics.Rect?) -> Unit,
+    onPipStateChanged: (eligible: Boolean) -> Unit,
     currentThemeMode: ThemeMode,
     onThemeModeChange: (ThemeMode) -> Unit,
     amoledTheme: Boolean,
@@ -594,16 +589,15 @@ fun MusicApp(
 
     // Keep the Activity's PiP inputs current. It needs them outside the
     // composition, in onUserLeaveHint, where there is no way to read state.
-    val pipAspectRatio by videoPlayerViewModel.videoAspectRatio.collectAsState()
     val pipBounds by videoPlayerViewModel.videoSurfaceBounds.collectAsState()
+    val miniPipBounds by videoPlayerViewModel.miniVideoSurfaceBounds.collectAsState()
     val videoIsPlaying by videoPlayerViewModel.isPlaying.collectAsState()
+    val activePipBounds = if (isVideoOverlayExpanded) pipBounds else miniPipBounds
     androidx.compose.runtime.SideEffect {
         onPipStateChanged(
             overlayVideo != null &&
-                isVideoOverlayExpanded &&
-                videoIsPlaying,
-            pipAspectRatio,
-            pipBounds
+                videoIsPlaying &&
+                activePipBounds?.isEmpty == false
         )
     }
 

--- a/app/src/main/java/com/ivor/ivormusic/data/VideoItem.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/VideoItem.kt
@@ -294,6 +294,52 @@ data class VideoChapter(
 )
 
 /**
+ * A YouTube storyboard sprite used while scrubbing the video timeline.
+ *
+ * NewPipe returns the sprite pages as part of the same extraction that resolves
+ * playback, so this adds no second player request. [durationPerFrameMs] maps a
+ * requested playback position to one cell inside one of [pageUrls].
+ */
+data class VideoSeekPreview(
+    val pageUrls: List<String>,
+    val frameWidthPx: Int,
+    val frameHeightPx: Int,
+    val framesPerPageX: Int,
+    val framesPerPageY: Int,
+    val totalFrameCount: Int,
+    val durationPerFrameMs: Int,
+) {
+    val isUsable: Boolean
+        get() = pageUrls.isNotEmpty() &&
+            frameWidthPx > 0 && frameHeightPx > 0 &&
+            framesPerPageX > 0 && framesPerPageY > 0 &&
+            totalFrameCount > 0 && durationPerFrameMs > 0
+
+    fun frameAt(positionMs: Long): VideoSeekPreviewFrame? {
+        if (!isUsable) return null
+        val frameIndex = (positionMs.coerceAtLeast(0L) / durationPerFrameMs)
+            .coerceAtMost((totalFrameCount - 1).toLong())
+            .toInt()
+        val framesPerPage = framesPerPageX * framesPerPageY
+        val pageIndex = frameIndex / framesPerPage
+        val indexOnPage = frameIndex % framesPerPage
+        return pageUrls.getOrNull(pageIndex)?.let { url ->
+            VideoSeekPreviewFrame(
+                pageUrl = url,
+                column = indexOnPage % framesPerPageX,
+                row = indexOnPage / framesPerPageX,
+            )
+        }
+    }
+}
+
+data class VideoSeekPreviewFrame(
+    val pageUrl: String,
+    val column: Int,
+    val row: Int,
+)
+
+/**
  * Everything the video player needs from a single watch-next (/next) call:
  * engagement state, enriched metadata, related videos and chapters.
  */

--- a/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
@@ -4446,6 +4446,31 @@ class YouTubeRepository(private val context: Context) {
         val extractor = ytService.getStreamExtractor("https://www.youtube.com/watch?v=$videoId")
         extractor.fetchPage()
 
+        // Storyboards ride the same extraction as the stream URLs. Prefer the
+        // largest usable frameset so a fullscreen scrub preview stays sharp;
+        // failure is best-effort and must never hold playback resolution up.
+        cachedSeekPreview = runCatching {
+            extractor.frames
+                .asSequence()
+                .filter {
+                    it.urls.isNotEmpty() && it.frameWidth > 0 && it.frameHeight > 0 &&
+                        it.framesPerPageX > 0 && it.framesPerPageY > 0 &&
+                        it.totalCount > 0 && it.durationPerFrame > 0
+                }
+                .maxByOrNull { it.frameWidth * it.frameHeight }
+                ?.let {
+                    videoId to VideoSeekPreview(
+                        pageUrls = it.urls,
+                        frameWidthPx = it.frameWidth,
+                        frameHeightPx = it.frameHeight,
+                        framesPerPageX = it.framesPerPageX,
+                        framesPerPageY = it.framesPerPageY,
+                        totalFrameCount = it.totalCount,
+                        durationPerFrameMs = it.durationPerFrame,
+                    )
+                }
+        }.getOrNull()
+
         val videoOnlyStreams = extractor.videoOnlyStreams
         val muxedStreams = extractor.videoStreams
         val isLiveStream = extractor.streamType == StreamType.LIVE_STREAM ||
@@ -4562,6 +4587,13 @@ class YouTubeRepository(private val context: Context) {
                     .thenByDescending { fps(it.resolution) }
             )
     }
+
+    @Volatile
+    private var cachedSeekPreview: Pair<String, VideoSeekPreview>? = null
+
+    /** Storyboard harvested by the most recent NewPipe stream extraction. */
+    fun getCachedSeekPreview(videoId: String): VideoSeekPreview? =
+        cachedSeekPreview?.takeIf { it.first == videoId }?.second
 
     /**
      * Resolve the full video quality ladder via InnerTube: ANDROID_VR first

--- a/app/src/main/java/com/ivor/ivormusic/service/VideoPlaybackService.kt
+++ b/app/src/main/java/com/ivor/ivormusic/service/VideoPlaybackService.kt
@@ -125,24 +125,6 @@ class VideoPlaybackService : MediaSessionService() {
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? = session
 
     /**
-     * PiP RemoteActions arrive here directly instead of passing through an
-     * Activity- or Compose-owned receiver. The service already represents this
-     * exact player to Android, so its lifetime is the stable control boundary
-     * while the normal app UI is replaced by the video-only PiP surface.
-     */
-    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val player = session?.player ?: pendingPlayer
-        when (intent?.action) {
-            ACTION_PLAY -> player?.play()
-            ACTION_PAUSE -> player?.pause()
-            ACTION_REWIND -> player?.seekBack()
-            ACTION_FORWARD -> player?.seekForward()
-            else -> return super.onStartCommand(intent, flags, startId)
-        }
-        return START_NOT_STICKY
-    }
-
-    /**
      * Swiped out of recents. The player belongs to the ViewModel, which is
      * being torn down with the task, so pause and go away rather than leaving
      * an undismissable foreground notification behind.
@@ -257,8 +239,6 @@ class VideoPlaybackService : MediaSessionService() {
 
         const val ACTION_REWIND = "com.ivor.ivormusic.VIDEO_REWIND"
         const val ACTION_FORWARD = "com.ivor.ivormusic.VIDEO_FORWARD"
-        const val ACTION_PLAY = "com.ivor.ivormusic.VIDEO_PLAY"
-        const val ACTION_PAUSE = "com.ivor.ivormusic.VIDEO_PAUSE"
 
         @Volatile
         private var instance: VideoPlaybackService? = null

--- a/app/src/main/java/com/ivor/ivormusic/service/VideoPlaybackService.kt
+++ b/app/src/main/java/com/ivor/ivormusic/service/VideoPlaybackService.kt
@@ -125,6 +125,24 @@ class VideoPlaybackService : MediaSessionService() {
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? = session
 
     /**
+     * PiP RemoteActions arrive here directly instead of passing through an
+     * Activity- or Compose-owned receiver. The service already represents this
+     * exact player to Android, so its lifetime is the stable control boundary
+     * while the normal app UI is replaced by the video-only PiP surface.
+     */
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val player = session?.player ?: pendingPlayer
+        when (intent?.action) {
+            ACTION_PLAY -> player?.play()
+            ACTION_PAUSE -> player?.pause()
+            ACTION_REWIND -> player?.seekBack()
+            ACTION_FORWARD -> player?.seekForward()
+            else -> return super.onStartCommand(intent, flags, startId)
+        }
+        return START_NOT_STICKY
+    }
+
+    /**
      * Swiped out of recents. The player belongs to the ViewModel, which is
      * being torn down with the task, so pause and go away rather than leaving
      * an undismissable foreground notification behind.
@@ -239,6 +257,8 @@ class VideoPlaybackService : MediaSessionService() {
 
         const val ACTION_REWIND = "com.ivor.ivormusic.VIDEO_REWIND"
         const val ACTION_FORWARD = "com.ivor.ivormusic.VIDEO_FORWARD"
+        const val ACTION_PLAY = "com.ivor.ivormusic.VIDEO_PLAY"
+        const val ACTION_PAUSE = "com.ivor.ivormusic.VIDEO_PAUSE"
 
         @Volatile
         private var instance: VideoPlaybackService? = null

--- a/app/src/main/java/com/ivor/ivormusic/service/VideoPlaybackService.kt
+++ b/app/src/main/java/com/ivor/ivormusic/service/VideoPlaybackService.kt
@@ -6,6 +6,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.media3.common.ForwardingPlayer
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.CommandButton
@@ -47,6 +48,7 @@ import com.ivor.ivormusic.R
 class VideoPlaybackService : MediaSessionService() {
 
     private var session: MediaSession? = null
+    private var sessionSourcePlayer: Player? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -88,9 +90,15 @@ class VideoPlaybackService : MediaSessionService() {
      */
     private fun ensureSession(player: Player) {
         session?.let { existing ->
-            if (existing.player === player) return
+            if (sessionSourcePlayer === player) return
             releaseSession()
         }
+
+        // Some OEM PiP implementations ignore PictureInPictureParams actions
+        // whenever an active MediaSession exists and render only that session's
+        // standard previous/play/next row. Present those standard commands as
+        // 10-second seeks without changing the ExoPlayer owned by the ViewModel.
+        val systemPlayer = VideoSeekForwardingPlayer(player)
 
         val sessionIntent = PendingIntent.getActivity(
             this,
@@ -100,7 +108,7 @@ class VideoPlaybackService : MediaSessionService() {
         )
 
         val built = try {
-            MediaSession.Builder(this, player)
+            MediaSession.Builder(this, systemPlayer)
                 // A process may not hold two sessions with the same id, and
                 // MusicService already owns the default (empty) one.
                 .setId(SESSION_ID)
@@ -114,6 +122,7 @@ class VideoPlaybackService : MediaSessionService() {
             return
         }
         session = built
+        sessionSourcePlayer = player
         // Explicit, not incidental: Media3 registers a session automatically
         // only when a MediaController binds and onGetSession answers. Nothing in
         // Koda binds to this service - the ViewModel already has the player - so
@@ -143,8 +152,46 @@ class VideoPlaybackService : MediaSessionService() {
     private fun releaseSession() {
         val current = session ?: return
         session = null
+        sessionSourcePlayer = null
         runCatching { removeSession(current) }
         current.release()
+    }
+
+    /**
+     * Gives OEM system media controls a previous/play/next fallback while the
+     * underlying one-item ExoPlayer keeps its real queue semantics unchanged.
+     * Previous and next are deliberately ten-second seeks here: playlist queue
+     * advancement belongs to VideoPlayerViewModel, not this borrowed session.
+     */
+    private class VideoSeekForwardingPlayer(player: Player) : ForwardingPlayer(player) {
+        override fun getAvailableCommands(): Player.Commands =
+            super.getAvailableCommands().buildUpon()
+                .add(Player.COMMAND_SEEK_TO_PREVIOUS)
+                .add(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
+                .add(Player.COMMAND_SEEK_TO_NEXT)
+                .add(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
+                .build()
+
+        override fun isCommandAvailable(command: Int): Boolean =
+            when (command) {
+                Player.COMMAND_SEEK_TO_PREVIOUS,
+                Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM,
+                Player.COMMAND_SEEK_TO_NEXT,
+                Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM -> true
+                else -> super.isCommandAvailable(command)
+            }
+
+        override fun hasPreviousMediaItem(): Boolean = true
+
+        override fun hasNextMediaItem(): Boolean = true
+
+        override fun seekToPrevious() = seekBack()
+
+        override fun seekToPreviousMediaItem() = seekBack()
+
+        override fun seekToNext() = seekForward()
+
+        override fun seekToNextMediaItem() = seekForward()
     }
 
     /**
@@ -183,26 +230,16 @@ class VideoPlaybackService : MediaSessionService() {
                         .add(SessionCommand(ACTION_FORWARD, Bundle.EMPTY))
                         .build()
                 )
-                // The video player holds exactly one item, so "previous" only
-                // ever seeks to zero and "next" is permanently dead. Withdrawing
-                // both is what leaves room for the skip pair below, and stops a
-                // car head unit from offering a track-change that does nothing.
-                //
-                // Still true with playlist queues: a VideoQueue lives in the
-                // ViewModel above the player, and each entry is loaded as a
-                // fresh single-item media source, so the *player's* transport
-                // commands really would do nothing. Surfacing queue skips here
-                // means a stable ForwardingPlayer wrapping the ViewModel's
-                // player and reporting has/seekToNext through it - worth doing,
-                // but it changes what the `existing.player === player` identity
-                // check in ensureSession compares, so it is not a two-line
-                // change and is deliberately not done here.
+                // Xiaomi and some other OEM PiP menus prefer standard session
+                // controls over the three custom PiP RemoteActions. The session
+                // wrapper maps this previous/next pair to 10-second seeks, so
+                // either system UI path controls the same underlying player.
                 .setAvailablePlayerCommands(
                     MediaSession.ConnectionResult.DEFAULT_PLAYER_COMMANDS.buildUpon()
-                        .remove(Player.COMMAND_SEEK_TO_PREVIOUS)
-                        .remove(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
-                        .remove(Player.COMMAND_SEEK_TO_NEXT)
-                        .remove(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
+                        .add(Player.COMMAND_SEEK_TO_PREVIOUS)
+                        .add(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
+                        .add(Player.COMMAND_SEEK_TO_NEXT)
+                        .add(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
                         .build()
                 )
                 .build()

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/MiniVideoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/MiniVideoPlayerContent.kt
@@ -38,6 +38,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -223,6 +225,20 @@ private fun MiniVideoSurface(
         modifier = Modifier
             .width(MINI_VIDEO_THUMB_WIDTH)
             .aspectRatio(16f / 9f)
+            // PiP entry from the collapsed player must animate from the video
+            // thumbnail, never from a stale expanded-player rectangle or the
+            // whole activity. Window coordinates are what Android expects.
+            .onGloballyPositioned { coordinates ->
+                val bounds = coordinates.boundsInWindow()
+                viewModel.setMiniVideoSurfaceBounds(
+                    android.graphics.Rect(
+                        bounds.left.toInt(),
+                        bounds.top.toInt(),
+                        bounds.right.toInt(),
+                        bounds.bottom.toInt(),
+                    )
+                )
+            }
             .clip(RoundedCornerShape(12.dp))
             // Letterbox bars are the absence of picture, not a themed surface,
             // so they stay black in either theme. The documented exception to

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPipController.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPipController.kt
@@ -9,27 +9,24 @@ import android.content.Intent
 import android.graphics.drawable.Icon
 import android.os.Build
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.media3.common.util.UnstableApi
 import com.ivor.ivormusic.R
+import com.ivor.ivormusic.service.VideoPlaybackService
 
 /**
  * Everything that keeps the system Picture-in-Picture window in sync with the
- * video player: its shape, its transport controls, and the receiver those
- * controls fire into.
+ * video player: its shape and its transport controls.
  *
  * This has to be composed **above** MainActivity's `if (isInPipMode) return`,
  * and that is the whole reason it is its own composable rather than a block
  * inside [VideoPlayerOverlay]. The overlay is part of the app UI that PiP
- * replaces, so entering PiP tore it out of the composition, which disposed the
- * broadcast receiver and unregistered it - the play/pause button in the PiP
- * window fired an intent nothing was listening for, and did nothing. The params
- * effect went with it, so even a working button could never have flipped its
- * own icon between play and pause.
+ * replaces, so entering PiP tears it out of the composition. The actions target
+ * [VideoPlaybackService] directly rather than relying on any UI-owned receiver;
+ * this controller remains here so their icons track play/pause state in PiP.
  *
  * Being composed for the whole life of the player also means the params are
  * kept honest when there is no video: auto-enter used to stay armed after the
@@ -52,37 +49,6 @@ fun VideoPipController(viewModel: VideoPlayerViewModel) {
     val videoAspectRatio by viewModel.videoAspectRatio.collectAsState()
     val videoBounds by viewModel.videoSurfaceBounds.collectAsState()
     val miniVideoBounds by viewModel.miniVideoSurfaceBounds.collectAsState()
-
-    val packageName = context.packageName
-
-    // Registered for as long as a video player exists, PiP or not. Actions are
-    // package-scoped so no other app can drive playback through them.
-    DisposableEffect(context, viewModel) {
-        val receiver = object : android.content.BroadcastReceiver() {
-            override fun onReceive(ctx: android.content.Context?, intent: Intent?) {
-                when (intent?.action) {
-                    "$packageName.$ACTION_PLAY" -> viewModel.exoPlayer?.play()
-                    "$packageName.$ACTION_PAUSE" -> viewModel.exoPlayer?.pause()
-                    "$packageName.$ACTION_REWIND" ->
-                        viewModel.seekBy(-VideoPlayerViewModel.SEEK_STEP_MS)
-                    "$packageName.$ACTION_FORWARD" ->
-                        viewModel.seekBy(VideoPlayerViewModel.SEEK_STEP_MS)
-                }
-            }
-        }
-        val filter = android.content.IntentFilter().apply {
-            addAction("$packageName.$ACTION_PLAY")
-            addAction("$packageName.$ACTION_PAUSE")
-            addAction("$packageName.$ACTION_REWIND")
-            addAction("$packageName.$ACTION_FORWARD")
-        }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            context.registerReceiver(receiver, filter, android.content.Context.RECEIVER_NOT_EXPORTED)
-        } else {
-            context.registerReceiver(receiver, filter)
-        }
-        onDispose { runCatching { context.unregisterReceiver(receiver) } }
-    }
 
     // PictureInPictureParams live on the Activity and are sticky. Update them
     // synchronously after every successful composition instead of from a
@@ -107,7 +73,7 @@ fun VideoPipController(viewModel: VideoPlayerViewModel) {
             builder.setActions(emptyList<RemoteAction>())
         } else {
             builder.setAspectRatio(pipAspectRatio(videoAspectRatio))
-            builder.setActions(pipActions(activity, packageName, isPlaying))
+            builder.setActions(pipActions(activity, isPlaying))
 
             // Animate the PiP window out of the video rather than out of the
             // whole activity window. Without a source rect the system scales
@@ -157,13 +123,18 @@ fun VideoPipController(viewModel: VideoPlayerViewModel) {
  */
 private fun pipActions(
     activity: androidx.activity.ComponentActivity,
-    packageName: String,
     isPlaying: Boolean
 ): List<RemoteAction> {
     val playPause = if (isPlaying) {
-        remoteAction(activity, packageName, ACTION_PAUSE, R.drawable.ic_media_pause, "Pause")
+        remoteAction(
+            activity, VideoPlaybackService.ACTION_PAUSE,
+            R.drawable.ic_media_pause, "Pause"
+        )
     } else {
-        remoteAction(activity, packageName, ACTION_PLAY, R.drawable.ic_media_play, "Play")
+        remoteAction(
+            activity, VideoPlaybackService.ACTION_PLAY,
+            R.drawable.ic_media_play, "Play"
+        )
     }
 
     val maxActions = try {
@@ -173,12 +144,12 @@ private fun pipActions(
     }
     val actions = listOf(
         remoteAction(
-            activity, packageName, ACTION_REWIND,
+            activity, VideoPlaybackService.ACTION_REWIND,
             R.drawable.ic_media_replay_10, "Back 10 seconds"
         ),
         playPause,
         remoteAction(
-            activity, packageName, ACTION_FORWARD,
+            activity, VideoPlaybackService.ACTION_FORWARD,
             R.drawable.ic_media_forward_10, "Forward 10 seconds"
         )
     )
@@ -191,22 +162,20 @@ private fun pipActions(
 
 private fun remoteAction(
     activity: androidx.activity.ComponentActivity,
-    packageName: String,
     action: String,
     iconRes: Int,
     label: String
 ): RemoteAction {
-    val intent = PendingIntent.getBroadcast(
+    // The explicit service is already publishing this ExoPlayer through its
+    // MediaSession. Unlike a dynamic receiver, it does not belong to a Compose
+    // subtree or Activity UI that an OEM may suspend while PiP is active.
+    val intent = PendingIntent.getService(
         activity,
         action.hashCode(),
-        Intent("$packageName.$action").setPackage(packageName),
+        Intent(activity, VideoPlaybackService::class.java).setAction(action),
         PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
     )
     return RemoteAction(Icon.createWithResource(activity, iconRes), label, label, intent)
 }
 
 private const val TAG = "VideoPipController"
-private const val ACTION_PLAY = "PIP_PLAY"
-private const val ACTION_PAUSE = "PIP_PAUSE"
-private const val ACTION_REWIND = "PIP_REWIND"
-private const val ACTION_FORWARD = "PIP_FORWARD"

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPipController.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPipController.kt
@@ -51,6 +51,7 @@ fun VideoPipController(viewModel: VideoPlayerViewModel) {
     val isExpanded by viewModel.isExpanded.collectAsState()
     val videoAspectRatio by viewModel.videoAspectRatio.collectAsState()
     val videoBounds by viewModel.videoSurfaceBounds.collectAsState()
+    val miniVideoBounds by viewModel.miniVideoSurfaceBounds.collectAsState()
 
     val packageName = context.packageName
 
@@ -90,10 +91,11 @@ fun VideoPipController(viewModel: VideoPlayerViewModel) {
     // system capture the mini player and the entire app hierarchy into PiP.
     SideEffect {
         val builder = PictureInPictureParams.Builder()
-        val validBounds = videoBounds?.takeIf { !it.isEmpty }
+        val validBounds = (if (isExpanded) videoBounds else miniVideoBounds)
+            ?.takeIf { !it.isEmpty }
         val autoEnterEligible = currentVideo != null &&
-            isExpanded &&
-            isPlaying
+            isPlaying &&
+            validBounds != null
 
         if (currentVideo == null) {
             // No video: disarm. Auto-enter is sticky, so a player closed while
@@ -119,12 +121,12 @@ fun VideoPipController(viewModel: VideoPlayerViewModel) {
             if (autoEnterEligible) validBounds?.let { builder.setSourceRectHint(it) }
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                // Only auto-enter PiP while the full player is on screen.
-                // Auto-entering from the mini player captures the whole app UI
-                // into the PiP window instead of just the video surface. A
-                // paused player is also ineligible: its newly attached PiP
-                // SurfaceView may not produce a fresh frame to replace the
-                // system's transition snapshot.
+                // Both expanded and collapsed playback are eligible, but only
+                // after that layout's own video surface has reported bounds.
+                // The source rect makes the transition snapshot video-only;
+                // MainActivity then replaces the app with PipVideoSurface.
+                // A paused player remains ineligible because its newly attached
+                // PiP SurfaceView may not produce a fresh replacement frame.
                 builder.setAutoEnterEnabled(autoEnterEligible)
                 // The content is a video, not a layout that needs to reflow, so
                 // let the system crossfade the resize instead of re-laying out.
@@ -149,9 +151,9 @@ fun VideoPipController(viewModel: VideoPlayerViewModel) {
  * skips live here as buttons rather than as the gesture they are on the full
  * player.
  *
- * Devices advertise how many actions they will render (three on every current
- * Android build). If a device offers fewer, play/pause is the one control that
- * must survive, so the seeks are dropped rather than the list truncated.
+ * Devices advertise how many actions they will render. Play/pause is the one
+ * control that must survive; a two-slot OEM still gets forward seek rather
+ * than unnecessarily collapsing the row to a single button.
  */
 private fun pipActions(
     activity: androidx.activity.ComponentActivity,
@@ -169,9 +171,7 @@ private fun pipActions(
     } catch (e: Exception) {
         3
     }
-    if (maxActions < 3) return listOf(playPause)
-
-    return listOf(
+    val actions = listOf(
         remoteAction(
             activity, packageName, ACTION_REWIND,
             R.drawable.ic_media_replay_10, "Back 10 seconds"
@@ -182,6 +182,11 @@ private fun pipActions(
             R.drawable.ic_media_forward_10, "Forward 10 seconds"
         )
     )
+    return when {
+        maxActions >= 3 -> actions
+        maxActions == 2 -> listOf(playPause, actions.last())
+        else -> listOf(playPause)
+    }
 }
 
 private fun remoteAction(

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPipController.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPipController.kt
@@ -93,8 +93,7 @@ fun VideoPipController(viewModel: VideoPlayerViewModel) {
         val validBounds = videoBounds?.takeIf { !it.isEmpty }
         val autoEnterEligible = currentVideo != null &&
             isExpanded &&
-            isPlaying &&
-            validBounds != null
+            isPlaying
 
         if (currentVideo == null) {
             // No video: disarm. Auto-enter is sticky, so a player closed while

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPipController.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPipController.kt
@@ -9,24 +9,25 @@ import android.content.Intent
 import android.graphics.drawable.Icon
 import android.os.Build
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.media3.common.util.UnstableApi
 import com.ivor.ivormusic.R
-import com.ivor.ivormusic.service.VideoPlaybackService
 
 /**
  * Everything that keeps the system Picture-in-Picture window in sync with the
- * video player: its shape and its transport controls.
+ * video player: its shape, its transport controls, and the receiver those
+ * controls fire into.
  *
  * This has to be composed **above** MainActivity's `if (isInPipMode) return`,
  * and that is the whole reason it is its own composable rather than a block
  * inside [VideoPlayerOverlay]. The overlay is part of the app UI that PiP
- * replaces, so entering PiP tears it out of the composition. The actions target
- * [VideoPlaybackService] directly rather than relying on any UI-owned receiver;
- * this controller remains here so their icons track play/pause state in PiP.
+ * replaces, so entering PiP tears it out of the composition. This controller
+ * stays above that replacement so its package-scoped action receiver remains
+ * registered and its icons continue to track play/pause state in PiP.
  *
  * Being composed for the whole life of the player also means the params are
  * kept honest when there is no video: auto-enter used to stay armed after the
@@ -49,6 +50,42 @@ fun VideoPipController(viewModel: VideoPlayerViewModel) {
     val videoAspectRatio by viewModel.videoAspectRatio.collectAsState()
     val videoBounds by viewModel.videoSurfaceBounds.collectAsState()
     val miniVideoBounds by viewModel.miniVideoSurfaceBounds.collectAsState()
+
+    val packageName = context.packageName
+
+    // This is the known-good pre-redesign control path. Keep the receiver in
+    // the controller above MainActivity's PiP early return so swapping the app
+    // UI for PipVideoSurface cannot unregister the buttons behind the window.
+    DisposableEffect(context, viewModel, packageName) {
+        val receiver = object : android.content.BroadcastReceiver() {
+            override fun onReceive(ctx: android.content.Context?, intent: Intent?) {
+                when (intent?.action) {
+                    "$packageName.$ACTION_PLAY" -> viewModel.exoPlayer?.play()
+                    "$packageName.$ACTION_PAUSE" -> viewModel.exoPlayer?.pause()
+                    "$packageName.$ACTION_REWIND" ->
+                        viewModel.seekBy(-VideoPlayerViewModel.SEEK_STEP_MS)
+                    "$packageName.$ACTION_FORWARD" ->
+                        viewModel.seekBy(VideoPlayerViewModel.SEEK_STEP_MS)
+                }
+            }
+        }
+        val filter = android.content.IntentFilter().apply {
+            addAction("$packageName.$ACTION_PLAY")
+            addAction("$packageName.$ACTION_PAUSE")
+            addAction("$packageName.$ACTION_REWIND")
+            addAction("$packageName.$ACTION_FORWARD")
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.registerReceiver(
+                receiver,
+                filter,
+                android.content.Context.RECEIVER_NOT_EXPORTED
+            )
+        } else {
+            context.registerReceiver(receiver, filter)
+        }
+        onDispose { runCatching { context.unregisterReceiver(receiver) } }
+    }
 
     // PictureInPictureParams live on the Activity and are sticky. Update them
     // synchronously after every successful composition instead of from a
@@ -73,7 +110,7 @@ fun VideoPipController(viewModel: VideoPlayerViewModel) {
             builder.setActions(emptyList<RemoteAction>())
         } else {
             builder.setAspectRatio(pipAspectRatio(videoAspectRatio))
-            builder.setActions(pipActions(activity, isPlaying))
+            builder.setActions(pipActions(activity, packageName, isPlaying))
 
             // Animate the PiP window out of the video rather than out of the
             // whole activity window. Without a source rect the system scales
@@ -125,28 +162,29 @@ fun VideoPipController(viewModel: VideoPlayerViewModel) {
  */
 private fun pipActions(
     activity: androidx.activity.ComponentActivity,
+    packageName: String,
     isPlaying: Boolean
 ): List<RemoteAction> {
     val playPause = if (isPlaying) {
         remoteAction(
-            activity, VideoPlaybackService.ACTION_PAUSE,
+            activity, packageName, ACTION_PAUSE,
             R.drawable.ic_media_pause, "Pause"
         )
     } else {
         remoteAction(
-            activity, VideoPlaybackService.ACTION_PLAY,
+            activity, packageName, ACTION_PLAY,
             R.drawable.ic_media_play, "Play"
         )
     }
 
     return listOf(
         remoteAction(
-            activity, VideoPlaybackService.ACTION_REWIND,
+            activity, packageName, ACTION_REWIND,
             R.drawable.ic_media_replay_10, "Back 10 seconds"
         ),
         playPause,
         remoteAction(
-            activity, VideoPlaybackService.ACTION_FORWARD,
+            activity, packageName, ACTION_FORWARD,
             R.drawable.ic_media_forward_10, "Forward 10 seconds"
         )
     )
@@ -154,20 +192,22 @@ private fun pipActions(
 
 private fun remoteAction(
     activity: androidx.activity.ComponentActivity,
+    packageName: String,
     action: String,
     iconRes: Int,
     label: String
 ): RemoteAction {
-    // The explicit service is already publishing this ExoPlayer through its
-    // MediaSession. Unlike a dynamic receiver, it does not belong to a Compose
-    // subtree or Activity UI that an OEM may suspend while PiP is active.
-    val intent = PendingIntent.getService(
+    val intent = PendingIntent.getBroadcast(
         activity,
         action.hashCode(),
-        Intent(activity, VideoPlaybackService::class.java).setAction(action),
+        Intent("$packageName.$action").setPackage(packageName),
         PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
     )
     return RemoteAction(Icon.createWithResource(activity, iconRes), label, label, intent)
 }
 
 private const val TAG = "VideoPipController"
+private const val ACTION_PLAY = "PIP_PLAY"
+private const val ACTION_PAUSE = "PIP_PAUSE"
+private const val ACTION_REWIND = "PIP_REWIND"
+private const val ACTION_FORWARD = "PIP_FORWARD"

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPipController.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPipController.kt
@@ -117,9 +117,11 @@ fun VideoPipController(viewModel: VideoPlayerViewModel) {
  * skips live here as buttons rather than as the gesture they are on the full
  * player.
  *
- * Devices advertise how many actions they will render. Play/pause is the one
- * control that must survive; a two-slot OEM still gets forward seek rather
- * than unnecessarily collapsing the row to a single button.
+ * Always publish the complete row. Some OEM builds report an action capacity
+ * of one even though their PiP menu renders the normal three slots; trusting
+ * that value made Koda voluntarily remove both seeks on those devices. The
+ * window manager remains free to lay out what it can, but the actions handed
+ * to it are never incomplete.
  */
 private fun pipActions(
     activity: androidx.activity.ComponentActivity,
@@ -137,12 +139,7 @@ private fun pipActions(
         )
     }
 
-    val maxActions = try {
-        activity.maxNumPictureInPictureActions
-    } catch (e: Exception) {
-        3
-    }
-    val actions = listOf(
+    return listOf(
         remoteAction(
             activity, VideoPlaybackService.ACTION_REWIND,
             R.drawable.ic_media_replay_10, "Back 10 seconds"
@@ -153,11 +150,6 @@ private fun pipActions(
             R.drawable.ic_media_forward_10, "Forward 10 seconds"
         )
     )
-    return when {
-        maxActions >= 3 -> actions
-        maxActions == 2 -> listOf(playPause, actions.last())
-        else -> listOf(playPause)
-    }
 }
 
 private fun remoteAction(

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
@@ -113,6 +113,7 @@ fun VideoPlayerContent(
     val relatedVideos by viewModel.relatedVideos.collectAsState()
     val queue by viewModel.queue.collectAsState()
     val chapters by viewModel.chapters.collectAsState()
+    val seekPreview by viewModel.seekPreview.collectAsState()
     val captionTracks by viewModel.captionTracks.collectAsState()
     val selectedCaption by viewModel.selectedCaption.collectAsState()
     val captionCues by viewModel.captionCues.collectAsState()
@@ -361,7 +362,11 @@ fun VideoPlayerContent(
             window?.let { WindowCompat.setDecorFitsSystemWindows(it, false) }
             // Draw into the camera cutout area too, otherwise the system
             // letterboxes the window and background shows around the notch
-            setCutoutMode(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES)
+            // The moving image is background content and should use every
+            // physical pixel, including waterfall/corner-cutout layouts. The
+            // controls independently apply displayCutoutPadding, so only the
+            // video and its gradients extend behind camera hardware.
+            setCutoutMode(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS)
             // A vertical video fills the screen held upright, so fullscreen
             // holds it there rather than rotating into a letterboxed strip.
             // Everything else gets sensor landscape, both directions, like
@@ -570,6 +575,7 @@ fun VideoPlayerContent(
                 duration = duration,
                 progress = progress,
                 bufferedProgress = bufferedProgress,
+                seekPreview = seekPreview,
                 videoTitle = currentVideo.title,
                 onPlayPause = { viewModel.togglePlayPause() },
                 onSeek = { newProgress -> exoPlayer.seekTo((newProgress * duration).toLong()) },
@@ -585,6 +591,13 @@ fun VideoPlayerContent(
                 },
                 onSettings = { showQualitySheet = true },
                 onLoopToggle = { viewModel.toggleLooping() },
+                showPipButton = pipSupported,
+                onPipClick = {
+                    val host = activity as? androidx.activity.ComponentActivity
+                    if (host != null) {
+                        enterPipMode(host, videoAspectRatio, videoSurfaceBounds)
+                    }
+                },
                 showTimedCommentsButton = timedCommentsFeatureEnabled,
                 timedCommentsActive = timedCommentsActive,
                 onTimedCommentsToggle = { timedCommentsActive = !timedCommentsActive },
@@ -881,6 +894,7 @@ fun VideoPlayerContent(
                         duration = duration,
                         progress = progress,
                         bufferedProgress = bufferedProgress,
+                        seekPreview = seekPreview,
                         videoTitle = currentVideo.title,
                         onPlayPause = { viewModel.togglePlayPause() },
                         onSeek = { newProgress -> exoPlayer.seekTo((newProgress * duration).toLong()) },

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
@@ -118,7 +118,6 @@ fun VideoPlayerContent(
     val selectedCaption by viewModel.selectedCaption.collectAsState()
     val captionCues by viewModel.captionCues.collectAsState()
     val videoAspectRatio by viewModel.videoAspectRatio.collectAsState()
-    val videoSurfaceBounds by viewModel.videoSurfaceBounds.collectAsState()
 
     // PiP is a device capability, not a given: Android TV and a few OEM builds
     // ship without it, and the button must not sit there doing nothing.
@@ -595,7 +594,7 @@ fun VideoPlayerContent(
                 onPipClick = {
                     val host = activity as? androidx.activity.ComponentActivity
                     if (host != null) {
-                        enterPipMode(host, videoAspectRatio, videoSurfaceBounds)
+                        enterPipMode(host)
                     }
                 },
                 showTimedCommentsButton = timedCommentsFeatureEnabled,
@@ -933,7 +932,7 @@ fun VideoPlayerContent(
                         onPipClick = {
                             val host = activity as? androidx.activity.ComponentActivity
                             if (host != null) {
-                                enterPipMode(host, videoAspectRatio, videoSurfaceBounds)
+                                enterPipMode(host)
                             }
                         },
                         minimizeDragEnabled = true,

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerOverlay.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerOverlay.kt
@@ -86,11 +86,8 @@ private const val VIDEO_BACK_PEEK = 0.82f
  * device does not support it), so callers can fall back to doing nothing
  * rather than assuming they are now in PiP.
  */
-fun enterPipMode(
-    activity: androidx.activity.ComponentActivity,
-    videoAspectRatio: Float?,
-    videoBounds: android.graphics.Rect?
-): Boolean {
+@Suppress("DEPRECATION")
+fun enterPipMode(activity: androidx.activity.ComponentActivity): Boolean {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return false
     if (!activity.packageManager.hasSystemFeature(
             android.content.pm.PackageManager.FEATURE_PICTURE_IN_PICTURE
@@ -98,11 +95,12 @@ fun enterPipMode(
     ) return false
 
     return try {
-        val params = PictureInPictureParams.Builder()
-            .setAspectRatio(pipAspectRatio(videoAspectRatio))
-            .apply { videoBounds?.takeIf { !it.isEmpty }?.let { setSourceRectHint(it) } }
-            .build()
-        activity.enterPictureInPictureMode(params)
+        // VideoPipController has already installed the current aspect ratio,
+        // source rectangle and transport actions. Passing a freshly built
+        // params object here used to erase those actions at the moment PiP was
+        // entered, leaving only the system's basic control.
+        activity.enterPictureInPictureMode()
+        true
     } catch (e: Exception) {
         KLog.w("VideoPlayerOverlay", "enterPictureInPictureMode refused", e)
         false

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -150,6 +150,8 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 import coil.compose.AsyncImage
+import coil.request.CachePolicy
+import coil.request.ImageRequest
 import kotlin.math.abs
 import kotlin.math.roundToInt
 import com.ivor.ivormusic.data.LikeStatus
@@ -1185,6 +1187,7 @@ private fun SeekPreviewCard(
     modifier: Modifier = Modifier,
 ) {
     val frame = preview?.frameAt(positionMs)
+    val context = LocalContext.current
     Surface(
         modifier = modifier,
         shape = RoundedCornerShape(10.dp),
@@ -1197,13 +1200,39 @@ private fun SeekPreviewCard(
                 val frameWidth = 144.dp
                 val frameHeight = frameWidth *
                     (preview.frameHeightPx.toFloat() / preview.frameWidthPx.toFloat())
+                val pageRequest = remember(
+                    frame.pageUrl,
+                    preview.frameWidthPx,
+                    preview.frameHeightPx,
+                    preview.framesPerPageX,
+                    preview.framesPerPageY,
+                ) {
+                    ImageRequest.Builder(context)
+                        .data(frame.pageUrl)
+                        // Decode at the storyboard's real dimensions rather
+                        // than the density-scaled size of the Compose grid.
+                        .size(
+                            preview.frameWidthPx * preview.framesPerPageX,
+                            preview.frameHeightPx * preview.framesPerPageY,
+                        )
+                        // A long video can have many multi-megabyte pages. The
+                        // visible painter already owns the current one; keeping
+                        // every page in Coil's memory cache exhausts the 128MB
+                        // heap after a scrub across the timeline. Compressed
+                        // pages remain on disk, so revisiting one avoids network.
+                        .memoryCachePolicy(CachePolicy.DISABLED)
+                        .diskCachePolicy(CachePolicy.ENABLED)
+                        .allowRgb565(true)
+                        .crossfade(false)
+                        .build()
+                }
                 Box(
                     modifier = Modifier
                         .size(frameWidth, frameHeight)
                         .clip(RoundedCornerShape(topStart = 10.dp, topEnd = 10.dp))
                 ) {
                     AsyncImage(
-                        model = frame.pageUrl,
+                        model = pageRequest,
                         contentDescription = null,
                         contentScale = ContentScale.FillBounds,
                         // `size` is capped by the one-frame parent constraints,

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -1205,8 +1206,13 @@ private fun SeekPreviewCard(
                         model = frame.pageUrl,
                         contentDescription = null,
                         contentScale = ContentScale.FillBounds,
+                        // `size` is capped by the one-frame parent constraints,
+                        // which shrinks the whole storyboard into 144dp and
+                        // makes every translated cell except the first blank.
+                        // The sprite must retain its full grid dimensions; the
+                        // clipped parent is the viewport onto the selected cell.
                         modifier = Modifier
-                            .size(
+                            .requiredSize(
                                 frameWidth * preview.framesPerPageX,
                                 frameHeight * preview.framesPerPageY,
                             )

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -42,6 +43,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -154,6 +156,7 @@ import com.ivor.ivormusic.data.ThemePreferences
 import com.ivor.ivormusic.data.VideoChapter
 import com.ivor.ivormusic.data.VideoEngagement
 import com.ivor.ivormusic.data.VideoItem
+import com.ivor.ivormusic.data.VideoSeekPreview
 import com.ivor.ivormusic.data.VttCue
 import com.ivor.ivormusic.data.WebVttParser
 import kotlinx.coroutines.delay
@@ -256,6 +259,7 @@ fun FullscreenPlayerContent(
     duration: Long,
     progress: Float,
     bufferedProgress: Float = 0f,
+    seekPreview: VideoSeekPreview? = null,
     videoTitle: String,
     onPlayPause: () -> Unit,
     onSeek: (Float) -> Unit,
@@ -265,6 +269,8 @@ fun FullscreenPlayerContent(
     onFullscreenToggle: () -> Unit,
     onSettings: () -> Unit,
     onLoopToggle: () -> Unit,
+    showPipButton: Boolean = false,
+    onPipClick: () -> Unit = {},
     showTimedCommentsButton: Boolean = false,
     timedCommentsActive: Boolean = false,
     onTimedCommentsToggle: () -> Unit = {},
@@ -344,6 +350,19 @@ fun FullscreenPlayerContent(
             shapes = stableShapes
         ) {
             Icon(Icons.Rounded.Settings, "Playback settings")
+        }
+
+        if (showPipButton) {
+            FilledTonalIconButton(
+                onClick = onPipClick,
+                colors = IconButtonDefaults.filledTonalIconButtonColors(
+                    containerColor = Color.Black.copy(0.5f),
+                    contentColor = Color.White
+                ),
+                shapes = stableShapes
+            ) {
+                Icon(Icons.Rounded.PictureInPictureAlt, "Picture in picture")
+            }
         }
 
         Box {
@@ -504,34 +523,30 @@ fun FullscreenPlayerContent(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
-                        Surface(
+                        Row(
                             modifier = Modifier.weight(1f),
-                            shape = CircleShape,
-                            color = Color.Black.copy(alpha = 0.46f),
-                            contentColor = Color.White
+                            verticalAlignment = Alignment.CenterVertically
                         ) {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                FilledIconButton(
-                                    onClick = onBack,
-                                    colors = IconButtonDefaults.filledIconButtonColors(
-                                        containerColor = Color.Transparent,
-                                        contentColor = Color.White
-                                    ),
-                                    shapes = stableShapes
-                                ) {
-                                    Icon(Icons.AutoMirrored.Rounded.ArrowBack, "Back")
-                                }
-                                Text(
-                                    text = videoTitle,
-                                    style = MaterialTheme.typography.titleMedium,
-                                    color = Color.White,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier
-                                        .weight(1f)
-                                        .padding(end = 18.dp)
-                                )
+                            FilledIconButton(
+                                onClick = onBack,
+                                colors = IconButtonDefaults.filledIconButtonColors(
+                                    containerColor = Color.Black.copy(alpha = 0.46f),
+                                    contentColor = Color.White
+                                ),
+                                shapes = stableShapes
+                            ) {
+                                Icon(Icons.AutoMirrored.Rounded.ArrowBack, "Back")
                             }
+                            Text(
+                                text = videoTitle,
+                                style = MaterialTheme.typography.titleMedium,
+                                color = Color.White,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(horizontal = 12.dp)
+                            )
                         }
 
                         // Landscape keeps the single row it always had.
@@ -579,7 +594,6 @@ fun FullscreenPlayerContent(
                         isBuffering = isBuffering,
                         onClick = onPlayPause,
                         size = 74.dp,
-                        overVideo = true
                     )
                     if (showQueueControls) {
                         QueueSkipButton(
@@ -674,7 +688,8 @@ fun FullscreenPlayerContent(
                             onSeek = onSeek,
                             modifier = Modifier.weight(1f),
                             chapters = chapters,
-                            durationMs = duration
+                            durationMs = duration,
+                            seekPreview = seekPreview,
                         )
 
                         if (isLive) {
@@ -711,6 +726,7 @@ fun PortraitPlayerContent(
     duration: Long,
     progress: Float,
     bufferedProgress: Float = 0f,
+    seekPreview: VideoSeekPreview? = null,
     videoTitle: String,
     onPlayPause: () -> Unit,
     onSeek: (Float) -> Unit,
@@ -969,7 +985,8 @@ fun PortraitPlayerContent(
                             onSeek = onSeek,
                             modifier = Modifier.weight(1f),
                             chapters = chapters,
-                            durationMs = duration
+                            durationMs = duration,
+                            seekPreview = seekPreview,
                         )
 
                         if (isLive) {
@@ -1063,6 +1080,7 @@ internal fun PlayerSeekBar(
     bufferedProgress: Float = 0f,
     chapters: List<VideoChapter> = emptyList(),
     durationMs: Long = 0L,
+    seekPreview: VideoSeekPreview? = null,
     onTonalSurface: Boolean = false
 ) {
     var isScrubbing by remember { mutableStateOf(false) }
@@ -1084,7 +1102,7 @@ internal fun PlayerSeekBar(
         Color.Black.copy(alpha = 0.85f)
     }
 
-    Box(modifier = modifier) {
+    BoxWithConstraints(modifier = modifier) {
         // Buffered-ahead indicator: a soft white bar from the start to the
         // buffered position, drawn under the Slider. The inactive track is
         // translucent, so the buffered region reads as a brighter segment
@@ -1121,6 +1139,19 @@ internal fun PlayerSeekBar(
             modifier = Modifier.fillMaxWidth()
         )
 
+        if (isScrubbing && durationMs > 0L) {
+            val previewWidth = if (seekPreview?.isUsable == true) 144.dp else 72.dp
+            val previewX = (maxWidth * scrubValue - previewWidth / 2)
+                .coerceIn(0.dp, (maxWidth - previewWidth).coerceAtLeast(0.dp))
+            SeekPreviewCard(
+                preview = seekPreview,
+                positionMs = (scrubValue * durationMs).toLong(),
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .offset(x = previewX, y = if (seekPreview?.isUsable == true) (-126).dp else (-46).dp)
+            )
+        }
+
         // Chapter boundary ticks drawn over the track. Purely decorative; the
         // Canvas has no pointer input so touches still reach the Slider.
         if (chapters.size > 1 && durationMs > 0) {
@@ -1141,6 +1172,56 @@ internal fun PlayerSeekBar(
                     }
                 }
             }
+        }
+    }
+}
+
+/** Storyboard frame (when available) plus the exact target time while dragging. */
+@Composable
+private fun SeekPreviewCard(
+    preview: VideoSeekPreview?,
+    positionMs: Long,
+    modifier: Modifier = Modifier,
+) {
+    val frame = preview?.frameAt(positionMs)
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(10.dp),
+        color = Color.Black.copy(alpha = 0.9f),
+        contentColor = Color.White,
+        shadowElevation = 4.dp,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            if (preview != null && frame != null) {
+                val frameWidth = 144.dp
+                val frameHeight = frameWidth *
+                    (preview.frameHeightPx.toFloat() / preview.frameWidthPx.toFloat())
+                Box(
+                    modifier = Modifier
+                        .size(frameWidth, frameHeight)
+                        .clip(RoundedCornerShape(topStart = 10.dp, topEnd = 10.dp))
+                ) {
+                    AsyncImage(
+                        model = frame.pageUrl,
+                        contentDescription = null,
+                        contentScale = ContentScale.FillBounds,
+                        modifier = Modifier
+                            .size(
+                                frameWidth * preview.framesPerPageX,
+                                frameHeight * preview.framesPerPageY,
+                            )
+                            .offset(
+                                x = -(frameWidth * frame.column),
+                                y = -(frameHeight * frame.row),
+                            )
+                    )
+                }
+            }
+            Text(
+                text = formatDuration(positionMs),
+                style = MaterialTheme.typography.labelMedium,
+                modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
+            )
         }
     }
 }
@@ -2258,7 +2339,7 @@ private fun PlayerOverflowMenu(
     DropdownMenu(
         expanded = expanded,
         onDismissRequest = onDismiss,
-        shape = MaterialTheme.shapes.extraLarge,
+        shape = RoundedCornerShape(12.dp),
         containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
     ) {
         if (showQueue) {
@@ -2690,7 +2771,6 @@ fun ExpressivePlayPauseButton(
     isBuffering: Boolean = false,
     onClick: () -> Unit,
     size: androidx.compose.ui.unit.Dp = 72.dp,
-    overVideo: Boolean = false
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
@@ -2719,20 +2799,17 @@ fun ExpressivePlayPauseButton(
         onClick = onClick,
         modifier = Modifier.size(scale),
         shape = RoundedCornerShape(cornerRadius),
-        color = if (overVideo) Color.Black.copy(alpha = 0.62f)
-            else MaterialTheme.colorScheme.primaryContainer,
+        color = MaterialTheme.colorScheme.primaryContainer,
         interactionSource = interactionSource,
-        contentColor = if (overVideo) Color.White
-            else MaterialTheme.colorScheme.onPrimaryContainer,
-        shadowElevation = 0.dp
+        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        shadowElevation = 6.dp
     ) {
         Box(contentAlignment = Alignment.Center) {
             if (isBuffering && !isPlaying) {
                 // Expressive Loading Indicator
                  LoadingIndicator(
                     modifier = Modifier.size(size * 0.5f),
-                    color = if (overVideo) Color.White
-                        else MaterialTheme.colorScheme.onPrimaryContainer,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
                     polygons = listOf(
                         MaterialShapes.SoftBurst,
                         MaterialShapes.Cookie9Sided,

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
@@ -255,8 +255,20 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
     private val _videoSurfaceBounds = MutableStateFlow<android.graphics.Rect?>(null)
     val videoSurfaceBounds: StateFlow<android.graphics.Rect?> = _videoSurfaceBounds.asStateFlow()
 
+    // Kept separate from the expanded/fullscreen surface bounds. Reusing one
+    // rectangle across both layouts briefly leaves the expanded window bounds
+    // attached to a collapsed player, which lets Android snapshot the whole UI
+    // when Home is pressed during that hand-off.
+    private val _miniVideoSurfaceBounds = MutableStateFlow<android.graphics.Rect?>(null)
+    val miniVideoSurfaceBounds: StateFlow<android.graphics.Rect?> =
+        _miniVideoSurfaceBounds.asStateFlow()
+
     fun setVideoSurfaceBounds(bounds: android.graphics.Rect?) {
         _videoSurfaceBounds.value = bounds
+    }
+
+    fun setMiniVideoSurfaceBounds(bounds: android.graphics.Rect?) {
+        _miniVideoSurfaceBounds.value = bounds
     }
 
     // True while the app is in system Picture-in-Picture. Set by the

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
@@ -35,6 +35,7 @@ import com.ivor.ivormusic.data.TimedComment
 import com.ivor.ivormusic.data.VideoEngagement
 import com.ivor.ivormusic.data.VideoItem
 import com.ivor.ivormusic.data.VideoQuality
+import com.ivor.ivormusic.data.VideoSeekPreview
 import com.ivor.ivormusic.data.VttCue
 import com.ivor.ivormusic.data.YouTubeRepository
 import com.ivor.ivormusic.data.ThemePreferences
@@ -208,6 +209,11 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
     // Chapter markers for the current video (empty when the video has none)
     private val _chapters = MutableStateFlow<List<com.ivor.ivormusic.data.VideoChapter>>(emptyList())
     val chapters: StateFlow<List<com.ivor.ivormusic.data.VideoChapter>> = _chapters.asStateFlow()
+
+    // YouTube storyboard sprite harvested during the stream extraction. Null
+    // for live streams, local downloads and videos that do not expose frames.
+    private val _seekPreview = MutableStateFlow<VideoSeekPreview?>(null)
+    val seekPreview: StateFlow<VideoSeekPreview?> = _seekPreview.asStateFlow()
 
     // Caption/subtitle tracks (loaded lazily when the user opens the CC menu)
     private val _captionTracks = MutableStateFlow<List<CaptionTrack>>(emptyList())
@@ -1295,6 +1301,7 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         resetProgress()
         _relatedVideos.value = emptyList() // Clear previous related
         _chapters.value = emptyList() // Clear previous chapters
+        _seekPreview.value = null // Never show a frame from the previous video
         _captionTracks.value = emptyList() // Clear previous caption tracks
         _selectedCaption.value = null // Captions default off per video
         _isCaptionsLoading.value = false
@@ -1401,6 +1408,7 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
                     // FAST: Get stream URLs only (no metadata, no related, no channel avatar)
                     val qualities = youtubeRepository.getVideoStreamQualities(video.videoId)
                     _availableQualities.value = qualities
+                    _seekPreview.value = youtubeRepository.getCachedSeekPreview(video.videoId)
                     _isLive.value = qualities.any { it.isLive }
                     if (_isLive.value) {
                         // Some entry points do not know a broadcast is live


### PR DESCRIPTION
## Summary
- restore reliable automatic PiP entry and add a direct fullscreen PiP control
- refine fullscreen chrome, cutout handling, overflow corners, and the solid expressive play/pause button
- add storyboard thumbnail and timestamp previews while scrubbing, with a timestamp-only fallback

## Verification
- `./gradlew compileDebugKotlin`
- no emulator run