### PR TITLE
Video player polish and offline download improvements

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -428,6 +428,8 @@ The milestones behind us, kept here so the direction of travel is visible.
 - Local-first lyrics for device songs (`.lrc`/`.ttml` sidecars and embedded tags), multi-provider online fallbacks with TTML, QRC, Enhanced LRC, line and plain text, plus letter-by-letter highlighting from real word timings
 - Full-height expanded music players on Android 11 and 12, measured from the edge-to-edge window rather than the inset-excluding resource configuration
 - In-app video with a personalized feed, chapters, captions, and comments
+- Video scrubbing with chapter-aligned buffering and bounded storyboard previews that stay stable through release, control auto-hide, and rapid video switches
+- A restrained video chrome with one scroll-safe Playback settings surface for secondary controls, plus durable Autoplay and Loop behavior that cannot contradict itself
 - Eight player styles and a 27-palette color system with dynamic color and AMOLED
 - Listening statistics with play charts, streaks, and top artists
 - Offline downloads for music and video, written to the system Downloads folder

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -432,7 +432,7 @@ The milestones behind us, kept here so the direction of travel is visible.
 - A restrained video chrome with one scroll-safe Playback settings surface for secondary controls, plus durable Autoplay and Loop behavior that cannot contradict itself
 - Eight player styles and a 27-palette color system with dynamic color and AMOLED
 - Listening statistics with play charts, streaks, and top artists
-- Offline downloads for music and video, written to the system Downloads folder
+- Offline downloads for music and video, written to the system Downloads folder; music files carry portable title, artist, album, cover art and the best available lyric timing
 - Whole-playlist downloads in both modes, with one background queue, resumable partial batches, per-batch video quality, and honest skips for local music and live video
 - Live streams with live chat, including a full-screen player for vertical broadcasts
 - Account-free subscriptions, with import from NewPipe, PipePipe, Tubular, Takeout, and OPML
@@ -469,6 +469,8 @@ The milestones behind us, kept here so the direction of travel is visible.
 - An optional daily time limit with per-weekday budgets: Koda locks behind a full-screen "come back tomorrow" screen once the day's hours are used, offered at onboarding and in Settings > Advanced
 
 Whole-playlist downloads deliberately reuse the same serial worker as a single-item download. A playlist page contributes a batch of requests, and the Downloads screen remains the one place that owns transfer progress, retry and cancellation; there is no second batch state to drift from the files actually being written. Re-running a partially completed playlist only queues the missing ids, duplicate rows share one offline file, device-local songs count as already offline, and live broadcasts are rejected before they can enter the progressive MP4 path. Video batches pin one quality cap onto every request so a retry cannot silently change the choice halfway through the playlist.
+
+Music downloads are portable files rather than audio bytes backed only by Koda's private index. The downloader resolves an AAC audio-only stream before naming it M4A, writes title, artist, album, cover art and lyrics into the file, and places matching JPEG/LRC companions beside it for immediate offline UI use. Word timing survives as Enhanced LRC, line timing as ordinary LRC, and plain lyrics remain plain. Artwork and lyrics are best-effort enrichments—a provider miss cannot discard valid audio—but an invalid container or failed tag commit is never published under a misleading `.m4a` name. Playlist downloads inherit the same path one song at a time.
 
 Crossfade alternates two fully configured ExoPlayers while keeping one logical queue visible through the media session. The standby must reach `STATE_READY` before either volume moves; a failed resolution or buffer deadline keeps the outgoing track alive and falls back to a short ramp only when overlap is impossible. Both players share audio focus, the pinned audio-session id, loudness correction and ducking. Cancellation is an abort, never a swap, and shuffled playback asks the player for its real next index instead of assuming timeline order.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -431,6 +431,7 @@ The milestones behind us, kept here so the direction of travel is visible.
 - Eight player styles and a 27-palette color system with dynamic color and AMOLED
 - Listening statistics with play charts, streaks, and top artists
 - Offline downloads for music and video, written to the system Downloads folder
+- Whole-playlist downloads in both modes, with one background queue, resumable partial batches, per-batch video quality, and honest skips for local music and live video
 - Live streams with live chat, including a full-screen player for vertical broadcasts
 - Account-free subscriptions, with import from NewPipe, PipePipe, Tubular, Takeout, and OPML
 - "Don't recommend this" with a local blocklist, account propagation, and app-wide undo
@@ -464,6 +465,8 @@ The milestones behind us, kept here so the direction of travel is visible.
 - Whole-install backup and restore: one versioned file covering both modes - music and video playlists with their artwork, likes, saved playlists, stats, watch and search history, followed channels and the blocklist per profile, and every setting - written and read from Settings, offline, and carrying no sign-in
 - In-app bug reporting: recent logs and last-crash details previewed on-device and handed to Telegram or GitHub with device info attached, plus release builds that keep readable stack traces
 - An optional daily time limit with per-weekday budgets: Koda locks behind a full-screen "come back tomorrow" screen once the day's hours are used, offered at onboarding and in Settings > Advanced
+
+Whole-playlist downloads deliberately reuse the same serial worker as a single-item download. A playlist page contributes a batch of requests, and the Downloads screen remains the one place that owns transfer progress, retry and cancellation; there is no second batch state to drift from the files actually being written. Re-running a partially completed playlist only queues the missing ids, duplicate rows share one offline file, device-local songs count as already offline, and live broadcasts are rejected before they can enter the progressive MP4 path. Video batches pin one quality cap onto every request so a retry cannot silently change the choice halfway through the playlist.
 
 Crossfade alternates two fully configured ExoPlayers while keeping one logical queue visible through the media session. The standby must reach `STATE_READY` before either volume moves; a failed resolution or buffer deadline keeps the outgoing track alive and falls back to a short ramp only when overlap is impossible. Both players share audio focus, the pinned audio-session id, loudness correction and ducking. Cancellation is an abort, never a swap, and shuffled playback asks the player for its real next index instead of assuming timeline order.
 

--- a/app/src/main/java/com/ivor/ivormusic/data/DownloadRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/DownloadRepository.kt
@@ -468,10 +468,17 @@ class DownloadRepository private constructor(private val context: Context) {
     /**
      * Queue a whole playlist. Songs already downloaded or already queued are
      * skipped, so re-running this over a partially downloaded playlist only
-     * fetches what is missing.
+     * fetches what is missing. Device-local originals are already offline and
+     * must never be routed through YouTube stream resolution.
      */
     suspend fun downloadPlaylist(songs: List<Song>) {
-        enqueue(songs.map { it.toRequest() })
+        enqueue(
+            songs.asSequence()
+                .filter { it.source == SongSource.YOUTUBE }
+                .distinctBy { it.id }
+                .map { it.toRequest() }
+                .toList()
+        )
     }
 
     /**
@@ -482,9 +489,43 @@ class DownloadRepository private constructor(private val context: Context) {
         enqueue(listOf(video.toRequest(qualityLabel)))
     }
 
-    /** Queue several videos at once. */
-    suspend fun downloadVideos(videos: List<VideoItem>) {
-        enqueue(videos.map { it.toRequest() })
+    /**
+     * Queue several videos at once with one quality cap for the batch.
+     *
+     * Live broadcasts only expose an HLS manifest and cannot be remuxed by the
+     * offline MP4 path. They are skipped here as a final data-layer guard even
+     * though the playlist sheet also explains the skip before confirmation.
+     */
+    suspend fun downloadVideos(videos: List<VideoItem>, qualityLabel: String? = null) {
+        enqueue(
+            videos.asSequence()
+                .filterNot { it.isLive }
+                .distinctBy { it.videoId }
+                .map { it.toRequest(qualityLabel) }
+                .toList()
+        )
+    }
+
+    /**
+     * Resolve and queue a complete video playlist.
+     *
+     * A local playlist already carries its whole copied list. A YouTube
+     * playlist is normally loaded as one page for responsive browsing, so a
+     * batch explicitly follows every continuation here. False means neither
+     * independent resolver reached the real end; no partial batch is queued.
+     */
+    suspend fun downloadVideoPlaylist(
+        playlistId: String,
+        loadedVideos: List<VideoItem>,
+        qualityLabel: String? = null
+    ): Boolean {
+        val completeVideos = if (LocalVideoPlaylistsRepository.isLocal(playlistId)) {
+            loadedVideos
+        } else {
+            youtubeRepository.getCompletePlaylistVideos(playlistId) ?: return false
+        }
+        downloadVideos(completeVideos, qualityLabel)
+        return true
     }
 
     private fun Song.toRequest() = DownloadRequest(

--- a/app/src/main/java/com/ivor/ivormusic/data/DownloadRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/DownloadRepository.kt
@@ -3,8 +3,15 @@ package com.ivor.ivormusic.data
 import com.ivor.ivormusic.util.KLog
 
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
 import android.net.Uri
+import androidx.core.graphics.drawable.toBitmap
+import coil.imageLoader
+import coil.request.ImageRequest
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -100,6 +107,8 @@ class DownloadRepository private constructor(private val context: Context) {
         private const val MAX_ATTEMPTS = 3
         private const val RETRY_BACKOFF_MS = 2_000L
         private const val BUFFER_SIZE = 8192
+        private const val DOWNLOAD_ARTWORK_SIZE_PX = 1024
+        private const val DOWNLOAD_ARTWORK_JPEG_QUALITY = 92
 
         // Ranged-request chunk size. Bounded ranges are served at full CDN
         // speed where an open-ended request is paced to the media bitrate.
@@ -135,6 +144,7 @@ class DownloadRepository private constructor(private val context: Context) {
         .build()
 
     private val youtubeRepository = YouTubeRepository(context)
+    private val lyricsRepository = LyricsRepository()
     private val notificationHelper = DownloadNotificationHelper(context)
     private val storage = DownloadStorage(context)
 
@@ -238,6 +248,7 @@ class DownloadRepository private constructor(private val context: Context) {
             val songs = mutableListOf<Song>()
             var prunedAny = false
             var backfilledAny = false
+            var companionStateChanged = false
             // Entries written before downloads carried a timestamp get one
             // synthesized from their position: the array is in completion
             // order, so walking backwards from the metadata file's mtime keeps
@@ -252,6 +263,12 @@ class DownloadRepository private constructor(private val context: Context) {
 
                 val mediaUri = obj.optString("mediaUri").takeIf { it.isNotBlank() }
                 val legacyPath = obj.optString("localPath").takeIf { it.isNotBlank() }
+                val storedArtUri = obj.optString("albumArtUri")
+                    .takeIf(String::isNotBlank)
+                    ?.let(Uri::parse)
+                val storedLyricsUri = obj.optString("lyricsUri")
+                    .takeIf(String::isNotBlank)
+                    ?.let(Uri::parse)
 
                 val uri: Uri? = when {
                     mediaUri != null -> Uri.parse(mediaUri).takeIf { it in liveUris }
@@ -260,13 +277,20 @@ class DownloadRepository private constructor(private val context: Context) {
                 }
 
                 if (uri == null) {
+                    listOfNotNull(storedArtUri, storedLyricsUri)
+                        .filter(storage::isMusicCompanion)
+                        .forEach(storage::delete)
                     prunedAny = true
                     continue
                 }
 
                 val artUrl = obj.optString("albumArtUrl").takeIf {
                     it.isNotBlank() && !obj.isNull("albumArtUrl")
-                }
+                }?.takeIf { Uri.parse(it).scheme in setOf("http", "https") }
+                val localArtUri = storedArtUri?.takeIf { it in liveUris }
+                val lyricsUri = storedLyricsUri?.takeIf { it in liveUris }
+                if (storedArtUri != null && localArtUri == null) companionStateChanged = true
+                if (storedLyricsUri != null && lyricsUri == null) companionStateChanged = true
                 val addedAt = obj.optLong("addedAt").takeIf { it > 0 } ?: run {
                     backfilledAny = true
                     backfillAnchor - (entryCount - i) * 1000L
@@ -279,9 +303,12 @@ class DownloadRepository private constructor(private val context: Context) {
                         album = obj.optString("album", ""),
                         duration = obj.optLong("duration"),
                         uri = uri,
-                        albumArtUri = artUrl?.let(Uri::parse),
-                        thumbnailUrl = artUrl,
+                        albumArtUri = localArtUri ?: artUrl?.let(Uri::parse),
+                        // A local companion must win before any network URL or
+                        // artwork disappears exactly when the user goes offline.
+                        thumbnailUrl = localArtUri?.toString() ?: artUrl,
                         source = SongSource.LOCAL,
+                        lyricsUri = lyricsUri,
                         dateAdded = addedAt
                     )
                 )
@@ -290,7 +317,7 @@ class DownloadRepository private constructor(private val context: Context) {
             _downloadedSongs.value = songs
             // Persist the pruned list so externally deleted files do not get
             // re-checked on every launch, and so backfilled timestamps stick.
-            if (prunedAny || backfilledAny) saveMetadata()
+            if (prunedAny || backfilledAny || companionStateChanged) saveMetadata()
         } catch (e: Exception) {
             KLog.e(TAG, "Error loading downloads", e)
             _downloadedSongs.value = emptyList()
@@ -315,7 +342,13 @@ class DownloadRepository private constructor(private val context: Context) {
                     } else {
                         put("mediaUri", uri.toString())
                     }
-                    put("albumArtUrl", song.thumbnailUrl ?: song.albumArtUri?.toString())
+                    song.thumbnailUrl?.takeIf { url ->
+                        Uri.parse(url).scheme in setOf("http", "https")
+                    }?.let { put("albumArtUrl", it) }
+                    song.albumArtUri?.takeIf { it.scheme == "content" }?.let {
+                        put("albumArtUri", it.toString())
+                    }
+                    song.lyricsUri?.let { put("lyricsUri", it.toString()) }
                     song.dateAdded?.let { put("addedAt", it) }
                 }
                 jsonArray.put(obj)
@@ -533,7 +566,7 @@ class DownloadRepository private constructor(private val context: Context) {
         title = title,
         subtitle = artist,
         type = DownloadMediaType.MUSIC,
-        thumbnailUrl = thumbnailUrl ?: albumArtUri?.toString(),
+        thumbnailUrl = highResThumbnailUrl ?: thumbnailUrl ?: albumArtUri?.toString(),
         durationMs = duration,
         song = this
     )
@@ -677,52 +710,182 @@ class DownloadRepository private constructor(private val context: Context) {
     private suspend fun attemptMusicDownload(request: DownloadRequest): Boolean =
         withContext(Dispatchers.IO) {
             val song = request.song ?: return@withContext false
-            var pendingTarget: Uri? = null
+            val pendingTargets = mutableListOf<Uri>()
+            var audioTemp: File? = null
+            var artworkTemp: File? = null
             updateProgress(request, 0.02f, DownloadStatus.DOWNLOADING)
 
             try {
-                val streamUrl = youtubeRepository.getStreamUrl(request.id).getOrNull()
+                val streamUrl = youtubeRepository.getDownloadAudioStreamUrl(request.id).getOrNull()
                     ?: throw java.io.IOException("No stream URL for ${request.id}")
 
                 ensureActive()
                 updateProgress(request, 0.1f, DownloadStatus.DOWNLOADING)
 
-                val fileName =
-                    storage.buildFileName(request.title, request.subtitle, DownloadMediaType.MUSIC)
-                val target = storage.createPending(fileName, DownloadMediaType.MUSIC)
-                    ?: throw java.io.IOException("Could not create storage entry")
-                pendingTarget = target
+                coroutineScope {
+                    // These are best-effort enrichments and run under the audio
+                    // transfer rather than extending every playlist item by up
+                    // to two provider timeouts after its bytes have arrived.
+                    val lyricsDeferred = async {
+                        (lyricsRepository.fetchLyrics(song) as? LyricsResult.Success)
+                            ?.toDownloadLyrics()
+                            ?.takeIf(String::isNotBlank)
+                    }
+                    val artworkDeferred = async { loadDownloadArtwork(song) }
 
-                val output = storage.openOutput(target)
-                    ?: throw java.io.IOException("Could not open output")
+                    audioTemp = File.createTempFile("koda_music_", ".m4a", context.cacheDir)
+                    audioTemp!!.outputStream().use { out ->
+                        downloadStream(request, streamUrl, out, 0.1f, 0.82f)
+                    }
 
-                output.use { out ->
-                    downloadStream(request, streamUrl, out, 0.1f, 1f)
+                    ensureActive()
+                    updateProgress(request, 0.84f, DownloadStatus.DOWNLOADING)
+
+                    val lyrics = runCatching { lyricsDeferred.await() }
+                        .onFailure { KLog.w(TAG, "Lyrics unavailable for ${song.title}", it) }
+                        .getOrNull()
+                    val artwork = runCatching { artworkDeferred.await() }
+                        .onFailure { KLog.w(TAG, "Artwork unavailable for ${song.title}", it) }
+                        .getOrNull()
+                    artworkTemp = artwork?.let(::writeArtworkTemp)
+
+                    ensureActive()
+                    updateProgress(request, 0.88f, DownloadStatus.DOWNLOADING)
+                    DownloadedAudioMetadata.write(
+                        audioFile = audioTemp!!,
+                        song = song,
+                        artworkFile = artworkTemp,
+                        lyrics = lyrics
+                    )
+
+                    ensureActive()
+                    updateProgress(request, 0.92f, DownloadStatus.DOWNLOADING)
+
+                    val audioName = storage.buildFileName(
+                        request.title,
+                        request.subtitle,
+                        DownloadMediaType.MUSIC
+                    )
+                    val audioTarget = storage.createPending(audioName, DownloadMediaType.MUSIC)
+                        ?: throw java.io.IOException("Could not create audio storage entry")
+                    pendingTargets += audioTarget
+                    copyToPending(audioTemp!!, audioTarget)
+
+                    val artworkTarget = artworkTemp?.let { cover ->
+                        val name = storage.buildMusicCompanionFileName(
+                            request.title,
+                            request.subtitle,
+                            "jpg"
+                        )
+                        storage.createPendingMusicCompanion(name, "image/jpeg")?.also { target ->
+                            pendingTargets += target
+                            copyToPending(cover, target)
+                        } ?: throw java.io.IOException("Could not create artwork storage entry")
+                    }
+
+                    val lyricsTarget = lyrics?.let { body ->
+                        val name = storage.buildMusicCompanionFileName(
+                            request.title,
+                            request.subtitle,
+                            "lrc"
+                        )
+                        storage.createPendingMusicCompanion(name, "text/plain")?.also { target ->
+                            pendingTargets += target
+                            storage.openOutput(target)?.bufferedWriter(Charsets.UTF_8)?.use {
+                                it.write(body)
+                            } ?: throw java.io.IOException("Could not write lyric storage entry")
+                        } ?: throw java.io.IOException("Could not create lyric storage entry")
+                    }
+
+                    ensureActive()
+                    updateProgress(request, 0.98f, DownloadStatus.DOWNLOADING)
+
+                    // Publish companions first and audio last. A media scanner
+                    // can never observe a finished song before everything that
+                    // was successfully fetched for it is visible beside it.
+                    if (artworkTarget != null && !storage.publish(artworkTarget)) {
+                        throw java.io.IOException("Could not publish artwork storage entry")
+                    }
+                    if (lyricsTarget != null && !storage.publish(lyricsTarget)) {
+                        throw java.io.IOException("Could not publish lyric storage entry")
+                    }
+                    if (!storage.publish(audioTarget)) {
+                        throw java.io.IOException("Could not publish audio storage entry")
+                    }
+                    pendingTargets.clear()
+
+                    val localArtwork = artworkTarget ?: song.albumArtUri
+                    val downloaded = song.copy(
+                        uri = audioTarget,
+                        albumArtUri = localArtwork,
+                        thumbnailUrl = artworkTarget?.toString()
+                            ?: song.thumbnailUrl
+                            ?: song.albumArtUri?.toString(),
+                        source = SongSource.LOCAL,
+                        lyricsUri = lyricsTarget,
+                        dateAdded = System.currentTimeMillis()
+                    )
+                    _downloadedSongs.value = _downloadedSongs.value + downloaded
+                    saveMetadata()
                 }
-
-                storage.publish(target)
-                pendingTarget = null
-
-                val downloaded = song.copy(
-                    uri = target,
-                    source = SongSource.LOCAL,
-                    dateAdded = System.currentTimeMillis()
-                )
-                _downloadedSongs.value = _downloadedSongs.value + downloaded
-                saveMetadata()
 
                 finishSuccess(request)
                 true
             } catch (e: kotlinx.coroutines.CancellationException) {
-                cleanUpCancelled(request, pendingTarget)
+                withContext(kotlinx.coroutines.NonCancellable) {
+                    pendingTargets.forEach(storage::delete)
+                    _downloadingIds.value = _downloadingIds.value - request.id
+                    removeProgress(request.id)
+                }
                 throw e
             } catch (e: Exception) {
-                pendingTarget?.let { storage.delete(it) }
+                pendingTargets.forEach(storage::delete)
                 throw e
             } finally {
+                audioTemp?.delete()
+                artworkTemp?.delete()
                 activeDownloadCalls.remove(request.id)
             }
         }
+
+    /** Decode a bounded, software-backed cover through Coil's shared cache. */
+    private suspend fun loadDownloadArtwork(song: Song): Bitmap? {
+        val urls = listOfNotNull(song.highResThumbnailUrl, song.thumbnailUrl)
+            .distinct()
+        for (url in urls) {
+            val drawable = runCatching {
+                context.imageLoader.execute(
+                    ImageRequest.Builder(context)
+                        .data(url)
+                        .size(DOWNLOAD_ARTWORK_SIZE_PX, DOWNLOAD_ARTWORK_SIZE_PX)
+                        .allowHardware(false)
+                        .build()
+                ).drawable
+            }.getOrNull() ?: continue
+
+            return (drawable as? BitmapDrawable)?.bitmap
+                ?: drawable.toBitmap(DOWNLOAD_ARTWORK_SIZE_PX, DOWNLOAD_ARTWORK_SIZE_PX)
+        }
+        return null
+    }
+
+    private fun writeArtworkTemp(bitmap: Bitmap): File {
+        val file = File.createTempFile("koda_cover_", ".jpg", context.cacheDir)
+        val written = file.outputStream().use { out ->
+            bitmap.compress(Bitmap.CompressFormat.JPEG, DOWNLOAD_ARTWORK_JPEG_QUALITY, out)
+        }
+        if (!written) {
+            file.delete()
+            throw java.io.IOException("Could not encode album artwork")
+        }
+        return file
+    }
+
+    private fun copyToPending(source: File, target: Uri) {
+        val output = storage.openOutput(target)
+            ?: throw java.io.IOException("Could not open storage entry")
+        output.use { out -> source.inputStream().use { input -> input.copyTo(out) } }
+    }
 
     /**
      * One video download attempt.
@@ -1081,6 +1244,9 @@ class DownloadRepository private constructor(private val context: Context) {
                 storage.delete(uri)
             }
         }
+        listOfNotNull(songToDelete.albumArtUri, songToDelete.lyricsUri)
+            .filter(storage::isMusicCompanion)
+            .forEach(storage::delete)
 
         currentList.remove(songToDelete)
         _downloadedSongs.value = currentList

--- a/app/src/main/java/com/ivor/ivormusic/data/DownloadStorage.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/DownloadStorage.kt
@@ -72,15 +72,22 @@ class DownloadStorage(private val context: Context) {
      * "<videoId>.m4a".
      */
     fun buildFileName(title: String, artist: String, type: DownloadMediaType): String {
+        return "${safeBaseName(title, artist)}.${type.extension}"
+    }
+
+    /** A cover or LRC that intentionally shares the audio file's stem. */
+    fun buildMusicCompanionFileName(title: String, artist: String, extension: String): String =
+        "${safeBaseName(title, artist)}.${extension.trimStart('.')}"
+
+    private fun safeBaseName(title: String, artist: String): String {
         val base = if (artist.isBlank()) title else "$title - $artist"
-        val safe = ILLEGAL_FILENAME_CHARS.replace(base, "")
+        return ILLEGAL_FILENAME_CHARS.replace(base, "")
             .replace(Regex("""\s+"""), " ")
             .trim()
             .trim('.')
             .take(MAX_NAME_LENGTH)
             .trim()
             .ifBlank { "Koda download" }
-        return "$safe.${type.extension}"
     }
 
     /**
@@ -88,11 +95,20 @@ class DownloadStorage(private val context: Context) {
      * The file stays invisible to other apps until [publish].
      */
     fun createPending(displayName: String, type: DownloadMediaType): Uri? {
+        return createPending(displayName, type.mimeType, type.relativePath)
+    }
+
+    /** Create album-art or lyric data beside a music download. */
+    fun createPendingMusicCompanion(displayName: String, mimeType: String): Uri? {
+        return createPending(displayName, mimeType, DownloadMediaType.MUSIC.relativePath)
+    }
+
+    private fun createPending(displayName: String, mimeType: String, relativePath: String): Uri? {
         return try {
             val values = ContentValues().apply {
                 put(MediaStore.MediaColumns.DISPLAY_NAME, displayName)
-                put(MediaStore.MediaColumns.MIME_TYPE, type.mimeType)
-                put(MediaStore.MediaColumns.RELATIVE_PATH, type.relativePath)
+                put(MediaStore.MediaColumns.MIME_TYPE, mimeType)
+                put(MediaStore.MediaColumns.RELATIVE_PATH, relativePath)
                 put(MediaStore.MediaColumns.IS_PENDING, 1)
             }
             resolver.insert(collection, values)
@@ -112,14 +128,15 @@ class DownloadStorage(private val context: Context) {
     }
 
     /** Clear IS_PENDING, making the file visible in the Files app. */
-    fun publish(uri: Uri) {
-        try {
+    fun publish(uri: Uri): Boolean {
+        return try {
             val values = ContentValues().apply {
                 put(MediaStore.MediaColumns.IS_PENDING, 0)
             }
-            resolver.update(uri, values, null, null)
+            resolver.update(uri, values, null, null) > 0
         } catch (e: Exception) {
             KLog.e(TAG, "Failed to publish $uri", e)
+            false
         }
     }
 
@@ -149,6 +166,36 @@ class DownloadStorage(private val context: Context) {
                 null,
                 null
             )?.use { it.moveToFirst() } ?: false
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    /** Guard companion cleanup so an old external artwork URI is never deleted. */
+    fun isMusicCompanion(uri: Uri): Boolean {
+        if (uri.scheme != "content") return false
+        return try {
+            resolver.query(
+                uri,
+                arrayOf(
+                    MediaStore.MediaColumns.RELATIVE_PATH,
+                    MediaStore.MediaColumns.MIME_TYPE,
+                    MediaStore.MediaColumns.DISPLAY_NAME
+                ),
+                null,
+                null,
+                null
+            )?.use { cursor ->
+                if (!cursor.moveToFirst()) return@use false
+                val path = cursor.getString(0).orEmpty()
+                val mimeType = cursor.getString(1).orEmpty()
+                val displayName = cursor.getString(2).orEmpty().lowercase()
+                path.startsWith(DownloadMediaType.MUSIC.relativePath) &&
+                    (mimeType.startsWith("image/") ||
+                        mimeType.startsWith("text/") ||
+                        displayName.endsWith(".lrc") ||
+                        displayName.endsWith(".ttml"))
+            } ?: false
         } catch (e: Exception) {
             false
         }

--- a/app/src/main/java/com/ivor/ivormusic/data/DownloadedAudioMetadata.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/DownloadedAudioMetadata.kt
@@ -1,0 +1,106 @@
+package com.ivor.ivormusic.data
+
+import org.jaudiotagger.audio.AudioFileIO
+import org.jaudiotagger.tag.FieldKey
+import org.jaudiotagger.tag.images.ArtworkFactory
+import java.io.File
+import java.util.Locale
+
+/**
+ * Writes portable metadata into a completed M4A before it is published.
+ *
+ * Koda's private downloads JSON is an index, not a substitute for file tags:
+ * files in public storage must retain their identity when opened in another
+ * player or after Koda is uninstalled. Artwork and lyrics therefore live in
+ * the M4A itself as well as in the optional companion files Koda keeps for
+ * fast offline display.
+ */
+internal object DownloadedAudioMetadata {
+
+    fun write(
+        audioFile: File,
+        song: Song,
+        artworkFile: File?,
+        lyrics: String?
+    ) {
+        val taggedAudio = AudioFileIO.read(audioFile)
+        val tag = taggedAudio.tagOrCreateAndSetDefault
+
+        tag.setField(FieldKey.TITLE, song.title.ifBlank { audioFile.nameWithoutExtension })
+        song.artist.takeIf(String::isNotBlank)?.let { artist ->
+            tag.setField(FieldKey.ARTIST, artist)
+            tag.setField(FieldKey.ALBUM_ARTIST, artist)
+        }
+        song.album.takeIf(String::isNotBlank)?.let { tag.setField(FieldKey.ALBUM, it) }
+        lyrics?.takeIf(String::isNotBlank)?.let { tag.setField(FieldKey.LYRICS, it) }
+
+        artworkFile?.takeIf { it.isFile && it.length() > 0L }?.let { cover ->
+            tag.deleteArtworkField()
+            tag.setField(
+                ArtworkFactory.createArtworkFromFile(cover).apply {
+                    description = "Cover"
+                    pictureType = FRONT_COVER_PICTURE_TYPE
+                }
+            )
+        }
+
+        taggedAudio.commit()
+    }
+
+    private const val FRONT_COVER_PICTURE_TYPE = 3
+}
+
+/**
+ * Serialize the exact lyric fidelity the player chose into a portable LRC
+ * payload. Word timings use Enhanced LRC tags, line timings use ordinary LRC,
+ * and unsynchronised lyrics remain plain text. [LyricsParser] reads all three,
+ * so a downloaded track does not lose word highlighting when played offline.
+ */
+internal fun LyricsResult.Success.toDownloadLyrics(): String = when (syncType) {
+    LyricsSyncType.PLAIN -> lines
+        .asSequence()
+        .map { it.text.singleLine() }
+        .filter(String::isNotBlank)
+        .joinToString("\n")
+
+    LyricsSyncType.LINE -> lines
+        .asSequence()
+        .filter { it.timeMs >= 0L && it.text.isNotBlank() }
+        .joinToString("\n") { line ->
+            "[${line.timeMs.toLrcTimestamp()}]${line.text.singleLine()}"
+        }
+
+    LyricsSyncType.WORD -> lines
+        .asSequence()
+        .filter { it.timeMs >= 0L && it.text.isNotBlank() }
+        .joinToString("\n") { line ->
+            buildString {
+                append('[')
+                append(line.timeMs.toLrcTimestamp())
+                append(']')
+                if (line.contentSpans.isEmpty()) {
+                    append(line.text.singleLine())
+                } else {
+                    line.contentSpans.forEach { span ->
+                        append('<')
+                        append(span.timeMs.coerceAtLeast(0L).toLrcTimestamp())
+                        append('>')
+                        append(span.text.singleLine(preserveEdgeSpaces = true))
+                    }
+                }
+            }
+        }
+}
+
+private fun Long.toLrcTimestamp(): String {
+    val safe = coerceAtLeast(0L)
+    val minutes = safe / 60_000L
+    val seconds = (safe % 60_000L) / 1_000L
+    val centiseconds = (safe % 1_000L) / 10L
+    return String.format(Locale.US, "%02d:%02d.%02d", minutes, seconds, centiseconds)
+}
+
+private fun String.singleLine(preserveEdgeSpaces: Boolean = false): String {
+    val collapsed = replace(Regex("[\\r\\n]+"), " ")
+    return if (preserveEdgeSpaces) collapsed else collapsed.trim()
+}

--- a/app/src/main/java/com/ivor/ivormusic/data/LocalLyricsSource.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/LocalLyricsSource.kt
@@ -2,6 +2,8 @@ package com.ivor.ivormusic.data
 
 import com.ivor.ivormusic.util.KLog
 
+import android.content.Context
+import android.net.Uri
 import org.jaudiotagger.audio.AudioFileIO
 import org.jaudiotagger.tag.FieldKey
 import java.io.File
@@ -10,6 +12,10 @@ import java.util.LinkedHashMap
 
 /** Reads lyrics that travel with a local audio file, without using the network. */
 internal class LocalLyricsSource(
+    private val sharedSidecarReader: (Song) -> String? = { null },
+    private val sharedEmbeddedLyricsReader: (Song) -> String? = { null },
+    // Keep this last: LocalLyricsSource { ... } is the test seam used for
+    // ordinary file tags, and Kotlin binds a trailing lambda to the last arg.
     private val embeddedLyricsReader: (File) -> String? = ::readEmbeddedLyrics
 ) {
     private class CachedSidecars(val stamp: Long, val files: List<File>)
@@ -32,16 +38,27 @@ internal class LocalLyricsSource(
         val audioFile = song.filePath
             ?.takeIf { it.isNotBlank() }
             ?.let(::File)
-            ?: return null
 
-        findSidecar(audioFile)?.let { sidecar ->
-            readSidecar(sidecar)?.let(LyricsParser::parse)?.let { parsed ->
-                return parsed.toResult("Local ${sidecar.extension.uppercase()}")
+        if (audioFile != null) {
+            findSidecar(audioFile)?.let { sidecar ->
+                readSidecar(sidecar)?.let(LyricsParser::parse)?.let { parsed ->
+                    return parsed.toResult("Local ${sidecar.extension.uppercase()}")
+                }
             }
         }
 
-        val embedded = runCatching { embeddedLyricsReader(audioFile) }
-            .onFailure { KLog.w(TAG, "Could not read embedded lyrics from ${audioFile.name}", it) }
+        runCatching { sharedSidecarReader(song) }
+            .onFailure { KLog.w(TAG, "Could not read downloaded lyric sidecar for ${song.title}", it) }
+            .getOrNull()
+            ?.takeIf { it.isNotBlank() && it.length <= MAX_SIDECAR_BYTES }
+            ?.let(LyricsParser::parse)
+            ?.let { return it.toResult("Downloaded LRC") }
+
+        val embedded = runCatching {
+            if (audioFile != null) embeddedLyricsReader(audioFile)
+            else sharedEmbeddedLyricsReader(song)
+        }
+            .onFailure { KLog.w(TAG, "Could not read embedded lyrics from ${song.title}", it) }
             .getOrNull()
             ?.takeIf { it.isNotBlank() && it.length <= MAX_EMBEDDED_LYRICS_CHARS }
 
@@ -136,7 +153,7 @@ internal class LocalLyricsSource(
         syncType = syncType
     )
 
-    private companion object {
+    companion object {
         const val TAG = "LocalLyricsSource"
         const val MAX_SIDECAR_BYTES = 2L * 1024L * 1024L
         const val MAX_EMBEDDED_LYRICS_CHARS = 2 * 1024 * 1024
@@ -149,6 +166,50 @@ internal class LocalLyricsSource(
                 .tag
                 ?.getFirst(FieldKey.LYRICS)
                 ?.takeIf(String::isNotBlank)
+        }
+
+        /**
+         * Content-URI counterpart used by downloads in scoped shared storage.
+         * Their explicit LRC companion is the fast path; copying the M4A into
+         * cache is only a recovery path if that sidecar was removed while the
+         * embedded tag still survives.
+         */
+        fun forContext(context: Context): LocalLyricsSource {
+            val appContext = context.applicationContext
+            return LocalLyricsSource(
+                sharedSidecarReader = { song ->
+                    song.lyricsUri?.let { uri -> readContentUri(appContext, uri, MAX_SIDECAR_BYTES) }
+                },
+                sharedEmbeddedLyricsReader = { song ->
+                    song.uri?.let { uri ->
+                        val temp = File.createTempFile("koda_lyrics_", ".m4a", appContext.cacheDir)
+                        try {
+                            val copied = appContext.contentResolver.openInputStream(uri)?.use { input ->
+                                temp.outputStream().use(input::copyTo)
+                                true
+                            } ?: false
+                            if (copied) readEmbeddedLyrics(temp) else null
+                        } finally {
+                            temp.delete()
+                        }
+                    }
+                }
+            )
+        }
+
+        private fun readContentUri(context: Context, uri: Uri, maxBytes: Long): String? {
+            return context.contentResolver.openInputStream(uri)?.use { input ->
+                val bytes = input.readNBytes((maxBytes + 1L).toInt())
+                if (bytes.size.toLong() > maxBytes) null else decodeSharedSidecar(bytes)
+            }
+        }
+
+        private fun decodeSharedSidecar(bytes: ByteArray): String = when {
+            bytes.size >= 2 && bytes[0] == 0xFF.toByte() && bytes[1] == 0xFE.toByte() ->
+                String(bytes, 2, bytes.size - 2, Charsets.UTF_16LE)
+            bytes.size >= 2 && bytes[0] == 0xFE.toByte() && bytes[1] == 0xFF.toByte() ->
+                String(bytes, 2, bytes.size - 2, Charsets.UTF_16BE)
+            else -> String(bytes, Charsets.UTF_8)
         }
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/data/LyricsRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/LyricsRepository.kt
@@ -2,6 +2,7 @@ package com.ivor.ivormusic.data
 
 import com.ivor.ivormusic.util.KLog
 
+import android.content.Context
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
@@ -28,10 +29,12 @@ import java.util.LinkedHashMap
  * [fetchLyrics]'s `allowRemote`.
  */
 class LyricsRepository internal constructor(
+    context: Context? = null,
     private val http: LyricsHttpClient = LyricsHttpClient(),
     private val wordProviders: List<RemoteLyricsProvider> = defaultWordLyricsProviders(http),
     private val fallbackProviders: List<RemoteLyricsProvider> = defaultFallbackLyricsProviders(http),
-    private val localLyricsSource: LocalLyricsSource = LocalLyricsSource()
+    private val localLyricsSource: LocalLyricsSource =
+        context?.let(LocalLyricsSource::forContext) ?: LocalLyricsSource()
 ) {
     private companion object {
         const val TAG = "LyricsRepository"

--- a/app/src/main/java/com/ivor/ivormusic/data/Song.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/Song.kt
@@ -29,6 +29,8 @@ data class Song(
     val thumbnailUrl: String? = null, // YouTube thumbnail URL
     val source: SongSource = SongSource.LOCAL,
     val filePath: String? = null, // Local file path for folder filtering and embedded lyrics
+    @Serializable(with = UriAsStringSerializer::class)
+    val lyricsUri: Uri? = null, // Downloaded LRC companion in shared storage
     // When this song entered the user's library, epoch millis. Each source
     // stamps its own notion of "added": MediaStore DATE_ADDED for device
     // files, download completion time for downloads, like time for likes.

--- a/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/ThemePreferences.kt
@@ -406,6 +406,7 @@ class ThemePreferences(context: Context) {
          * and written when the user changes them in the player itself.
          */
         private const val KEY_VIDEO_REPEAT = "video_repeat"
+        private const val KEY_VIDEO_AUTOPLAY = "video_autoplay"
         private const val KEY_VIDEO_BRIGHTNESS = "video_brightness"
 
         /** Stored brightness sentinel meaning "never set, follow the system". */
@@ -1020,6 +1021,18 @@ class ThemePreferences(context: Context) {
 
     fun setVideoRepeatEnabled(enabled: Boolean) {
         prefs.edit().putBoolean(KEY_VIDEO_REPEAT, enabled).apply()
+    }
+
+    /**
+     * Whether a finished video may advance to the next playlist or related
+     * item. Defaults to on to preserve the player's historical behaviour.
+     * Loop is governed by the same end-of-video master switch in the player,
+     * so disabling autoplay also disables repeat there.
+     */
+    fun isVideoAutoplayEnabled(): Boolean = prefs.getBoolean(KEY_VIDEO_AUTOPLAY, true)
+
+    fun setVideoAutoplayEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_VIDEO_AUTOPLAY, enabled).apply()
     }
 
     /**

--- a/app/src/main/java/com/ivor/ivormusic/data/VideoItem.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/VideoItem.kt
@@ -340,6 +340,18 @@ data class VideoSeekPreviewFrame(
 )
 
 /**
+ * The atomic result of resolving a video's playback streams.
+ *
+ * The storyboard belongs to the same NewPipe extraction as [qualities]. Keeping
+ * them in one value prevents a second video resolution from overwriting a
+ * repository-level "last preview" between the two reads.
+ */
+data class VideoStreamResult(
+    val qualities: List<VideoQuality>,
+    val seekPreview: VideoSeekPreview? = null,
+)
+
+/**
  * Everything the video player needs from a single watch-next (/next) call:
  * engagement state, enriched metadata, related videos and chapters.
  */

--- a/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
@@ -708,6 +708,26 @@ class YouTubeRepository(private val context: Context) {
     }
 
     /**
+     * Resolve an AAC/M4A audio-only stream for a file download.
+     *
+     * Playback may consume Opus/WebM or a muxed video fallback because Media3
+     * only needs a playable track. Downloads are published as `.m4a` and then
+     * tagged, so accepting either fallback would put bytes from the wrong
+     * container behind an M4A filename and make metadata writing unreliable.
+     */
+    suspend fun getDownloadAudioStreamUrl(videoId: String): Result<String> =
+        withContext(Dispatchers.IO) {
+            val newPipeUrl = resolveM4aAudioUrlViaNewPipe(videoId)
+            if (!newPipeUrl.isNullOrBlank()) return@withContext Result.success(newPipeUrl)
+
+            val innerTubeUrl = resolvePlayerStreamingData(videoId)
+                ?.let(::pickM4aAudioStreamUrl)
+            if (!innerTubeUrl.isNullOrBlank()) return@withContext Result.success(innerTubeUrl)
+
+            Result.failure(Exception("No AAC/M4A audio stream found for $videoId"))
+        }
+
+    /**
      * Resolve an audio stream URL through NewPipe's maintained client chain.
      * Applies the same per-network music quality policy as [pickAudioStreamUrl]
      * (NewPipe's averageBitrate is in kbps), and falls back to a muxed
@@ -728,13 +748,7 @@ class YouTubeRepository(private val context: Context) {
             val audioStreams = originalTrackAudioStreams(
                 streamExtractor.audioStreams.filter { it.isUrl },
             )
-            when (ThemePreferences.currentMusicQuality(context)) {
-                ThemePreferences.MUSIC_QUALITY_LOW ->
-                    audioStreams.minByOrNull { it.averageBitrate }
-                ThemePreferences.MUSIC_QUALITY_NORMAL ->
-                    audioStreams.minByOrNull { kotlin.math.abs(it.averageBitrate - 128) }
-                else -> audioStreams.maxByOrNull { it.averageBitrate }
-            }
+            pickAudioStreamForCurrentQuality(audioStreams)
                 ?.content
                 ?.takeIf { it.isNotBlank() }
                 ?.let { return@withContext it }
@@ -752,6 +766,63 @@ class YouTubeRepository(private val context: Context) {
             )
             null
         }
+    }
+
+    private suspend fun resolveM4aAudioUrlViaNewPipe(videoId: String): String? =
+        withContext(Dispatchers.IO) {
+            try {
+                val ytService = ServiceList.all().find { it.serviceInfo.name == "YouTube" }
+                    ?: return@withContext null
+                val extractor = ytService.getStreamExtractor(
+                    "https://www.youtube.com/watch?v=$videoId"
+                )
+                extractor.fetchPage()
+
+                val m4aStreams = originalTrackAudioStreams(
+                    extractor.audioStreams.filter { it.isUrl }
+                ).filter { stream ->
+                    stream.format?.suffix.equals("m4a", ignoreCase = true) ||
+                        stream.codec?.contains("mp4a", ignoreCase = true) == true
+                }
+                pickAudioStreamForCurrentQuality(m4aStreams)
+                    ?.content
+                    ?.takeIf(String::isNotBlank)
+            } catch (e: Exception) {
+                KLog.w(
+                    "YouTubeRepository",
+                    "Resolve[M4A/NewPipe] failed videoId=$videoId: ${e.message}"
+                )
+                null
+            }
+        }
+
+    private fun pickAudioStreamForCurrentQuality(streams: List<AudioStream>): AudioStream? =
+        when (ThemePreferences.currentMusicQuality(context)) {
+            ThemePreferences.MUSIC_QUALITY_LOW ->
+                streams.minByOrNull { it.averageBitrate }
+            ThemePreferences.MUSIC_QUALITY_NORMAL ->
+                streams.minByOrNull { kotlin.math.abs(it.averageBitrate - 128) }
+            else -> streams.maxByOrNull { it.averageBitrate }
+        }
+
+    private fun pickM4aAudioStreamUrl(streamingData: org.json.JSONObject): String? {
+        val formats = streamingData.optJSONArray("adaptiveFormats") ?: return null
+        val candidates = (0 until formats.length())
+            .mapNotNull(formats::optJSONObject)
+            .filter { format ->
+                val mime = format.optString("mimeType")
+                mime.startsWith("audio/mp4") &&
+                    (mime.contains("mp4a", ignoreCase = true) || mime.contains("aac", ignoreCase = true)) &&
+                    format.optString("url").isNotBlank()
+            }
+        val originals = originalTrackAudioFormats(candidates)
+        val selected = when (ThemePreferences.currentMusicQuality(context)) {
+            ThemePreferences.MUSIC_QUALITY_LOW -> originals.minByOrNull { it.optInt("bitrate") }
+            ThemePreferences.MUSIC_QUALITY_NORMAL ->
+                originals.minByOrNull { kotlin.math.abs(it.optInt("bitrate") - 128_000) }
+            else -> originals.maxByOrNull { it.optInt("bitrate") }
+        }
+        return selected?.optString("url")?.takeIf(String::isNotBlank)
     }
 
     /**

--- a/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
@@ -5,6 +5,7 @@ import com.ivor.ivormusic.util.KLog
 import android.content.Context
 import android.net.Uri
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.sync.withLock
@@ -4397,7 +4398,15 @@ class YouTubeRepository(private val context: Context) {
      * Does NOT fetch channel avatar, related videos, or extra metadata.
      * Use this to start playback ASAP, then call getVideoDetails() for the rest.
      */
-    suspend fun getVideoStreamQualities(videoId: String): List<VideoQuality> = withContext(Dispatchers.IO) {
+    suspend fun getVideoStreamQualities(videoId: String): List<VideoQuality> =
+        getVideoStreamResult(videoId).qualities
+
+    /**
+     * Resolve the quality ladder and the storyboard harvested by that exact
+     * extraction as one value. Callers that render a scrub preview must use
+     * this API instead of trying to coordinate two independently mutable reads.
+     */
+    suspend fun getVideoStreamResult(videoId: String): VideoStreamResult = withContext(Dispatchers.IO) {
         // NewPipe 0.26.3+ deliberately resolves VOD streams through Android's
         // reel endpoint and a visionOS fallback, both of which avoid the WEB
         // client's SABR-only response. Keep that maintained client selection in
@@ -4406,14 +4415,16 @@ class YouTubeRepository(private val context: Context) {
         // succeeds, so accepting that ladder first creates a source that starts
         // normally and then dies part-way through playback.
         try {
-            val extractedQualities = getVideoQualitiesFromNewPipe(videoId)
-            if (extractedQualities.isNotEmpty()) {
+            val extracted = getVideoStreamsFromNewPipe(videoId)
+            if (extracted.qualities.isNotEmpty()) {
                 KLog.i(
                     "YouTubeRepo",
-                    "Video qualities via NewPipe: ${extractedQualities.size} for $videoId"
+                    "Video qualities via NewPipe: ${extracted.qualities.size} for $videoId"
                 )
-                return@withContext extractedQualities
+                return@withContext extracted
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             KLog.w(
                 "YouTubeRepo",
@@ -4425,10 +4436,12 @@ class YouTubeRepository(private val context: Context) {
         // Last-resort fallback. It is still useful for a client-specific edge
         // case, but it must not be the normal VOD path for the reason above.
         try {
-            getVideoQualitiesFromInnerTube(videoId)
+            VideoStreamResult(getVideoQualitiesFromInnerTube(videoId))
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             KLog.e("YouTubeRepo", "Error getting video stream qualities", e)
-            emptyList()
+            VideoStreamResult(emptyList())
         }
     }
 
@@ -4440,16 +4453,16 @@ class YouTubeRepository(private val context: Context) {
      * content is not a URI and handing it to Media3's progressive source fails
      * before the first frame.
      */
-    private fun getVideoQualitiesFromNewPipe(videoId: String): List<VideoQuality> {
+    private fun getVideoStreamsFromNewPipe(videoId: String): VideoStreamResult {
         val ytService = ServiceList.all().find { it.serviceInfo.name == "YouTube" }
-            ?: return emptyList()
+            ?: return VideoStreamResult(emptyList())
         val extractor = ytService.getStreamExtractor("https://www.youtube.com/watch?v=$videoId")
         extractor.fetchPage()
 
         // Storyboards ride the same extraction as the stream URLs. Prefer the
         // largest usable frameset so a fullscreen scrub preview stays sharp;
         // failure is best-effort and must never hold playback resolution up.
-        cachedSeekPreview = runCatching {
+        val seekPreview = runCatching {
             extractor.frames
                 .asSequence()
                 .filter {
@@ -4459,7 +4472,7 @@ class YouTubeRepository(private val context: Context) {
                 }
                 .maxByOrNull { it.frameWidth * it.frameHeight }
                 ?.let {
-                    videoId to VideoSeekPreview(
+                    VideoSeekPreview(
                         pageUrls = it.urls,
                         frameWidthPx = it.frameWidth,
                         frameHeightPx = it.frameHeight,
@@ -4502,7 +4515,7 @@ class YouTubeRepository(private val context: Context) {
         }
 
         // Progressive live entries are segment endpoints, not complete files.
-        if (isLiveStream) return qualities
+        if (isLiveStream) return VideoStreamResult(qualities)
 
         val bestAudio = originalTrackAudioStreams(extractedAudioStreams)
             .asSequence()
@@ -4572,7 +4585,7 @@ class YouTubeRepository(private val context: Context) {
         // NewPipe exposes several codecs for the same label. Retain the AVC
         // MP4 variant when one exists so the download worker is not left with
         // only a VP9/WebM entry after de-duplication.
-        return qualities
+        val sortedQualities = qualities
             .groupBy { it.resolution }
             .mapNotNull { (_, variants) ->
                 variants.maxWithOrNull(
@@ -4586,14 +4599,8 @@ class YouTubeRepository(private val context: Context) {
                 compareByDescending<VideoQuality> { height(it.resolution) }
                     .thenByDescending { fps(it.resolution) }
             )
+        return VideoStreamResult(sortedQualities, seekPreview)
     }
-
-    @Volatile
-    private var cachedSeekPreview: Pair<String, VideoSeekPreview>? = null
-
-    /** Storyboard harvested by the most recent NewPipe stream extraction. */
-    fun getCachedSeekPreview(videoId: String): VideoSeekPreview? =
-        cachedSeekPreview?.takeIf { it.first == videoId }?.second
 
     /**
      * Resolve the full video quality ladder via InnerTube: ANDROID_VR first

--- a/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
+++ b/app/src/main/java/com/ivor/ivormusic/data/YouTubeRepository.kt
@@ -3514,11 +3514,9 @@ class YouTubeRepository(private val context: Context) {
     }
 
     /**
-     * Videos of one playlist via browse VL<playlistId> (first page, up to 100).
-     * Works for Watch Later ("WL") and Liked videos ("LL") too — both need
-     * login. The renderer differs per playlist surface: WL and regular
-     * playlists come as playlistVideoRenderers, LL comes as plain video
-     * lockupViewModels — parse whichever the response contains.
+     * The first page of one video playlist for browsing and playback. A normal
+     * open stays one network call; [getCompletePlaylistVideos] pays for every
+     * continuation only when an operation really needs the whole list.
      */
     suspend fun getPlaylistVideos(playlistId: String): List<VideoItem> = withContext(Dispatchers.IO) {
         try {
@@ -3533,9 +3531,6 @@ class YouTubeRepository(private val context: Context) {
             }
             val lockups = mutableListOf<org.json.JSONObject>()
             findObjectsByKey(root, "lockupViewModel", lockups)
-            // Signed out, a playlist's videos arrive as lockups rather than
-            // playlistVideoRenderers (verified August 2026), so this is the
-            // normal path there rather than the fallback it reads as.
             lockups.mapNotNull { parseLockupViewModel(it) }
                 .ifEmpty { getPlaylistVideosAnonymous(playlistId) }
         } catch (e: Exception) {
@@ -3545,27 +3540,165 @@ class YouTubeRepository(private val context: Context) {
     }
 
     /**
+     * Resolve a playlist only if one of the two independent paths reaches its
+     * real end. Used by whole-playlist download; returning null on an incomplete
+     * chain prevents a button labelled "full playlist" from silently queuing
+     * only the first exact page boundary.
+     *
+     * The WEB renderer differs per session: an authenticated response can carry
+     * `playlistVideoRenderer`s, while an anonymous public playlist uses
+     * `lockupViewModel`s. Verified August 2026: page one puts its playlist token
+     * inside `itemSectionRenderer`; later pages arrive under
+     * `appendContinuationItemsAction.continuationItems`.
+     */
+    suspend fun getCompletePlaylistVideos(playlistId: String): List<VideoItem>? =
+        withContext(Dispatchers.IO) {
+            val browseResult = getPlaylistVideosFromBrowse(playlistId)
+            if (browseResult.complete && browseResult.videos.isNotEmpty()) {
+                return@withContext browseResult.videos
+            }
+
+            val newPipeResult = getCompletePlaylistVideosFromNewPipe(playlistId)
+            if (newPipeResult.complete && newPipeResult.videos.isNotEmpty()) {
+                return@withContext newPipeResult.videos
+            }
+
+            val partialSize = maxOf(browseResult.videos.size, newPipeResult.videos.size)
+            if (partialSize > 0) {
+                KLog.w(
+                    "YouTubeRepo",
+                    "Refusing incomplete full-playlist load for $playlistId ($partialSize videos resolved)"
+                )
+            }
+            null
+        }
+
+    private data class VideoPlaylistLoadResult(
+        val videos: List<VideoItem>,
+        val complete: Boolean
+    )
+
+    private fun getPlaylistVideosFromBrowse(playlistId: String): VideoPlaylistLoadResult {
+        val browseId = if (playlistId.startsWith("VL")) playlistId else "VL$playlistId"
+        val videos = mutableListOf<VideoItem>()
+        val seenTokens = mutableSetOf<String>()
+        var json = fetchYouTubeBrowse(browseId)
+        if (json.isEmpty()) return VideoPlaylistLoadResult(emptyList(), complete = false)
+
+        return try {
+            while (true) {
+                val root = org.json.JSONObject(json)
+                val renderers = mutableListOf<org.json.JSONObject>()
+                findObjectsByKey(root, "playlistVideoRenderer", renderers)
+                if (renderers.isNotEmpty()) {
+                    videos += renderers.mapNotNull { parsePlaylistVideoRenderer(it) }
+                } else {
+                    val lockups = mutableListOf<org.json.JSONObject>()
+                    findObjectsByKey(root, "lockupViewModel", lockups)
+                    videos += lockups.mapNotNull { parseLockupViewModel(it) }
+                }
+
+                val token = extractVideoPlaylistContinuationToken(root) ?: break
+                if (!seenTokens.add(token)) {
+                    KLog.w("YouTubeRepo", "Repeated video playlist continuation for $playlistId")
+                    return VideoPlaylistLoadResult(videos, complete = false)
+                }
+                json = fetchYouTubeBrowseContinuation(token)
+                if (json.isEmpty()) {
+                    KLog.w(
+                        "YouTubeRepo",
+                        "Video playlist continuation failed for $playlistId after ${videos.size} videos"
+                    )
+                    return VideoPlaylistLoadResult(videos, complete = false)
+                }
+            }
+            VideoPlaylistLoadResult(videos, complete = true)
+        } catch (e: Exception) {
+            KLog.e("YouTubeRepo", "Video playlist browse failed for $playlistId", e)
+            VideoPlaylistLoadResult(videos, complete = false)
+        }
+    }
+
+    private fun extractVideoPlaylistContinuationToken(root: org.json.JSONObject): String? {
+        val scopes = mutableListOf<org.json.JSONObject>()
+        findObjectsByKey(root, "itemSectionRenderer", scopes)
+        findObjectsByKey(root, "playlistVideoListRenderer", scopes)
+        findObjectsByKey(root, "appendContinuationItemsAction", scopes)
+        findObjectsByKey(root, "reloadContinuationItemsCommand", scopes)
+        return scopes.asSequence().mapNotNull { scope ->
+            val tokens = mutableListOf<String>()
+            findContinuationTokens(scope, tokens)
+            tokens.firstOrNull()
+        }.firstOrNull()
+    }
+
+    private fun fetchYouTubeBrowseContinuation(token: String): String =
+        postWatchApi(
+            "browse",
+            org.json.JSONObject()
+                .put("context", webContext())
+                .put("continuation", token)
+        ).orEmpty()
+
+    /**
      * A playlist's videos through NewPipe's playlist page, as the last resort
      * when the browse above parsed to nothing.
      *
-     * **Not the signed-out path**, which was the first guess and the wrong one:
-     * NewPipe's playlist extractor collects `playlistVideoRenderer`s, and a
-     * signed-out browse returns lockups, so it comes back with zero items and
-     * *no exception* - an empty playlist page with nothing in the log to say
-     * why. It is kept because it reads a genuinely different response shape,
-     * which is exactly what is wanted in a fallback, and because it is what the
-     * music side leads with (`getPlaylistInternal`, which then falls back to an
-     * anonymous browse of its own - the same pairing, in the other order).
+     * **Not the primary signed-out path**: page-one browsing uses WEB lockups,
+     * while this is the independent full-load fallback. NewPipe's playlist
+     * extractor collects `playlistVideoRenderer`s, and a signed-out browse can
+     * therefore come back with zero items and *no exception* when that shape
+     * changes. It remains valuable here precisely because its page tokens are
+     * independent from WEB's.
      *
-     * First page only, matching the browse: neither follows continuations, and
-     * the same playlist coming back a different length depending on which path
-     * served it would be worse than both being short.
+     * Every NewPipe continuation is followed. If one fails, the rows already
+     * resolved are returned as an explicitly incomplete result so the caller
+     * can reject the batch instead of presenting a partial one as complete.
      */
-    private suspend fun getPlaylistVideosAnonymous(playlistId: String): List<VideoItem> =
+    private suspend fun getCompletePlaylistVideosFromNewPipe(
+        playlistId: String
+    ): VideoPlaylistLoadResult =
         withContext(Dispatchers.IO) {
             val listId = playlistId.removePrefix("VL")
             // The account's own feeds have no public page to fetch: asking for
             // one anonymously is a guaranteed miss, so skip the request.
+            if (listId == "WL" || listId == "LL" || listId == "LM") {
+                return@withContext VideoPlaylistLoadResult(emptyList(), complete = false)
+            }
+            try {
+                val ytService = ServiceList.all().find { it.serviceInfo.name == "YouTube" }
+                    ?: return@withContext VideoPlaylistLoadResult(emptyList(), complete = false)
+                val extractor = ytService.getPlaylistExtractor(
+                    "https://www.youtube.com/playlist?list=$listId"
+                )
+                extractor.fetchPage()
+                val videos = mutableListOf<VideoItem>()
+                var page = extractor.initialPage
+                videos += page.items.toVideoItems()
+                while (page.hasNextPage()) {
+                    try {
+                        page = extractor.getPage(page.nextPage)
+                        videos += page.items.toVideoItems()
+                    } catch (e: Exception) {
+                        KLog.w(
+                            "YouTubeRepo",
+                            "Anonymous video playlist continuation failed for $listId after ${videos.size} videos",
+                            e
+                        )
+                        return@withContext VideoPlaylistLoadResult(videos, complete = false)
+                    }
+                }
+                VideoPlaylistLoadResult(videos, complete = true)
+            } catch (e: Exception) {
+                KLog.e("YouTubeRepo", "Anonymous playlist fetch failed for $listId", e)
+                VideoPlaylistLoadResult(emptyList(), complete = false)
+            }
+        }
+
+    /** First NewPipe page only, matching [getPlaylistVideos]'s browse cost. */
+    private suspend fun getPlaylistVideosAnonymous(playlistId: String): List<VideoItem> =
+        withContext(Dispatchers.IO) {
+            val listId = playlistId.removePrefix("VL")
             if (listId == "WL" || listId == "LL" || listId == "LM") return@withContext emptyList()
             try {
                 val ytService = ServiceList.all().find { it.serviceInfo.name == "YouTube" }

--- a/app/src/main/java/com/ivor/ivormusic/ui/downloads/PlaylistDownloadSheet.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/downloads/PlaylistDownloadSheet.kt
@@ -1,0 +1,749 @@
+package com.ivor.ivormusic.ui.downloads
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.Download
+import androidx.compose.material.icons.rounded.ErrorOutline
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularWavyProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearWavyProgressIndicator
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.progressBarRangeInfo
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.material3.MaterialShapes
+import androidx.compose.material3.toShape
+import com.ivor.ivormusic.data.DownloadMediaType
+import com.ivor.ivormusic.data.DownloadProgress
+import com.ivor.ivormusic.data.DownloadRepository
+import com.ivor.ivormusic.data.DownloadStatus
+import com.ivor.ivormusic.data.Song
+import com.ivor.ivormusic.data.SongSource
+import com.ivor.ivormusic.data.ThemePreferences
+import com.ivor.ivormusic.data.VideoItem
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+private enum class PlaylistDownloadKind(
+    val itemName: String,
+    val itemNamePlural: String
+) {
+    MUSIC("track", "tracks"),
+    VIDEO("video", "videos")
+}
+
+private data class PlaylistDownloadSnapshot(
+    val eligibleIds: Set<String>,
+    val completedIds: Set<String>,
+    val active: Map<String, DownloadProgress>,
+    val failedIds: Set<String>,
+    val localOfflineCount: Int,
+    val skippedCount: Int
+) {
+    val completedCount: Int get() = completedIds.size + localOfflineCount
+    val activeCount: Int get() = active.size
+    val remainingIds: Set<String>
+        get() = eligibleIds - completedIds - active.keys
+    val remainingCount: Int get() = remainingIds.size
+    val isComplete: Boolean
+        get() = (eligibleIds.isNotEmpty() || localOfflineCount > 0) &&
+            completedIds.containsAll(eligibleIds) && skippedCount == 0
+
+    val overallProgress: Float
+        get() {
+            if (eligibleIds.isEmpty()) return if (localOfflineCount > 0) 1f else 0f
+            val total = eligibleIds.sumOf { id ->
+                when {
+                    id in completedIds -> 1.0
+                    else -> active[id]?.progress?.toDouble() ?: 0.0
+                }
+            }
+            return (total / eligibleIds.size).toFloat().coerceIn(0f, 1f)
+        }
+}
+
+/**
+ * Download entry point for a music playlist or album.
+ *
+ * Device-local songs are already offline, while YouTube songs are deduplicated
+ * by id before they reach the worker. The visible count is therefore the number
+ * of files still needed, not the number of repeated rows in the playlist.
+ */
+@Composable
+fun MusicPlaylistDownloadAction(
+    playlistTitle: String,
+    songs: List<Song>,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val repository = remember(context) { DownloadRepository.getInstance(context) }
+    val downloadedSongs by repository.downloadedSongs.collectAsState()
+    val progress by repository.downloadProgress.collectAsState()
+    var showSheet by remember(playlistTitle) { mutableStateOf(false) }
+
+    val eligibleSongs = remember(songs) {
+        songs.filter { it.source == SongSource.YOUTUBE && it.id.isNotBlank() }
+            .distinctBy { it.id }
+    }
+    val eligibleIds = remember(eligibleSongs) { eligibleSongs.mapTo(linkedSetOf()) { it.id } }
+    val downloadedIds = remember(downloadedSongs, eligibleIds) {
+        downloadedSongs.asSequence().map { it.id }.filter { it in eligibleIds }.toSet()
+    }
+    val relevantProgress = remember(progress, eligibleIds) {
+        progress.values.filter {
+            it.request.type == DownloadMediaType.MUSIC && it.request.id in eligibleIds
+        }.associateBy { it.request.id }
+    }
+    val snapshot = remember(eligibleIds, downloadedIds, relevantProgress) {
+        PlaylistDownloadSnapshot(
+            eligibleIds = eligibleIds,
+            completedIds = downloadedIds,
+            active = relevantProgress.filterValues {
+                it.status == DownloadStatus.QUEUED || it.status == DownloadStatus.DOWNLOADING
+            },
+            failedIds = relevantProgress.filterValues { it.status == DownloadStatus.FAILED }.keys,
+            localOfflineCount = songs.count { it.source == SongSource.LOCAL },
+            skippedCount = songs.count { it.source == SongSource.YOUTUBE && it.id.isBlank() }
+        )
+    }
+
+    PlaylistDownloadButton(
+        kind = PlaylistDownloadKind.MUSIC,
+        snapshot = snapshot,
+        enabled = songs.isNotEmpty(),
+        onClick = { showSheet = true },
+        modifier = modifier
+    )
+
+    if (showSheet) {
+        PlaylistDownloadSheet(
+            playlistTitle = playlistTitle,
+            kind = PlaylistDownloadKind.MUSIC,
+            playlistItemCountLabel = itemCountLabel(songs.size, PlaylistDownloadKind.MUSIC),
+            snapshot = snapshot,
+            onDismiss = { showSheet = false },
+            onQueue = {
+                repository.downloadPlaylist(eligibleSongs)
+                true
+            }
+        )
+    }
+}
+
+/** Download entry point for a video playlist, including a per-batch quality cap. */
+@Composable
+fun VideoPlaylistDownloadAction(
+    playlistId: String,
+    playlistTitle: String,
+    videos: List<VideoItem>,
+    playlistCountText: String? = null,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val repository = remember(context) { DownloadRepository.getInstance(context) }
+    val downloadedVideos by repository.downloadedVideos.collectAsState()
+    val progress by repository.downloadProgress.collectAsState()
+    var showSheet by remember(playlistTitle) { mutableStateOf(false) }
+
+    val eligibleVideos = remember(videos) {
+        videos.filter { !it.isLive && it.videoId.isNotBlank() }.distinctBy { it.videoId }
+    }
+    val eligibleIds = remember(eligibleVideos) { eligibleVideos.mapTo(linkedSetOf()) { it.videoId } }
+    val downloadedIds = remember(downloadedVideos, eligibleIds) {
+        downloadedVideos.asSequence().map { it.id }.filter { it in eligibleIds }.toSet()
+    }
+    val relevantProgress = remember(progress, eligibleIds) {
+        progress.values.filter {
+            it.request.type == DownloadMediaType.VIDEO && it.request.id in eligibleIds
+        }.associateBy { it.request.id }
+    }
+    val snapshot = remember(eligibleIds, downloadedIds, relevantProgress, videos) {
+        PlaylistDownloadSnapshot(
+            eligibleIds = eligibleIds,
+            completedIds = downloadedIds,
+            active = relevantProgress.filterValues {
+                it.status == DownloadStatus.QUEUED || it.status == DownloadStatus.DOWNLOADING
+            },
+            failedIds = relevantProgress.filterValues { it.status == DownloadStatus.FAILED }.keys,
+            localOfflineCount = 0,
+            skippedCount = videos.count { it.isLive || it.videoId.isBlank() }
+        )
+    }
+
+    PlaylistDownloadButton(
+        kind = PlaylistDownloadKind.VIDEO,
+        snapshot = snapshot,
+        enabled = videos.isNotEmpty(),
+        onClick = { showSheet = true },
+        modifier = modifier
+    )
+
+    if (showSheet) {
+        PlaylistDownloadSheet(
+            playlistTitle = playlistTitle,
+            kind = PlaylistDownloadKind.VIDEO,
+            playlistItemCountLabel = playlistCountText
+                ?.takeIf { it.isNotBlank() }
+                ?: if (videos.size >= 100) "100+ videos"
+                else itemCountLabel(videos.size, PlaylistDownloadKind.VIDEO),
+            snapshot = snapshot,
+            onDismiss = { showSheet = false },
+            onQueue = { quality ->
+                repository.downloadVideoPlaylist(playlistId, eligibleVideos, quality)
+            }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun PlaylistDownloadButton(
+    kind: PlaylistDownloadKind,
+    snapshot: PlaylistDownloadSnapshot,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val canOpen = enabled && snapshot.eligibleIds.isNotEmpty() && !snapshot.isComplete
+    val label = when {
+        snapshot.isComplete -> "Available offline"
+        snapshot.activeCount > 0 && kind == PlaylistDownloadKind.VIDEO -> "Downloading playlist"
+        snapshot.activeCount > 0 -> "Downloading ${snapshot.activeCount}"
+        snapshot.remainingCount > 0 && snapshot.remainingIds.all { it in snapshot.failedIds } ->
+            "Retry ${snapshot.remainingCount}"
+        snapshot.remainingCount > 0 && kind == PlaylistDownloadKind.VIDEO -> "Download playlist"
+        snapshot.remainingCount > 0 -> "Download ${snapshot.remainingCount}"
+        snapshot.skippedCount > 0 -> "Unavailable offline"
+        else -> "Download ${kind.itemNamePlural}"
+    }
+
+    FilledTonalButton(
+        onClick = onClick,
+        enabled = canOpen,
+        modifier = modifier,
+        shapes = ButtonDefaults.shapes()
+    ) {
+        AnimatedContent(
+            targetState = when {
+                snapshot.isComplete -> "complete"
+                snapshot.activeCount > 0 -> "active"
+                snapshot.eligibleIds.isEmpty() -> "unavailable"
+                else -> "ready"
+            },
+            transitionSpec = { fadeIn() togetherWith fadeOut() },
+            label = "playlistDownloadState"
+        ) { state ->
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                when (state) {
+                    "complete" -> Icon(Icons.Rounded.CheckCircle, contentDescription = null)
+                    "active" -> CircularWavyProgressIndicator(
+                        progress = { snapshot.overallProgress },
+                        modifier = Modifier
+                            .size(20.dp)
+                            .semantics {
+                                contentDescription = "Downloading playlist"
+                                progressBarRangeInfo = ProgressBarRangeInfo(
+                                    snapshot.overallProgress,
+                                    0f..1f
+                                )
+                            }
+                    )
+                    "unavailable" -> Icon(Icons.Rounded.ErrorOutline, contentDescription = null)
+                    else -> Icon(Icons.Rounded.Download, contentDescription = null)
+                }
+                Spacer(Modifier.width(8.dp))
+                Text(label, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            }
+        }
+    }
+}
+
+@OptIn(
+    ExperimentalMaterial3Api::class,
+    ExperimentalMaterial3ExpressiveApi::class,
+    ExperimentalLayoutApi::class
+)
+@Composable
+private fun PlaylistDownloadSheet(
+    playlistTitle: String,
+    kind: PlaylistDownloadKind,
+    playlistItemCountLabel: String,
+    snapshot: PlaylistDownloadSnapshot,
+    onDismiss: () -> Unit,
+    onQueue: suspend (qualityLabel: String?) -> Boolean
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val haptics = LocalHapticFeedback.current
+    val preferences = remember(context) { ThemePreferences(context) }
+    // This is a compact task with its own scrolling body and pinned action. Opening
+    // halfway hides the quality and summary context while making the first scroll
+    // gesture resize the sheet, so enter directly at the expanded anchor.
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var selectedQuality by remember {
+        mutableStateOf(preferences.getDownloadVideoQuality())
+    }
+    var rememberQuality by remember { mutableStateOf(false) }
+    var queued by remember { mutableStateOf(false) }
+    var queueing by remember { mutableStateOf(false) }
+    var queueFailed by remember { mutableStateOf(false) }
+    val localOnly = remember { ThemePreferences.isLocalOnly(context) }
+
+    LaunchedEffect(queued) {
+        if (queued) {
+            delay(850)
+            onDismiss()
+        }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        contentColor = MaterialTheme.colorScheme.onSurface
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(0.9f)
+        ) {
+            LazyColumn(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth(),
+                contentPadding = PaddingValues(
+                    start = 20.dp,
+                    end = 20.dp,
+                    bottom = 16.dp
+                ),
+                verticalArrangement = Arrangement.spacedBy(18.dp)
+            ) {
+                item {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 8.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Surface(
+                            shape = MaterialShapes.Cookie9Sided.toShape(),
+                            color = MaterialTheme.colorScheme.primaryContainer,
+                            modifier = Modifier.size(64.dp)
+                        ) {
+                            Box(contentAlignment = Alignment.Center) {
+                                Icon(
+                                    imageVector = Icons.Rounded.Download,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(30.dp),
+                                    tint = MaterialTheme.colorScheme.onPrimaryContainer
+                                )
+                            }
+                        }
+                        Spacer(Modifier.height(14.dp))
+                        Text(
+                            text = "Download playlist",
+                            style = MaterialTheme.typography.headlineSmall,
+                            fontWeight = FontWeight.Bold,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                        Text(
+                            text = playlistTitle,
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                }
+
+                item {
+                    Surface(
+                        shape = RoundedCornerShape(20.dp),
+                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(10.dp)
+                        ) {
+                            DownloadSummaryRow("In playlist", playlistItemCountLabel)
+                            if (kind == PlaylistDownloadKind.VIDEO) {
+                                DownloadSummaryRow(
+                                    "Loaded now",
+                                    itemCountLabel(
+                                        snapshot.eligibleIds.size + snapshot.skippedCount,
+                                        kind
+                                    )
+                                )
+                                DownloadSummaryRow(
+                                    "Already offline here",
+                                    itemCountLabel(snapshot.completedCount, kind)
+                                )
+                                Text(
+                                    text = "Every remaining playlist page is resolved after you confirm; existing downloads are skipped then too.",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            } else {
+                                DownloadSummaryRow(
+                                    "Already offline",
+                                    itemCountLabel(snapshot.completedCount, kind)
+                                )
+                                DownloadSummaryRow(
+                                    "To download",
+                                    itemCountLabel(snapshot.remainingCount, kind)
+                                )
+                            }
+                            if (snapshot.activeCount > 0) {
+                                DownloadSummaryRow(
+                                    "In progress",
+                                    itemCountLabel(snapshot.activeCount, kind)
+                                )
+                                LinearWavyProgressIndicator(
+                                    progress = { snapshot.overallProgress },
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .semantics {
+                                            contentDescription = "Playlist download progress"
+                                            progressBarRangeInfo = ProgressBarRangeInfo(
+                                                snapshot.overallProgress,
+                                                0f..1f
+                                            )
+                                        }
+                                )
+                            }
+                        }
+                    }
+                }
+
+                if (kind == PlaylistDownloadKind.VIDEO) {
+                    item {
+                        Column(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalArrangement = Arrangement.spacedBy(10.dp)
+                        ) {
+                            Text(
+                                text = "Video quality",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                            Text(
+                                text = "Each video uses the best MP4 quality at or below this limit.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            FlowRow(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                verticalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                ThemePreferences.VIDEO_QUALITY_OPTIONS.forEach { quality ->
+                                    BatchQualityPill(
+                                        label = if (quality == ThemePreferences.VIDEO_QUALITY_AUTO) {
+                                            "Best available"
+                                        } else quality,
+                                        selected = selectedQuality == quality,
+                                        onClick = { selectedQuality = quality }
+                                    )
+                                }
+                            }
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable { rememberQuality = !rememberQuality }
+                                    .padding(vertical = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(
+                                        text = "Remember this quality",
+                                        style = MaterialTheme.typography.titleSmall,
+                                        fontWeight = FontWeight.SemiBold
+                                    )
+                                    Text(
+                                        text = "Use it for future video downloads",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                                Switch(
+                                    checked = rememberQuality,
+                                    onCheckedChange = { rememberQuality = it }
+                                )
+                            }
+                        }
+                    }
+                } else {
+                    item {
+                        val musicQuality = remember {
+                            ThemePreferences.currentMusicQuality(context)
+                        }
+                        Text(
+                            text = "Music uses your ${musicQuality.replaceFirstChar { it.uppercase() }} quality setting for this network.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+
+                if (snapshot.skippedCount > 0 || localOnly) {
+                    item {
+                        Surface(
+                            shape = RoundedCornerShape(16.dp),
+                            color = if (localOnly) MaterialTheme.colorScheme.errorContainer
+                                else MaterialTheme.colorScheme.secondaryContainer,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Row(
+                                modifier = Modifier.padding(14.dp),
+                                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Rounded.ErrorOutline,
+                                    contentDescription = null,
+                                    tint = if (localOnly) MaterialTheme.colorScheme.onErrorContainer
+                                        else MaterialTheme.colorScheme.onSecondaryContainer
+                                )
+                                Text(
+                                    text = when {
+                                        localOnly -> "Turn off Local only mode before starting a download."
+                                        kind == PlaylistDownloadKind.VIDEO ->
+                                            "${itemCountLabel(snapshot.skippedCount, kind)} can't be downloaded while live and will be skipped."
+                                        else ->
+                                            "${itemCountLabel(snapshot.skippedCount, kind)} has no downloadable source and will be skipped."
+                                    },
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = if (localOnly) MaterialTheme.colorScheme.onErrorContainer
+                                        else MaterialTheme.colorScheme.onSecondaryContainer,
+                                    modifier = Modifier.weight(1f)
+                                )
+                            }
+                        }
+                    }
+                }
+
+                if (queueFailed) {
+                    item {
+                        Surface(
+                            shape = RoundedCornerShape(16.dp),
+                            color = MaterialTheme.colorScheme.errorContainer,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Row(
+                                modifier = Modifier.padding(14.dp),
+                                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Rounded.ErrorOutline,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onErrorContainer
+                                )
+                                Text(
+                                    text = "Couldn't load the complete playlist. Check your connection and try again.",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onErrorContainer,
+                                    modifier = Modifier.weight(1f)
+                                )
+                            }
+                        }
+                    }
+                }
+
+                item {
+                    Text(
+                        text = "Downloads continue in the background. Existing downloads and repeated items are skipped automatically.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
+
+            Surface(
+                color = MaterialTheme.colorScheme.surfaceContainer,
+                tonalElevation = 2.dp,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Button(
+                    onClick = {
+                        haptics.performHapticFeedback(HapticFeedbackType.Confirm)
+                        queueing = true
+                        queueFailed = false
+                        scope.launch {
+                            val success = onQueue(
+                                selectedQuality.takeIf { kind == PlaylistDownloadKind.VIDEO }
+                            )
+                            queueing = false
+                            if (success) {
+                                if (kind == PlaylistDownloadKind.VIDEO && rememberQuality) {
+                                    preferences.setDownloadVideoQuality(selectedQuality)
+                                }
+                                queued = true
+                            } else {
+                                queueFailed = true
+                            }
+                        }
+                    },
+                    enabled = snapshot.remainingCount > 0 && !queued && !queueing && !localOnly,
+                    shapes = ButtonDefaults.shapes(),
+                    modifier = Modifier
+                        .padding(horizontal = 20.dp, vertical = 16.dp)
+                        .fillMaxWidth()
+                        .height(56.dp)
+                ) {
+                    val label = when {
+                        queued -> "Added to downloads"
+                        queueing -> if (kind == PlaylistDownloadKind.VIDEO) {
+                            "Loading full playlist..."
+                        } else "Adding to downloads..."
+                        localOnly -> "Local only mode is on"
+                        snapshot.isComplete -> "Already available offline"
+                        snapshot.remainingCount == 0 && snapshot.activeCount > 0 -> "Downloading"
+                        snapshot.remainingIds.all { it in snapshot.failedIds } ->
+                            "Retry ${itemCountLabel(snapshot.remainingCount, kind)}"
+                        kind == PlaylistDownloadKind.VIDEO -> "Download full playlist"
+                        else -> "Download ${itemCountLabel(snapshot.remainingCount, kind)}"
+                    }
+                    if (queueing) {
+                        LoadingIndicator(modifier = Modifier.size(22.dp))
+                    } else {
+                        Icon(
+                            imageVector = if (queued || snapshot.isComplete) Icons.Rounded.CheckCircle
+                                else Icons.Rounded.Download,
+                            contentDescription = null
+                        )
+                    }
+                    Spacer(Modifier.width(8.dp))
+                    Text(label, fontWeight = FontWeight.SemiBold)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DownloadSummaryRow(label: String, value: String) {
+    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f)
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.End
+        )
+    }
+}
+
+private fun itemCountLabel(count: Int, kind: PlaylistDownloadKind): String =
+    "$count ${if (count == 1) kind.itemName else kind.itemNamePlural}"
+
+@Composable
+private fun BatchQualityPill(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val pressed by interactionSource.collectIsPressedAsState()
+    val scale by animateFloatAsState(
+        targetValue = if (pressed) 0.94f else 1f,
+        animationSpec = spring(dampingRatio = 0.65f),
+        label = "batchQualityScale"
+    )
+    val color by animateColorAsState(
+        targetValue = if (selected) MaterialTheme.colorScheme.primaryContainer
+            else MaterialTheme.colorScheme.surfaceContainerHigh,
+        label = "batchQualityColor"
+    )
+    Surface(
+        shape = RoundedCornerShape(if (selected) 14.dp else 24.dp),
+        color = color,
+        modifier = Modifier
+            .scale(scale)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick
+            )
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            if (selected) {
+                Icon(Icons.Rounded.Check, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(6.dp))
+            }
+            Text(label, style = MaterialTheme.typography.labelLarge)
+        }
+    }
+}

--- a/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/library/LibraryScreen.kt
@@ -79,6 +79,7 @@ import com.ivor.ivormusic.data.Song
 import com.ivor.ivormusic.data.ThemePreferences
 import com.ivor.ivormusic.ui.artist.ArtistScreen
 import com.ivor.ivormusic.ui.components.ExpressivePullToRefresh
+import com.ivor.ivormusic.ui.downloads.MusicPlaylistDownloadAction
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.runtime.mutableFloatStateOf
 import com.ivor.ivormusic.ui.home.HomeViewModel
@@ -3064,6 +3065,19 @@ fun PlaylistDetailScreen(
                                     }
                                 }
                             }
+                        }
+
+                        // Saving keeps a live reference; downloading makes the
+                        // loaded snapshot available offline. They stay separate
+                        // actions because either can be useful without the other.
+                        if (songs.isNotEmpty()) {
+                            MusicPlaylistDownloadAction(
+                                playlistTitle = resolvedPlaylist.name,
+                                songs = songs,
+                                modifier = Modifier.padding(
+                                    top = if (canSavePlaylist) 12.dp else 20.dp
+                                )
+                            )
                         }
                     }
                 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/player/PlayerViewModel.kt
@@ -120,7 +120,7 @@ class PlayerViewModel(private val context: Context) : ViewModel() {
     val isLoadingMore: StateFlow<Boolean> = _isLoadingMore.asStateFlow()
     
     // Lyrics Repository and State
-    private val lyricsRepository = LyricsRepository()
+    private val lyricsRepository = LyricsRepository(context)
     
     // Stats Repository
     private val statsRepository = com.ivor.ivormusic.data.StatsRepository(context)

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VerticalLivePlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VerticalLivePlayerContent.kt
@@ -149,6 +149,7 @@ fun VerticalLivePlayerContent(
     likeStatus: LikeStatus,
     onPlayPause: () -> Unit,
     onSeek: (Float) -> Unit,
+    onScrubbingChanged: (Boolean) -> Unit = {},
     onSeekBackward: () -> Unit,
     onSeekForward: () -> Unit,
     onSeekToLive: () -> Unit,
@@ -547,11 +548,14 @@ fun VerticalLivePlayerContent(
                             horizontalArrangement = Arrangement.spacedBy(10.dp)
                         ) {
                             PlayerSeekBar(
+                                mediaId = video.videoId,
                                 progress = progress,
                                 bufferedProgress = bufferedProgress,
                                 onSeek = onSeek,
                                 modifier = Modifier.weight(1f),
                                 durationMs = duration,
+                                showSeekPreview = false,
+                                onScrubbingChanged = onScrubbingChanged,
                                 onTonalSurface = true
                             )
                             LiveEdgeChip(

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoLibraryScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoLibraryScreen.kt
@@ -101,6 +101,7 @@ import com.ivor.ivormusic.ui.components.ExpressivePullToRefresh
 import com.ivor.ivormusic.ui.components.PlaylistRowSkeleton
 import com.ivor.ivormusic.ui.components.SkeletonList
 import com.ivor.ivormusic.ui.components.PredictiveBackStack
+import com.ivor.ivormusic.ui.downloads.VideoPlaylistDownloadAction
 import com.ivor.ivormusic.ui.home.HomeViewModel
 
 /**
@@ -1256,6 +1257,20 @@ fun VideoPlaylistDetail(
                 ),
                 verticalArrangement = Arrangement.spacedBy(10.dp)
             ) {
+                item {
+                    // A batch download is a playlist action, not one more row
+                    // menu item. Keeping it above the list makes the action
+                    // reachable without obscuring playback or removal controls.
+                    VideoPlaylistDownloadAction(
+                        playlistId = playlist.playlistId,
+                        playlistTitle = playlist.title,
+                        videos = videos,
+                        playlistCountText = playlist.videoCountText,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp)
+                    )
+                }
                 // Index-qualified: YouTube playlists can contain the same video
                 // twice, and duplicate LazyColumn keys crash
                 itemsIndexed(videos, key = { index, video -> "${video.videoId}_$index" }) { index, video ->

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerContent.kt
@@ -18,6 +18,7 @@ import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -26,10 +27,16 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.Chat
+import androidx.compose.material.icons.automirrored.rounded.Comment
+import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.PictureInPictureAlt
 import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.RepeatOne
 import androidx.compose.material.icons.rounded.Speed
+import androidx.compose.material.icons.rounded.StayCurrentPortrait
 import androidx.compose.material.icons.rounded.Tune
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -46,6 +53,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
@@ -128,6 +136,7 @@ fun VideoPlayerContent(
             )
     }
     val isCaptionsLoading by viewModel.isCaptionsLoading.collectAsState()
+    val isAutoplayEnabled by viewModel.isAutoplayEnabled.collectAsState()
     val isLooping by viewModel.isLooping.collectAsState()
     val playbackSpeed by viewModel.playbackSpeed.collectAsState()
     val playbackError by viewModel.playbackError.collectAsState()
@@ -161,6 +170,9 @@ fun VideoPlayerContent(
 
     // Local UI State
     var showControls by remember { mutableStateOf(false) }
+    // Keyed to the video so a source switch can never inherit a drag that
+    // belonged to the old timeline.
+    var isSeekScrubbing by remember(video?.videoId) { mutableStateOf(false) }
     var isFullscreen by remember { mutableStateOf(false) }
     var showChaptersSheet by remember { mutableStateOf(false) }
     var showCaptionsSheet by remember { mutableStateOf(false) }
@@ -308,8 +320,8 @@ fun VideoPlayerContent(
     }
 
     // Auto-hide controls
-    LaunchedEffect(showControls, isPlaying) {
-        if (showControls && isPlaying) {
+    LaunchedEffect(showControls, isPlaying, isSeekScrubbing) {
+        if (showControls && isPlaying && !isSeekScrubbing) {
             delay(4000)
             showControls = false
         }
@@ -440,9 +452,9 @@ fun VideoPlayerContent(
         onDispose { listener.disable() }
     }
     
-    // Quality Sheet State
-    var showQualitySheet by remember { mutableStateOf(false) }
-    val sheetState = rememberModalBottomSheetState()
+    // Playback-settings sheet state
+    var showPlaybackSettings by remember { mutableStateOf(false) }
+    val playbackSettingsSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     // Comments Sheet + Sign-in Dialog State
     var showCommentsSheet by remember { mutableStateOf(false) }
@@ -562,6 +574,7 @@ fun VideoPlayerContent(
             ) {
                 FullscreenPlayerContent(
                 exoPlayer = exoPlayer,
+                videoId = currentVideo.videoId,
                 showControls = showControls,
                 onToggleControls = { showControls = !showControls },
                 hasError = playbackError != null,
@@ -569,7 +582,6 @@ fun VideoPlayerContent(
                 isLoading = isLoading,
                 isBuffering = isBuffering,
                 isPlaying = isPlaying,
-                isLooping = isLooping,
                 currentPosition = currentPosition,
                 duration = duration,
                 progress = progress,
@@ -578,6 +590,7 @@ fun VideoPlayerContent(
                 videoTitle = currentVideo.title,
                 onPlayPause = { viewModel.togglePlayPause() },
                 onSeek = { newProgress -> exoPlayer.seekTo((newProgress * duration).toLong()) },
+                onScrubbingChanged = { isSeekScrubbing = it },
                 onSeekBackward = { seekBy(-VideoPlayerViewModel.SEEK_STEP_MS) },
                 onSeekForward = { seekBy(VideoPlayerViewModel.SEEK_STEP_MS) },
                 onBack = {
@@ -588,29 +601,7 @@ fun VideoPlayerContent(
                     isFullscreen = false
                     fullscreenIsPortrait = false
                 },
-                onSettings = { showQualitySheet = true },
-                onLoopToggle = { viewModel.toggleLooping() },
-                showPipButton = pipSupported,
-                onPipClick = {
-                    val host = activity as? androidx.activity.ComponentActivity
-                    if (host != null) {
-                        enterPipMode(host)
-                    }
-                },
-                showTimedCommentsButton = timedCommentsFeatureEnabled,
-                timedCommentsActive = timedCommentsActive,
-                onTimedCommentsToggle = { timedCommentsActive = !timedCommentsActive },
-                showCommentsButton = !isLive && commentsToken != null && !fullscreenIsPortrait,
-                commentsActive = showCommentsSheet,
-                onCommentsToggle = {
-                    if (showCommentsSheet) {
-                        showCommentsSheet = false
-                    } else {
-                        viewModel.ensureCommentsLoaded()
-                        showCommentsSheet = true
-                        showControls = false
-                    }
-                },
+                onSettings = { showPlaybackSettings = true },
                 chapters = chapters,
                 onOpenChapters = { showChaptersSheet = true },
                 captionsActive = selectedCaption != null,
@@ -624,10 +615,7 @@ fun VideoPlayerContent(
                 hasNextInQueue = queue?.hasNext == true,
                 onPreviousInQueue = { viewModel.playPreviousInQueue() },
                 onNextInQueue = { viewModel.playNextInQueue() },
-                onOpenQueue = { showQueueSheet = true },
                 isLive = isLive,
-                liveChatActive = showLiveChat,
-                onLiveChatToggle = { showLiveChat = !showLiveChat },
                 onSeekToLive = { exoPlayer.seekToDefaultPosition() },
                 // A pillarboxed 9:16 stream and a docked chat column are the
                 // one pairing where landscape wastes nothing - but only if the
@@ -794,6 +782,7 @@ fun VideoPlayerContent(
                     likeStatus = engagement?.likeStatus ?: LikeStatus.INDIFFERENT,
                     onPlayPause = { viewModel.togglePlayPause() },
                     onSeek = { newProgress -> exoPlayer.seekTo((newProgress * duration).toLong()) },
+                    onScrubbingChanged = { isSeekScrubbing = it },
                     onSeekBackward = { seekBy(-VideoPlayerViewModel.SEEK_STEP_MS) },
                     onSeekForward = { seekBy(VideoPlayerViewModel.SEEK_STEP_MS) },
                     onSeekToLive = { exoPlayer.seekToDefaultPosition() },
@@ -804,7 +793,7 @@ fun VideoPlayerContent(
                         viewModel.ensureCaptionsLoaded()
                         showCaptionsSheet = true
                     },
-                    onSettings = { showQualitySheet = true },
+                    onSettings = { showPlaybackSettings = true },
                     onSubscribeClick = { requireSubscribeLogin { viewModel.toggleSubscribe() } },
                     onLikeClick = { requireLogin { viewModel.toggleLike() } },
                     onRetry = { viewModel.retryPlayback() },
@@ -881,6 +870,7 @@ fun VideoPlayerContent(
                 ) {
                     PortraitPlayerContent(
                         exoPlayer = exoPlayer,
+                        videoId = currentVideo.videoId,
                         showControls = showControls,
                         onToggleControls = { showControls = !showControls },
                         hasError = playbackError != null,
@@ -888,7 +878,6 @@ fun VideoPlayerContent(
                         isLoading = isLoading,
                         isBuffering = isBuffering,
                         isPlaying = isPlaying,
-                        isLooping = isLooping,
                         currentPosition = currentPosition,
                         duration = duration,
                         progress = progress,
@@ -897,6 +886,7 @@ fun VideoPlayerContent(
                         videoTitle = currentVideo.title,
                         onPlayPause = { viewModel.togglePlayPause() },
                         onSeek = { newProgress -> exoPlayer.seekTo((newProgress * duration).toLong()) },
+                        onScrubbingChanged = { isSeekScrubbing = it },
                         onSeekBackward = { seekBy(-VideoPlayerViewModel.SEEK_STEP_MS) },
                         onSeekForward = { seekBy(VideoPlayerViewModel.SEEK_STEP_MS) },
                         onBack = onBackClick,
@@ -906,11 +896,7 @@ fun VideoPlayerContent(
                             fullscreenIsPortrait = portraitFullscreenAvailable
                             isFullscreen = true
                         },
-                        onSettings = { showQualitySheet = true },
-                        onLoopToggle = { viewModel.toggleLooping() },
-                        showTimedCommentsButton = timedCommentsFeatureEnabled,
-                        timedCommentsActive = timedCommentsActive,
-                        onTimedCommentsToggle = { timedCommentsActive = !timedCommentsActive },
+                        onSettings = { showPlaybackSettings = true },
                         chapters = chapters,
                         onOpenChapters = { showChaptersSheet = true },
                         captionsActive = selectedCaption != null,
@@ -926,15 +912,6 @@ fun VideoPlayerContent(
                         onNextInQueue = { viewModel.playNextInQueue() },
                         isLive = isLive,
                         onSeekToLive = { exoPlayer.seekToDefaultPosition() },
-                        showVerticalLiveButton = verticalLiveAvailable,
-                        onVerticalLiveClick = { showVideoPageForVerticalLive = false },
-                        showPipButton = pipSupported,
-                        onPipClick = {
-                            val host = activity as? androidx.activity.ComponentActivity
-                            if (host != null) {
-                                enterPipMode(host)
-                            }
-                        },
                         minimizeDragEnabled = true,
                         onMinimizeDragDelta = onMinimizeDragDelta,
                         onMinimizeDragRelease = onMinimizeDragRelease,
@@ -1203,16 +1180,74 @@ fun VideoPlayerContent(
         )
     }
 
+    // One settings body serves the portrait sheet and fullscreen side panel.
+    // Keeping the action wiring here prevents the two surfaces from drifting
+    // back into different feature sets.
+    val playbackSettingsContent: @Composable () -> Unit = {
+        PlayerSettingsSections(
+            isLoading = isLoading,
+            qualities = availableQualities,
+            currentQuality = currentQuality,
+            onQualitySelected = { viewModel.setQuality(it) },
+            playbackSpeed = playbackSpeed,
+            onSpeedSelected = { viewModel.setPlaybackSpeed(it) },
+            showEndBehavior = !isLive,
+            autoplayEnabled = isAutoplayEnabled,
+            onAutoplayChanged = viewModel::setAutoplayEnabled,
+            isLooping = isLooping,
+            onLoopChanged = { enabled ->
+                if (enabled != isLooping) viewModel.toggleLooping()
+            },
+            showPip = pipSupported,
+            onPipClick = {
+                showPlaybackSettings = false
+                val host = activity as? androidx.activity.ComponentActivity
+                if (host != null) enterPipMode(host)
+            },
+            showComments = !isLive && commentsToken != null,
+            commentsActive = showCommentsSheet,
+            onCommentsClick = {
+                showPlaybackSettings = false
+                if (showCommentsSheet) {
+                    showCommentsSheet = false
+                } else {
+                    viewModel.ensureCommentsLoaded()
+                    showCommentsSheet = true
+                    showControls = false
+                }
+            },
+            showQueue = queue != null,
+            onQueueClick = {
+                showPlaybackSettings = false
+                showQueueSheet = true
+            },
+            showTimedComments = timedCommentsFeatureEnabled && !isLive,
+            timedCommentsActive = timedCommentsActive,
+            onTimedCommentsChanged = { timedCommentsActive = it },
+            showLiveChat = isLive && isLiveChatAvailable == true,
+            liveChatActive = showLiveChat,
+            onLiveChatChanged = { enabled ->
+                showPlaybackSettings = false
+                showLiveChat = enabled
+            },
+            showVerticalLive = verticalLiveAvailable && showVideoPageForVerticalLive,
+            onVerticalLiveClick = {
+                showPlaybackSettings = false
+                showVideoPageForVerticalLive = false
+            }
+        )
+    }
+
     // Playback settings: bottom sheet in portrait, side panel over the video
     // in fullscreen landscape so the video stays visible while adjusting
-    androidx.activity.compose.BackHandler(enabled = showQualitySheet && isFullscreen) {
-        showQualitySheet = false
+    androidx.activity.compose.BackHandler(enabled = showPlaybackSettings && isFullscreen) {
+        showPlaybackSettings = false
     }
 
     if (isFullscreen) {
         Box(modifier = Modifier.fillMaxSize()) {
             AnimatedVisibility(
-                visible = showQualitySheet,
+                visible = showPlaybackSettings,
                 enter = fadeIn(),
                 exit = fadeOut()
             ) {
@@ -1223,11 +1258,11 @@ fun VideoPlayerContent(
                         .clickable(
                             interactionSource = remember { MutableInteractionSource() },
                             indication = null
-                        ) { showQualitySheet = false }
+                        ) { showPlaybackSettings = false }
                 )
             }
             AnimatedVisibility(
-                visible = showQualitySheet,
+                visible = showPlaybackSettings,
                 modifier = Modifier.align(Alignment.CenterEnd),
                 enter = slideInHorizontally(
                     animationSpec = spring(stiffness = 300f, dampingRatio = 0.8f),
@@ -1258,32 +1293,27 @@ fun VideoPlayerContent(
                                 color = MaterialTheme.colorScheme.onSurface,
                                 modifier = Modifier.weight(1f)
                             )
-                            FilledTonalIconButton(onClick = { showQualitySheet = false }) {
+                            FilledTonalIconButton(onClick = { showPlaybackSettings = false }) {
                                 Icon(Icons.Rounded.Close, contentDescription = "Close")
                             }
                         }
                         Spacer(modifier = Modifier.height(16.dp))
-                        PlayerSettingsSections(
-                            isLoading = isLoading,
-                            qualities = availableQualities,
-                            currentQuality = currentQuality,
-                            onQualitySelected = { viewModel.setQuality(it) },
-                            playbackSpeed = playbackSpeed,
-                            onSpeedSelected = { viewModel.setPlaybackSpeed(it) }
-                        )
+                        playbackSettingsContent()
                     }
                 }
             }
         }
-    } else if (showQualitySheet) {
+    } else if (showPlaybackSettings) {
         ModalBottomSheet(
-            onDismissRequest = { showQualitySheet = false },
-            sheetState = sheetState,
+            onDismissRequest = { showPlaybackSettings = false },
+            sheetState = playbackSettingsSheetState,
             containerColor = MaterialTheme.colorScheme.surfaceContainer,
             contentColor = MaterialTheme.colorScheme.onSurface
         ) {
             Column(
                 modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
                     .padding(horizontal = 24.dp)
                     .padding(bottom = 32.dp)
             ) {
@@ -1294,24 +1324,16 @@ fun VideoPlayerContent(
                     color = MaterialTheme.colorScheme.onSurface
                 )
                 Spacer(modifier = Modifier.height(12.dp))
-                PlayerSettingsSections(
-                    isLoading = isLoading,
-                    qualities = availableQualities,
-                    currentQuality = currentQuality,
-                    onQualitySelected = { viewModel.setQuality(it) },
-                    playbackSpeed = playbackSpeed,
-                    onSpeedSelected = { viewModel.setPlaybackSpeed(it) }
-                )
+                playbackSettingsContent()
             }
         }
     }
 }
 
 /**
- * Shared quality + speed pickers for the playback settings surface. Options
- * are expressive ToggleButton pills (shape-morph on select) laid out in a
- * FlowRow, so they wrap to the available width in both the portrait sheet
- * and the landscape side panel.
+ * Shared content for the portrait playback sheet and fullscreen side panel.
+ * End behavior is explicit, quality and speed remain quick pill choices, and
+ * low-frequency actions are labeled rows instead of mystery icons over video.
  */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalLayoutApi::class)
 @Composable
@@ -1321,12 +1343,73 @@ private fun PlayerSettingsSections(
     currentQuality: VideoQuality?,
     onQualitySelected: (VideoQuality) -> Unit,
     playbackSpeed: Float,
-    onSpeedSelected: (Float) -> Unit
+    onSpeedSelected: (Float) -> Unit,
+    showEndBehavior: Boolean,
+    autoplayEnabled: Boolean,
+    onAutoplayChanged: (Boolean) -> Unit,
+    isLooping: Boolean,
+    onLoopChanged: (Boolean) -> Unit,
+    showPip: Boolean,
+    onPipClick: () -> Unit,
+    showComments: Boolean,
+    commentsActive: Boolean,
+    onCommentsClick: () -> Unit,
+    showQueue: Boolean,
+    onQueueClick: () -> Unit,
+    showTimedComments: Boolean,
+    timedCommentsActive: Boolean,
+    onTimedCommentsChanged: (Boolean) -> Unit,
+    showLiveChat: Boolean,
+    liveChatActive: Boolean,
+    onLiveChatChanged: (Boolean) -> Unit,
+    showVerticalLive: Boolean,
+    onVerticalLiveClick: () -> Unit
 ) {
     val optionColors = ToggleButtonDefaults.toggleButtonColors(
         containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
         contentColor = MaterialTheme.colorScheme.onSurfaceVariant
     )
+
+    if (showEndBehavior) {
+        SettingsSectionLabel(icon = Icons.Rounded.PlayArrow, label = "When video ends")
+        Spacer(modifier = Modifier.height(8.dp))
+        Surface(
+            shape = RoundedCornerShape(20.dp),
+            color = MaterialTheme.colorScheme.surfaceContainerHigh
+        ) {
+            Column {
+                SettingsToggleRow(
+                    icon = Icons.Rounded.PlayArrow,
+                    title = "Autoplay",
+                    supportingText = if (autoplayEnabled) {
+                        "Play the next playlist or related video"
+                    } else {
+                        "Stop and stay on this video"
+                    },
+                    checked = autoplayEnabled,
+                    onCheckedChange = onAutoplayChanged
+                )
+                HorizontalDivider(
+                    modifier = Modifier.padding(start = 64.dp),
+                    color = MaterialTheme.colorScheme.outlineVariant
+                )
+                SettingsToggleRow(
+                    icon = Icons.Rounded.RepeatOne,
+                    title = "Loop video",
+                    supportingText = if (!autoplayEnabled) {
+                        "Turning this on also enables Autoplay"
+                    } else if (isLooping) {
+                        "Repeat this video instead of moving on"
+                    } else {
+                        "Repeat this video when it ends"
+                    },
+                    checked = isLooping,
+                    onCheckedChange = onLoopChanged
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+    }
 
     SettingsSectionLabel(icon = Icons.Rounded.Tune, label = "Quality")
     Spacer(modifier = Modifier.height(12.dp))
@@ -1397,6 +1480,129 @@ private fun PlayerSettingsSections(
             }
         }
     }
+
+    val hasSecondaryActions = showPip || showComments || showQueue ||
+        showTimedComments || showLiveChat || showVerticalLive
+    if (hasSecondaryActions) {
+        Spacer(modifier = Modifier.height(24.dp))
+        SettingsSectionLabel(icon = Icons.Rounded.Tune, label = "More controls")
+        Spacer(modifier = Modifier.height(8.dp))
+        Surface(
+            shape = RoundedCornerShape(20.dp),
+            color = MaterialTheme.colorScheme.surfaceContainerHigh
+        ) {
+            Column {
+                if (showPip) {
+                    SettingsActionRow(
+                        icon = Icons.Rounded.PictureInPictureAlt,
+                        title = "Picture in picture",
+                        supportingText = "Keep watching over other apps",
+                        onClick = onPipClick
+                    )
+                }
+                if (showComments) {
+                    SettingsActionRow(
+                        icon = Icons.AutoMirrored.Rounded.Comment,
+                        title = if (commentsActive) "Close comments" else "Comments",
+                        supportingText = if (commentsActive) {
+                            "Return to the full video"
+                        } else {
+                            "Browse the conversation"
+                        },
+                        onClick = onCommentsClick
+                    )
+                }
+                if (showQueue) {
+                    SettingsActionRow(
+                        icon = Icons.AutoMirrored.Rounded.PlaylistPlay,
+                        title = "Playlist queue",
+                        supportingText = "See and choose what plays next",
+                        onClick = onQueueClick
+                    )
+                }
+                if (showTimedComments) {
+                    SettingsToggleRow(
+                        icon = Icons.AutoMirrored.Rounded.Comment,
+                        title = "Timed comments",
+                        supportingText = "Show comments at their video moments",
+                        checked = timedCommentsActive,
+                        onCheckedChange = onTimedCommentsChanged
+                    )
+                }
+                if (showLiveChat) {
+                    SettingsToggleRow(
+                        icon = Icons.AutoMirrored.Rounded.Chat,
+                        title = "Live chat",
+                        supportingText = "Show the conversation beside the stream",
+                        checked = liveChatActive,
+                        onCheckedChange = onLiveChatChanged
+                    )
+                }
+                if (showVerticalLive) {
+                    SettingsActionRow(
+                        icon = Icons.Rounded.StayCurrentPortrait,
+                        title = "Vertical live view",
+                        supportingText = "Return to the full-height stream",
+                        onClick = onVerticalLiveClick
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SettingsToggleRow(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    title: String,
+    supportingText: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    ListItem(
+        supportingContent = { Text(supportingText) },
+        leadingContent = {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = if (checked) MaterialTheme.colorScheme.primary
+                    else MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        },
+        trailingContent = {
+            Switch(
+                checked = checked,
+                onCheckedChange = null
+            )
+        },
+        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+        modifier = Modifier.toggleable(
+            value = checked,
+            role = Role.Switch,
+            onValueChange = onCheckedChange
+        )
+    ) { Text(title) }
+}
+
+@Composable
+private fun SettingsActionRow(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    title: String,
+    supportingText: String,
+    onClick: () -> Unit
+) {
+    ListItem(
+        supportingContent = { Text(supportingText) },
+        leadingContent = {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        },
+        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+        modifier = Modifier.clickable(onClick = onClick)
+    ) { Text(title) }
 }
 
 /**

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.displayCutoutPadding
@@ -66,21 +67,17 @@ import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.ClosedCaption
 import androidx.compose.material.icons.rounded.ClosedCaptionOff
-import androidx.compose.material.icons.rounded.PictureInPictureAlt
 import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.Error
 import androidx.compose.material.icons.rounded.ExpandMore
 import androidx.compose.material.icons.rounded.Forward10
 import androidx.compose.material.icons.rounded.Fullscreen
 import androidx.compose.material.icons.rounded.FullscreenExit
-import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.Refresh
-import androidx.compose.material.icons.rounded.RepeatOne
 import androidx.compose.material.icons.rounded.Replay10
 import androidx.compose.material.icons.rounded.Settings
-import androidx.compose.material.icons.rounded.StayCurrentPortrait
 import androidx.compose.material.icons.rounded.Share
 import androidx.compose.material.icons.rounded.SkipNext
 import androidx.compose.material.icons.rounded.SkipPrevious
@@ -91,8 +88,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ContainedLoadingIndicator
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledIconButton
@@ -250,6 +245,7 @@ internal fun CaptionOverlay(
 @Composable
 fun FullscreenPlayerContent(
     exoPlayer: ExoPlayer,
+    videoId: String,
     showControls: Boolean,
     onToggleControls: () -> Unit,
     hasError: Boolean,
@@ -257,7 +253,6 @@ fun FullscreenPlayerContent(
     isLoading: Boolean,
     isBuffering: Boolean,
     isPlaying: Boolean,
-    isLooping: Boolean,
     currentPosition: Long,
     duration: Long,
     progress: Float,
@@ -266,20 +261,12 @@ fun FullscreenPlayerContent(
     videoTitle: String,
     onPlayPause: () -> Unit,
     onSeek: (Float) -> Unit,
+    onScrubbingChanged: (Boolean) -> Unit = {},
     onSeekBackward: () -> Unit,
     onSeekForward: () -> Unit,
     onBack: () -> Unit,
     onFullscreenToggle: () -> Unit,
     onSettings: () -> Unit,
-    onLoopToggle: () -> Unit,
-    showPipButton: Boolean = false,
-    onPipClick: () -> Unit = {},
-    showTimedCommentsButton: Boolean = false,
-    timedCommentsActive: Boolean = false,
-    onTimedCommentsToggle: () -> Unit = {},
-    showCommentsButton: Boolean = false,
-    commentsActive: Boolean = false,
-    onCommentsToggle: () -> Unit = {},
     chapters: List<VideoChapter> = emptyList(),
     onOpenChapters: () -> Unit = {},
     captionsActive: Boolean = false,
@@ -295,10 +282,7 @@ fun FullscreenPlayerContent(
     hasNextInQueue: Boolean = false,
     onPreviousInQueue: () -> Unit = {},
     onNextInQueue: () -> Unit = {},
-    onOpenQueue: () -> Unit = {},
     isLive: Boolean = false,
-    liveChatActive: Boolean = false,
-    onLiveChatToggle: () -> Unit = {},
     /** Jump to the live edge of the DVR window. */
     onSeekToLive: () -> Unit = {},
     /**
@@ -323,12 +307,10 @@ fun FullscreenPlayerContent(
 ) {
     // Stable shapes to prevent "square flash"
     val stableShapes = IconButtonDefaults.shapes()
-    var showMoreControls by remember { mutableStateOf(false) }
 
     // The top-bar actions, defined once and placed either beside the title or
-    // on a line of their own. Landscape has width for one row and portrait
-    // does not, and the alternative to hoisting them is the same five buttons
-    // written twice.
+    // on a line of their own. Only immediate viewing controls live over the
+    // moving frame; everything secondary is in Playback settings.
     val topBarActions: @Composable RowScope.() -> Unit = {
         FilledTonalIconButton(
             onClick = onCaptionsClick,
@@ -353,49 +335,6 @@ fun FullscreenPlayerContent(
             shapes = stableShapes
         ) {
             Icon(Icons.Rounded.Settings, "Playback settings")
-        }
-
-        if (showPipButton) {
-            FilledTonalIconButton(
-                onClick = onPipClick,
-                colors = IconButtonDefaults.filledTonalIconButtonColors(
-                    containerColor = Color.Black.copy(0.5f),
-                    contentColor = Color.White
-                ),
-                shapes = stableShapes
-            ) {
-                Icon(Icons.Rounded.PictureInPictureAlt, "Picture in picture")
-            }
-        }
-
-        Box {
-            FilledTonalIconButton(
-                onClick = { showMoreControls = true },
-                colors = IconButtonDefaults.filledTonalIconButtonColors(
-                    containerColor = Color.Black.copy(0.5f),
-                    contentColor = Color.White
-                ),
-                shapes = stableShapes
-            ) {
-                Icon(Icons.Rounded.MoreVert, "More playback controls")
-            }
-            PlayerOverflowMenu(
-                expanded = showMoreControls,
-                onDismiss = { showMoreControls = false },
-                isLooping = isLooping,
-                onLoopToggle = onLoopToggle,
-                showQueue = showQueueControls,
-                onOpenQueue = onOpenQueue,
-                showTimedComments = showTimedCommentsButton && !isLive,
-                timedCommentsActive = timedCommentsActive,
-                onTimedCommentsToggle = onTimedCommentsToggle,
-                showComments = showCommentsButton,
-                commentsActive = commentsActive,
-                onCommentsToggle = onCommentsToggle,
-                showLiveChat = isLive,
-                liveChatActive = liveChatActive,
-                onLiveChatToggle = onLiveChatToggle
-            )
         }
 
         FilledIconButton(
@@ -630,7 +569,7 @@ fun FullscreenPlayerContent(
                         .padding(horizontal = 24.dp, vertical = 18.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    if (chapters.isNotEmpty() || showCommentsButton) {
+                    if (chapters.isNotEmpty()) {
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             verticalAlignment = Alignment.CenterVertically
@@ -643,34 +582,6 @@ fun FullscreenPlayerContent(
                                 )
                             }
                             Spacer(Modifier.weight(1f))
-                            if (showCommentsButton) {
-                                Surface(
-                                    onClick = onCommentsToggle,
-                                    shape = CircleShape,
-                                    color = if (commentsActive) {
-                                        MaterialTheme.colorScheme.primary.copy(alpha = 0.92f)
-                                    } else Color.Black.copy(alpha = 0.46f),
-                                    contentColor = if (commentsActive) {
-                                        MaterialTheme.colorScheme.onPrimary
-                                    } else Color.White
-                                ) {
-                                    Row(
-                                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 9.dp),
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        horizontalArrangement = Arrangement.spacedBy(7.dp)
-                                    ) {
-                                        Icon(
-                                            Icons.AutoMirrored.Rounded.Comment,
-                                            contentDescription = null,
-                                            modifier = Modifier.size(19.dp)
-                                        )
-                                        Text(
-                                            if (commentsActive) "Close comments" else "Comments",
-                                            style = MaterialTheme.typography.labelLarge
-                                        )
-                                    }
-                                }
-                            }
                         }
                     }
                     Row(
@@ -686,6 +597,7 @@ fun FullscreenPlayerContent(
                         }
 
                         PlayerSeekBar(
+                            mediaId = videoId,
                             progress = progress,
                             bufferedProgress = bufferedProgress,
                             onSeek = onSeek,
@@ -693,6 +605,8 @@ fun FullscreenPlayerContent(
                             chapters = chapters,
                             durationMs = duration,
                             seekPreview = seekPreview,
+                            showSeekPreview = !isLive,
+                            onScrubbingChanged = onScrubbingChanged,
                         )
 
                         if (isLive) {
@@ -717,6 +631,7 @@ fun FullscreenPlayerContent(
 @Composable
 fun PortraitPlayerContent(
     exoPlayer: ExoPlayer,
+    videoId: String,
     showControls: Boolean,
     onToggleControls: () -> Unit,
     hasError: Boolean,
@@ -724,7 +639,6 @@ fun PortraitPlayerContent(
     isLoading: Boolean,
     isBuffering: Boolean,
     isPlaying: Boolean,
-    isLooping: Boolean,
     currentPosition: Long,
     duration: Long,
     progress: Float,
@@ -733,15 +647,12 @@ fun PortraitPlayerContent(
     videoTitle: String,
     onPlayPause: () -> Unit,
     onSeek: (Float) -> Unit,
+    onScrubbingChanged: (Boolean) -> Unit = {},
     onSeekBackward: () -> Unit,
     onSeekForward: () -> Unit,
     onBack: () -> Unit,
     onFullscreenToggle: () -> Unit,
     onSettings: () -> Unit,
-    onLoopToggle: () -> Unit,
-    showTimedCommentsButton: Boolean = false,
-    timedCommentsActive: Boolean = false,
-    onTimedCommentsToggle: () -> Unit = {},
     chapters: List<VideoChapter> = emptyList(),
     onOpenChapters: () -> Unit = {},
     captionsActive: Boolean = false,
@@ -759,8 +670,6 @@ fun PortraitPlayerContent(
      * the full-bleed layout is built around live chat with nothing to say on a
      * finished video.
      */
-    showVerticalLiveButton: Boolean = false,
-    onVerticalLiveClick: () -> Unit = {},
     /**
      * Playlist transport. Composed only while a queue is running - see
      * [QueueSkipButton].
@@ -770,8 +679,6 @@ fun PortraitPlayerContent(
     hasNextInQueue: Boolean = false,
     onPreviousInQueue: () -> Unit = {},
     onNextInQueue: () -> Unit = {},
-    showPipButton: Boolean = false,
-    onPipClick: () -> Unit = {},
     minimizeDragEnabled: Boolean = false,
     onMinimizeDragDelta: (Float) -> Unit = {},
     onMinimizeDragRelease: (Float) -> Unit = {},
@@ -779,7 +686,6 @@ fun PortraitPlayerContent(
 ) {
     // Stable shapes
     val stableShapes = IconButtonDefaults.shapes()
-    var showMoreControls by remember { mutableStateOf(false) }
 
     // Speed captured when a hold-to-2x begins, restored when the finger lifts
     var speedBeforeBoost by remember { mutableFloatStateOf(1f) }
@@ -894,31 +800,6 @@ fun PortraitPlayerContent(
                         ) {
                             Icon(Icons.Rounded.Settings, "Playback settings")
                         }
-                        Box {
-                            FilledTonalIconButton(
-                                onClick = { showMoreControls = true },
-                                colors = IconButtonDefaults.filledTonalIconButtonColors(
-                                    containerColor = Color.Black.copy(0.5f),
-                                    contentColor = Color.White
-                                ),
-                                shapes = stableShapes
-                            ) {
-                                Icon(Icons.Rounded.MoreVert, "More playback controls")
-                            }
-                            PlayerOverflowMenu(
-                                expanded = showMoreControls,
-                                onDismiss = { showMoreControls = false },
-                                isLooping = isLooping,
-                                onLoopToggle = onLoopToggle,
-                                showTimedComments = showTimedCommentsButton && !isLive,
-                                timedCommentsActive = timedCommentsActive,
-                                onTimedCommentsToggle = onTimedCommentsToggle,
-                                showPip = showPipButton,
-                                onPipClick = onPipClick,
-                                showVerticalLive = showVerticalLiveButton,
-                                onVerticalLiveClick = onVerticalLiveClick
-                            )
-                        }
                         FilledIconButton(
                             onClick = onFullscreenToggle,
                             colors = IconButtonDefaults.filledIconButtonColors(
@@ -983,6 +864,7 @@ fun PortraitPlayerContent(
                         }
 
                         PlayerSeekBar(
+                            mediaId = videoId,
                             progress = progress,
                             bufferedProgress = bufferedProgress,
                             onSeek = onSeek,
@@ -990,6 +872,8 @@ fun PortraitPlayerContent(
                             chapters = chapters,
                             durationMs = duration,
                             seekPreview = seekPreview,
+                            showSeekPreview = !isLive,
+                            onScrubbingChanged = onScrubbingChanged,
                         )
 
                         if (isLive) {
@@ -1015,6 +899,12 @@ fun PortraitPlayerContent(
  * is genuinely behind.
  */
 internal const val LIVE_EDGE_THRESHOLD = 0.995f
+
+/** Time distance close enough to confirm that the position poll observed a seek. */
+private const val SEEK_CONFIRM_TOLERANCE_MS = 1_000f
+
+/** Backstop for failed or heavily rounded seeks; prevents a stale optimistic thumb. */
+private const val SEEK_COMMIT_TIMEOUT_MS = 1_500L
 
 /**
  * The "LIVE" marker where a normal video shows its duration. Red and tappable
@@ -1077,6 +967,7 @@ internal fun LiveEdgeChip(
  */
 @Composable
 internal fun PlayerSeekBar(
+    mediaId: String,
     progress: Float,
     onSeek: (Float) -> Unit,
     modifier: Modifier = Modifier,
@@ -1084,10 +975,39 @@ internal fun PlayerSeekBar(
     chapters: List<VideoChapter> = emptyList(),
     durationMs: Long = 0L,
     seekPreview: VideoSeekPreview? = null,
+    showSeekPreview: Boolean = true,
+    onScrubbingChanged: (Boolean) -> Unit = {},
     onTonalSurface: Boolean = false
 ) {
-    var isScrubbing by remember { mutableStateOf(false) }
-    var scrubValue by remember { mutableFloatStateOf(0f) }
+    var isScrubbing by remember(mediaId) { mutableStateOf(false) }
+    var scrubValue by remember(mediaId) { mutableFloatStateOf(0f) }
+    var committedSeekValue by remember(mediaId) { mutableStateOf<Float?>(null) }
+    val currentScrubbingChanged by rememberUpdatedState(onScrubbingChanged)
+    val externalProgress = progress.coerceIn(0f, 1f)
+    val displayedProgress = when {
+        isScrubbing -> scrubValue
+        committedSeekValue != null -> committedSeekValue ?: externalProgress
+        else -> externalProgress
+    }
+
+    // A seek changes ExoPlayer immediately, but the StateFlow feeding this
+    // composable is sampled twice a second. Hold the committed value until the
+    // poll catches up so the thumb never flashes back to the pre-seek position.
+    LaunchedEffect(externalProgress, mediaId) {
+        val target = committedSeekValue ?: return@LaunchedEffect
+        val distanceMs = abs(externalProgress - target) * durationMs.toFloat()
+        if (distanceMs <= SEEK_CONFIRM_TOLERANCE_MS) {
+            committedSeekValue = null
+        }
+    }
+    LaunchedEffect(committedSeekValue, mediaId) {
+        val target = committedSeekValue ?: return@LaunchedEffect
+        delay(SEEK_COMMIT_TIMEOUT_MS)
+        if (committedSeekValue == target) committedSeekValue = null
+    }
+    DisposableEffect(mediaId) {
+        onDispose { currentScrubbingChanged(false) }
+    }
 
     val bufferedColor = if (onTonalSurface) {
         MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f)
@@ -1104,45 +1024,84 @@ internal fun PlayerSeekBar(
     } else {
         Color.Black.copy(alpha = 0.85f)
     }
+    val sliderColors = SliderDefaults.colors(
+        thumbColor = MaterialTheme.colorScheme.primary,
+        activeTrackColor = MaterialTheme.colorScheme.primary,
+        inactiveTrackColor = inactiveTrackColor
+    )
 
-    BoxWithConstraints(modifier = modifier) {
-        // Buffered-ahead indicator: a soft white bar from the start to the
-        // buffered position, drawn under the Slider. The inactive track is
-        // translucent, so the buffered region reads as a brighter segment
-        // ahead of the playhead (YouTube-style) while the opaque active
-        // track covers the part already played.
-        if (bufferedProgress > 0f) {
-            Canvas(modifier = Modifier.matchParentSize()) {
-                val centerY = size.height / 2f
-                drawLine(
-                    color = bufferedColor,
-                    start = Offset(0f, centerY),
-                    end = Offset(bufferedProgress.coerceIn(0f, 1f) * size.width, centerY),
-                    strokeWidth = 4.dp.toPx(),
-                    cap = StrokeCap.Round
-                )
-            }
-        }
-
+    // Keep the control's measured height identical before and during a drag.
+    // The preview is an overlay: its negative offset changes where it draws,
+    // not the space the bottom controls reserve for this seek bar.
+    BoxWithConstraints(modifier = modifier.height(48.dp)) {
         Slider(
-            value = if (isScrubbing) scrubValue else progress.coerceIn(0f, 1f),
+            value = displayedProgress,
             onValueChange = {
-                isScrubbing = true
+                if (!isScrubbing) {
+                    isScrubbing = true
+                    committedSeekValue = null
+                    onScrubbingChanged(true)
+                }
                 scrubValue = it
             },
             onValueChangeFinished = {
-                onSeek(scrubValue)
+                if (isScrubbing) {
+                    val target = scrubValue.coerceIn(0f, 1f)
+                    committedSeekValue = target
+                    onSeek(target)
+                }
                 isScrubbing = false
+                onScrubbingChanged(false)
             },
-            colors = SliderDefaults.colors(
-                thumbColor = MaterialTheme.colorScheme.primary,
-                activeTrackColor = MaterialTheme.colorScheme.primary,
-                inactiveTrackColor = inactiveTrackColor
-            ),
+            enabled = durationMs > 0L,
+            colors = sliderColors,
+            track = { sliderState ->
+                // The track slot is measured to the slider's actual travel
+                // width and placed half a thumb in from either edge. Drawing
+                // buffer and chapter marks here keeps them on the same geometry
+                // as the gesture, instead of using the wider 48dp touch target.
+                Box {
+                    SliderDefaults.Track(
+                        sliderState = sliderState,
+                        enabled = durationMs > 0L,
+                        colors = sliderColors,
+                    )
+                    Canvas(modifier = Modifier.matchParentSize()) {
+                        val centerY = size.height / 2f
+                        val buffered = bufferedProgress.coerceIn(0f, 1f)
+                        if (buffered > displayedProgress) {
+                            drawLine(
+                                color = bufferedColor,
+                                start = Offset(displayedProgress * size.width, centerY),
+                                end = Offset(buffered * size.width, centerY),
+                                strokeWidth = 4.dp.toPx(),
+                                cap = StrokeCap.Round,
+                            )
+                        }
+
+                        if (chapters.size > 1 && durationMs > 0L) {
+                            val half = 5.dp.toPx()
+                            val stroke = 2.5.dp.toPx()
+                            chapters.forEach { chapter ->
+                                val fraction = chapter.startMs.toFloat() / durationMs.toFloat()
+                                if (fraction > 0.001f && fraction < 0.999f) {
+                                    val x = fraction * size.width
+                                    drawLine(
+                                        color = tickColor,
+                                        start = Offset(x, centerY - half),
+                                        end = Offset(x, centerY + half),
+                                        strokeWidth = stroke,
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             modifier = Modifier.fillMaxWidth()
         )
 
-        if (isScrubbing && durationMs > 0L) {
+        if (showSeekPreview && isScrubbing && durationMs > 0L) {
             val previewWidth = if (seekPreview?.isUsable == true) 144.dp else 72.dp
             val previewX = (maxWidth * scrubValue - previewWidth / 2)
                 .coerceIn(0.dp, (maxWidth - previewWidth).coerceAtLeast(0.dp))
@@ -1152,30 +1111,14 @@ internal fun PlayerSeekBar(
                 modifier = Modifier
                     .align(Alignment.TopStart)
                     .offset(x = previewX, y = if (seekPreview?.isUsable == true) (-126).dp else (-46).dp)
+                    // Measure the card at its natural size, but report only the
+                    // seek bar's fixed bounds to the parent. Without this, the
+                    // 108dp storyboard card makes the whole bottom row taller
+                    // and visibly pushes the slider upward as dragging begins.
+                    .wrapContentSize(Alignment.TopStart, unbounded = true)
             )
         }
 
-        // Chapter boundary ticks drawn over the track. Purely decorative; the
-        // Canvas has no pointer input so touches still reach the Slider.
-        if (chapters.size > 1 && durationMs > 0) {
-            Canvas(modifier = Modifier.matchParentSize()) {
-                val centerY = size.height / 2f
-                val half = 5.dp.toPx()
-                val stroke = 2.5.dp.toPx()
-                chapters.forEach { chapter ->
-                    val fraction = chapter.startMs.toFloat() / durationMs.toFloat()
-                    if (fraction > 0.001f && fraction < 0.999f) {
-                        val x = fraction * size.width
-                        drawLine(
-                            color = tickColor,
-                            start = Offset(x, centerY - half),
-                            end = Offset(x, centerY + half),
-                            strokeWidth = stroke
-                        )
-                    }
-                }
-            }
-        }
     }
 }
 
@@ -1241,6 +1184,7 @@ private fun SeekPreviewCard(
                         // The sprite must retain its full grid dimensions; the
                         // clipped parent is the viewport onto the selected cell.
                         modifier = Modifier
+                            .wrapContentSize(Alignment.TopStart, unbounded = true)
                             .requiredSize(
                                 frameWidth * preview.framesPerPageX,
                                 frameHeight * preview.framesPerPageY,
@@ -2332,137 +2276,6 @@ fun VideoInfoSection(
                     }
                 }
             }
-        }
-    }
-}
-
-/**
- * Secondary playback actions shared by inline and fullscreen chrome.
- *
- * Keeping these as labeled rows preserves every capability without asking a
- * viewer to decode a wall of equally weighted icons over the video. Selected
- * states retain both icon and color cues, while the menu itself provides the
- * stable tonal surface that moving frames cannot.
- */
-@Composable
-private fun PlayerOverflowMenu(
-    expanded: Boolean,
-    onDismiss: () -> Unit,
-    isLooping: Boolean,
-    onLoopToggle: () -> Unit,
-    showQueue: Boolean = false,
-    onOpenQueue: () -> Unit = {},
-    showTimedComments: Boolean = false,
-    timedCommentsActive: Boolean = false,
-    onTimedCommentsToggle: () -> Unit = {},
-    showComments: Boolean = false,
-    commentsActive: Boolean = false,
-    onCommentsToggle: () -> Unit = {},
-    showLiveChat: Boolean = false,
-    liveChatActive: Boolean = false,
-    onLiveChatToggle: () -> Unit = {},
-    showPip: Boolean = false,
-    onPipClick: () -> Unit = {},
-    showVerticalLive: Boolean = false,
-    onVerticalLiveClick: () -> Unit = {}
-) {
-    fun runAndDismiss(action: () -> Unit) {
-        onDismiss()
-        action()
-    }
-
-    DropdownMenu(
-        expanded = expanded,
-        onDismissRequest = onDismiss,
-        shape = RoundedCornerShape(12.dp),
-        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
-    ) {
-        if (showQueue) {
-            DropdownMenuItem(
-                text = { Text("Playlist queue") },
-                leadingIcon = {
-                    Icon(Icons.AutoMirrored.Rounded.PlaylistPlay, contentDescription = null)
-                },
-                onClick = { runAndDismiss(onOpenQueue) }
-            )
-        }
-        DropdownMenuItem(
-            text = { Text(if (isLooping) "Loop video on" else "Loop video") },
-            leadingIcon = {
-                Icon(
-                    Icons.Rounded.RepeatOne,
-                    contentDescription = null,
-                    tint = if (isLooping) MaterialTheme.colorScheme.primary
-                        else MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            },
-            trailingIcon = if (isLooping) {
-                { Icon(Icons.Rounded.CheckCircle, contentDescription = "Enabled") }
-            } else null,
-            onClick = { runAndDismiss(onLoopToggle) }
-        )
-        if (showTimedComments) {
-            DropdownMenuItem(
-                text = {
-                    Text(if (timedCommentsActive) "Timed comments on" else "Timed comments")
-                },
-                leadingIcon = {
-                    Icon(
-                        Icons.AutoMirrored.Rounded.Comment,
-                        contentDescription = null,
-                        tint = if (timedCommentsActive) MaterialTheme.colorScheme.primary
-                            else MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                },
-                trailingIcon = if (timedCommentsActive) {
-                    { Icon(Icons.Rounded.CheckCircle, contentDescription = "Enabled") }
-                } else null,
-                onClick = { runAndDismiss(onTimedCommentsToggle) }
-            )
-        }
-        if (showComments) {
-            DropdownMenuItem(
-                text = { Text(if (commentsActive) "Close comments" else "Browse comments") },
-                leadingIcon = {
-                    Icon(
-                        Icons.AutoMirrored.Rounded.Comment,
-                        contentDescription = null,
-                        tint = if (commentsActive) MaterialTheme.colorScheme.primary
-                            else MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                },
-                trailingIcon = if (commentsActive) {
-                    { Icon(Icons.Rounded.CheckCircle, contentDescription = "Open") }
-                } else null,
-                onClick = { runAndDismiss(onCommentsToggle) }
-            )
-        }
-        if (showLiveChat) {
-            DropdownMenuItem(
-                text = { Text(if (liveChatActive) "Hide live chat" else "Show live chat") },
-                leadingIcon = {
-                    Icon(Icons.AutoMirrored.Rounded.Chat, contentDescription = null)
-                },
-                onClick = { runAndDismiss(onLiveChatToggle) }
-            )
-        }
-        if (showPip) {
-            DropdownMenuItem(
-                text = { Text("Picture in picture") },
-                leadingIcon = {
-                    Icon(Icons.Rounded.PictureInPictureAlt, contentDescription = null)
-                },
-                onClick = { runAndDismiss(onPipClick) }
-            )
-        }
-        if (showVerticalLive) {
-            DropdownMenuItem(
-                text = { Text("Vertical live view") },
-                leadingIcon = {
-                    Icon(Icons.Rounded.StayCurrentPortrait, contentDescription = null)
-                },
-                onClick = { runAndDismiss(onVerticalLiveClick) }
-            )
         }
     }
 }

--- a/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/ivor/ivormusic/ui/video/VideoPlayerViewModel.kt
@@ -40,6 +40,7 @@ import com.ivor.ivormusic.data.VttCue
 import com.ivor.ivormusic.data.YouTubeRepository
 import com.ivor.ivormusic.data.ThemePreferences
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
@@ -55,6 +56,30 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+
+internal enum class VideoEndAction {
+    STOP,
+    NEXT_IN_QUEUE,
+    NEXT_RELATED
+}
+
+/**
+ * Resolves one completed video into exactly one outcome. Keeping this decision
+ * free of ExoPlayer makes the precedence explicit and unit-testable: autoplay
+ * is the master gate, a user-chosen playlist beats recommendations, and PiP
+ * may continue that playlist but never wanders into related videos.
+ */
+internal fun resolveVideoEndAction(
+    autoplayEnabled: Boolean,
+    queueHasNext: Boolean,
+    isInPipMode: Boolean,
+    hasRelatedVideo: Boolean
+): VideoEndAction = when {
+    !autoplayEnabled -> VideoEndAction.STOP
+    queueHasNext -> VideoEndAction.NEXT_IN_QUEUE
+    !isInPipMode && hasRelatedVideo -> VideoEndAction.NEXT_RELATED
+    else -> VideoEndAction.STOP
+}
 
 @UnstableApi
 class VideoPlayerViewModel(application: android.app.Application) : AndroidViewModel(application) {
@@ -122,6 +147,15 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
     val bufferedProgress: StateFlow<Float> = _bufferedProgress
 
     private var progressJob: Job? = null
+
+    // Initial stream resolution and watch-next metadata belong to one specific
+    // startVideo invocation. Cancellation handles the normal case; the
+    // generation check is still required because NewPipe's blocking fetch can
+    // finish after cancellation and because a forced retry can reuse the same
+    // video id.
+    private var streamLoadJob: Job? = null
+    private var watchNextJob: Job? = null
+    private var videoLoadGeneration = 0L
 
     // Qualities and Related
     private val _availableQualities = MutableStateFlow<List<VideoQuality>>(emptyList())
@@ -281,9 +315,16 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         _isInPipMode = inPip
     }
 
-    // Repeat sticks across videos and app restarts, so seed it from prefs
-    // rather than defaulting to off on every player creation.
-    private val _isLooping = MutableStateFlow(themePreferences.isVideoRepeatEnabled())
+    // End-of-video behavior sticks across videos and app restarts. Autoplay is
+    // the master gate: when it is off, a stored repeat flag is ignored and
+    // normalized away during init so the UI and ExoPlayer cannot disagree.
+    private val _isAutoplayEnabled =
+        MutableStateFlow(themePreferences.isVideoAutoplayEnabled())
+    val isAutoplayEnabled: StateFlow<Boolean> = _isAutoplayEnabled.asStateFlow()
+
+    private val _isLooping = MutableStateFlow(
+        _isAutoplayEnabled.value && themePreferences.isVideoRepeatEnabled()
+    )
     val isLooping: StateFlow<Boolean> = _isLooping.asStateFlow()
 
     private val _playbackSpeed = MutableStateFlow(1f)
@@ -526,6 +567,10 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
     init {
         observeProfileSwitches()
 
+        if (!_isAutoplayEnabled.value && themePreferences.isVideoRepeatEnabled()) {
+            themePreferences.setVideoRepeatEnabled(false)
+        }
+
         // Near-instant first frame (~1s buffered) plus an aggressive
         // read-ahead: up to 5 minutes (min == max: continuous top-up),
         // hard-capped at 200MB of sample RAM so high-bitrate 4K streams
@@ -603,36 +648,41 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
                         queueErrorSkipCount = 0
                     }
                     if (playbackState == Player.STATE_ENDED) {
-                        // Repeat and auto-play are mutually exclusive: looping
-                        // repeats the current video, otherwise playback moves on.
-                        if (!_isLooping.value) {
-                            val activeQueue = _queue.value
-                            when {
-                                // A playlist is the strongest statement of what
-                                // to play next there is, so it beats the
-                                // recommendations outright - and it advances in
-                                // PiP too. The rule below about staying on the
-                                // video the user put in the window is about not
-                                // wandering off into recommendations; a queue
-                                // the user built by opening a playlist is
-                                // exactly where they meant to go.
-                                activeQueue != null && activeQueue.hasNext && _exoPlayer != null ->
-                                    viewModelScope.launch { playQueueIndex(activeQueue.index + 1) }
+                        // Repeat-one normally prevents STATE_ENDED entirely.
+                        // The guard keeps a transient player/state mismatch
+                        // from advancing away from a video meant to loop.
+                        if (_isLooping.value) return
 
-                                // Off the end of the playlist (or never in one):
-                                // fall back to the related video, suppressed
-                                // during PiP so the user returns to the video
-                                // they put there.
-                                !_isInPipMode -> {
-                                    // The filtered list, not the raw one:
-                                    // auto-playing a video the user just said
-                                    // "not interested" to is the single most
-                                    // annoying way to get this wrong.
-                                    val nextVideo = relatedVideos.value.firstOrNull()
-                                    // Guard: ensure ViewModel/player is still valid before launching
-                                    if (nextVideo != null && _exoPlayer != null) {
-                                        viewModelScope.launch { playVideo(nextVideo) }
-                                    }
+                        val activeQueue = _queue.value
+                        val nextRelated = relatedVideos.value.firstOrNull()
+                        when (
+                            resolveVideoEndAction(
+                                autoplayEnabled = _isAutoplayEnabled.value,
+                                queueHasNext = activeQueue?.hasNext == true,
+                                isInPipMode = _isInPipMode,
+                                hasRelatedVideo = nextRelated != null
+                            )
+                        ) {
+                            VideoEndAction.STOP -> {
+                                // STATE_ENDED is not always exposed as paused
+                                // by media controls. Clear playWhenReady so the
+                                // UI, PiP and notification all agree it stopped.
+                                _exoPlayer?.pause()
+                            }
+
+                            VideoEndAction.NEXT_IN_QUEUE -> {
+                                if (activeQueue != null && _exoPlayer != null) {
+                                    viewModelScope.launch { playQueueIndex(activeQueue.index + 1) }
+                                }
+                            }
+
+                            VideoEndAction.NEXT_RELATED -> {
+                                // Use the filtered list: autoplaying something
+                                // the viewer marked not interested is worse than
+                                // stopping. The resolver already suppresses this
+                                // branch while PiP is active.
+                                if (nextRelated != null && _exoPlayer != null) {
+                                    viewModelScope.launch { playVideo(nextRelated) }
                                 }
                             }
                         }
@@ -1082,10 +1132,26 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         }
     }
 
+    fun setAutoplayEnabled(enabled: Boolean) {
+        _isAutoplayEnabled.value = enabled
+        themePreferences.setVideoAutoplayEnabled(enabled)
+        if (!enabled) setLooping(false)
+    }
+
     fun toggleLooping() {
-        _isLooping.value = !_isLooping.value
-        _exoPlayer?.repeatMode = if (_isLooping.value) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
-        themePreferences.setVideoRepeatEnabled(_isLooping.value)
+        val enableLoop = !_isLooping.value
+        // A direct tap on Loop should work, not bounce against a disabled
+        // master setting. It opts back into end-of-video behavior explicitly.
+        if (enableLoop && !_isAutoplayEnabled.value) {
+            setAutoplayEnabled(true)
+        }
+        setLooping(enableLoop)
+    }
+
+    private fun setLooping(enabled: Boolean) {
+        _isLooping.value = enabled
+        _exoPlayer?.repeatMode = if (enabled) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
+        themePreferences.setVideoRepeatEnabled(enabled)
     }
 
     /** Set the playback speed for the current video. Resets to 1x on video change. */
@@ -1293,6 +1359,10 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
             return
         }
 
+        val loadGeneration = ++videoLoadGeneration
+        streamLoadJob?.cancel()
+        watchNextJob?.cancel()
+
         // Decide from the item, not merely from the queue that introduced it.
         // This keeps ad-hoc online items added after an offline download from
         // being mislabeled or having their network features suppressed.
@@ -1311,6 +1381,8 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         // Zero the progress for the new video rather than letting the previous
         // one's position sit in the seek bar until the first poll lands.
         resetProgress()
+        _availableQualities.value = emptyList()
+        _currentQuality.value = null
         _relatedVideos.value = emptyList() // Clear previous related
         _chapters.value = emptyList() // Clear previous chapters
         _seekPreview.value = null // Never show a frame from the previous video
@@ -1410,17 +1482,20 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
 
         // ========== PHASE 1: START PLAYBACK ASAP (fast) ==========
         // Uses lightweight getVideoStreamQualities() which ONLY fetches stream URLs
-        viewModelScope.launch {
+        streamLoadJob = viewModelScope.launch {
             try {
+                if (!isCurrentVideoLoad(video.videoId, loadGeneration)) return@launch
                 _exoPlayer?.stop()
                 _exoPlayer?.clearMediaItems()
                 
                 // Add timeout for stream fetching to prevent "stuck in buffering"
                 kotlinx.coroutines.withTimeout(15000L) {
                     // FAST: Get stream URLs only (no metadata, no related, no channel avatar)
-                    val qualities = youtubeRepository.getVideoStreamQualities(video.videoId)
+                    val streamResult = youtubeRepository.getVideoStreamResult(video.videoId)
+                    if (!isCurrentVideoLoad(video.videoId, loadGeneration)) return@withTimeout
+                    val qualities = streamResult.qualities
                     _availableQualities.value = qualities
-                    _seekPreview.value = youtubeRepository.getCachedSeekPreview(video.videoId)
+                    _seekPreview.value = streamResult.seekPreview
                     _isLive.value = qualities.any { it.isLive }
                     if (_isLive.value) {
                         // Some entry points do not know a broadcast is live
@@ -1446,10 +1521,11 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
                             // FORCE PLAY: Ensure we override any previous paused state
                             _exoPlayer?.play()
                         }
-                        _isLoading.value = false // ✅ Playback starting NOW!
+                        _isLoading.value = false // Playback is starting now.
                     } else {
                         // Fallback to legacy stream URL
                         val streamUrl = youtubeRepository.getVideoStreamUrl(video.videoId)
+                        if (!isCurrentVideoLoad(video.videoId, loadGeneration)) return@withTimeout
                         if (streamUrl != null) {
                             _currentQuality.value = VideoQuality(
                                 resolution = "Auto",
@@ -1475,12 +1551,18 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
                     }
                 }
             } catch (e: kotlinx.coroutines.TimeoutCancellationException) {
-                _playbackError.value = Exception("Connection timed out. Please check your internet.")
-                _isLoading.value = false
+                if (isCurrentVideoLoad(video.videoId, loadGeneration)) {
+                    _playbackError.value = Exception("Connection timed out. Please check your internet.")
+                    _isLoading.value = false
+                }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
-                e.printStackTrace()
-                _playbackError.value = e
-                _isLoading.value = false
+                if (isCurrentVideoLoad(video.videoId, loadGeneration)) {
+                    KLog.e("VideoPlayerVM", "Initial stream load failed for ${video.videoId}", e)
+                    _playbackError.value = e
+                    _isLoading.value = false
+                }
             }
         }
         
@@ -1488,11 +1570,11 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         // One watch-next call answers all three (the old code paid for an
         // engagement /next call AND a full NewPipe extraction here, competing
         // with Phase 1's initial buffering for bandwidth).
-        viewModelScope.launch {
+        watchNextJob = viewModelScope.launch {
             try {
                 val watchNext = youtubeRepository.getWatchNextData(video.videoId, video)
                 // Guard against a video switch that happened mid-flight
-                if (_currentVideo.value?.videoId != video.videoId) return@launch
+                if (!isCurrentVideoLoad(video.videoId, loadGeneration)) return@launch
                 _engagement.value = watchNext.engagement
                 if (watchNext.updatedVideoItem != null) {
                     val wasNameless = _currentVideo.value?.title.isNullOrBlank()
@@ -1511,9 +1593,13 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
                 // Opening the chat panel now costs one poll instead of a second
                 // watch-next round trip plus its parse.
                 liveChatContinuation = watchNext.liveChatContinuation
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 // Phase 2 errors are non-critical - playback already started
-                KLog.w("VideoPlayerVM", "Failed to load watch-next data", e)
+                if (isCurrentVideoLoad(video.videoId, loadGeneration)) {
+                    KLog.w("VideoPlayerVM", "Failed to load watch-next data", e)
+                }
             }
         }
         
@@ -1542,6 +1628,9 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
             }
         }
     }
+
+    private fun isCurrentVideoLoad(videoId: String, generation: Long): Boolean =
+        videoLoadGeneration == generation && _currentVideo.value?.videoId == videoId
 
     /**
      * Pick the starting quality based on the Settings preference for the
@@ -1846,6 +1935,11 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         if (_isPlaying.value) {
             _exoPlayer?.pause()
         } else {
+            // After autoplay deliberately stops at the end, Play means replay
+            // this video. ExoPlayer does not leave STATE_ENDED on play() alone.
+            if (_exoPlayer?.playbackState == Player.STATE_ENDED) {
+                _exoPlayer?.seekToDefaultPosition()
+            }
             _exoPlayer?.play()
         }
     }
@@ -2559,6 +2653,10 @@ class VideoPlayerViewModel(application: android.app.Application) : AndroidViewMo
         qualityChangeListener = null
         sourceRecoveryJob?.cancel()
         sourceRecoveryJob = null
+        streamLoadJob?.cancel()
+        streamLoadJob = null
+        watchNextJob?.cancel()
+        watchNextJob = null
         progressJob?.cancel()
         progressJob = null
         stopLivePolling()

--- a/app/src/test/java/com/ivor/ivormusic/data/DownloadedAudioMetadataTest.kt
+++ b/app/src/test/java/com/ivor/ivormusic/data/DownloadedAudioMetadataTest.kt
@@ -1,0 +1,72 @@
+package com.ivor.ivormusic.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class DownloadedAudioMetadataTest {
+
+    @Test
+    fun plainLyricsRemainPlainAndCollapseEmbeddedNewlines() {
+        val lyrics = success(
+            LyricsSyncType.PLAIN,
+            LrcLine(-1L, " First\nline "),
+            LrcLine(-1L, ""),
+            LrcLine(-1L, "Second line")
+        )
+
+        val serialized = lyrics.toDownloadLyrics()
+        val parsed = LyricsParser.parse(serialized)
+
+        assertEquals("First line\nSecond line", serialized)
+        assertNotNull(parsed)
+        assertEquals(LyricsSyncType.PLAIN, parsed!!.syncType)
+        assertEquals(listOf("First line", "Second line"), parsed.lines.map { it.text })
+    }
+
+    @Test
+    fun lineSyncedLyricsRoundTripThroughLrc() {
+        val lyrics = success(
+            LyricsSyncType.LINE,
+            LrcLine(1_230L, "Opening line"),
+            LrcLine(3_661_990L, "Past an hour")
+        )
+
+        val serialized = lyrics.toDownloadLyrics()
+        val parsed = LyricsParser.parse(serialized)
+
+        assertEquals("[00:01.23]Opening line\n[61:01.99]Past an hour", serialized)
+        assertNotNull(parsed)
+        assertEquals(LyricsSyncType.LINE, parsed!!.syncType)
+        assertEquals(listOf(1_230L, 3_661_990L), parsed.lines.map { it.timeMs })
+        assertEquals(listOf("Opening line", "Past an hour"), parsed.lines.map { it.text })
+    }
+
+    @Test
+    fun wordSyncedLyricsRoundTripThroughEnhancedLrc() {
+        val lyrics = success(
+            LyricsSyncType.WORD,
+            LrcLine(
+                timeMs = 10_000L,
+                text = "Hello world",
+                contentSpans = listOf(
+                    LrcContentSpan(10_000L, "Hello ", 500L),
+                    LrcContentSpan(10_500L, "world", 500L)
+                )
+            )
+        )
+
+        val serialized = lyrics.toDownloadLyrics()
+        val parsed = LyricsParser.parse(serialized)
+
+        assertEquals("[00:10.00]<00:10.00>Hello <00:10.50>world", serialized)
+        assertNotNull(parsed)
+        assertEquals(LyricsSyncType.WORD, parsed!!.syncType)
+        assertEquals("Hello world", parsed.lines.single().text)
+        assertEquals(listOf(10_000L, 10_500L), parsed.lines.single().contentSpans.map { it.timeMs })
+        assertEquals(listOf("Hello ", "world"), parsed.lines.single().contentSpans.map { it.text })
+    }
+
+    private fun success(syncType: LyricsSyncType, vararg lines: LrcLine) =
+        LyricsResult.Success(lines.toList(), "test", syncType)
+}

--- a/app/src/test/java/com/ivor/ivormusic/data/LocalLyricsSourceTest.kt
+++ b/app/src/test/java/com/ivor/ivormusic/data/LocalLyricsSourceTest.kt
@@ -49,6 +49,40 @@ class LocalLyricsSourceTest {
     }
 
     @Test
+    fun downloadedSidecarWorksWithoutAFilePathAndWinsOverEmbeddedLyrics() {
+        var embeddedRead = false
+        val source = LocalLyricsSource(
+            sharedSidecarReader = { "[00:01.00]Downloaded line" },
+            sharedEmbeddedLyricsReader = {
+                embeddedRead = true
+                "Embedded line"
+            }
+        )
+        val song = localSong(temporaryFolder.newFile("unused.m4a")).copy(filePath = null)
+
+        val result = source.find(song)!!
+
+        assertEquals("Downloaded LRC", result.provider)
+        assertEquals(LyricsSyncType.LINE, result.syncType)
+        assertEquals("Downloaded line", result.lines.single().text)
+        assertEquals(false, embeddedRead)
+    }
+
+    @Test
+    fun downloadedEmbeddedLyricsRecoverWhenTheSidecarIsMissing() {
+        val source = LocalLyricsSource(
+            sharedSidecarReader = { null },
+            sharedEmbeddedLyricsReader = { "Recovered from the M4A" }
+        )
+        val song = localSong(temporaryFolder.newFile("unused.m4a")).copy(filePath = null)
+
+        val result = source.find(song)!!
+
+        assertEquals("Embedded lyrics", result.provider)
+        assertEquals("Recovered from the M4A", result.lines.single().text)
+    }
+
+    @Test
     fun utf16SidecarsAreDecodedRatherThanShownAsGarbage() {
         val audio = temporaryFolder.newFile("Track.mp3")
         // What a Windows editor writes when asked for "Unicode": UTF-16LE

--- a/app/src/test/java/com/ivor/ivormusic/data/VideoSeekPreviewTest.kt
+++ b/app/src/test/java/com/ivor/ivormusic/data/VideoSeekPreviewTest.kt
@@ -1,0 +1,101 @@
+package com.ivor.ivormusic.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VideoSeekPreviewTest {
+
+    @Test
+    fun usabilityRequiresEveryMappingDimension() {
+        val valid = preview()
+
+        assertTrue(valid.isUsable)
+        assertFalse(valid.copy(pageUrls = emptyList()).isUsable)
+        assertFalse(valid.copy(frameWidthPx = 0).isUsable)
+        assertFalse(valid.copy(frameHeightPx = 0).isUsable)
+        assertFalse(valid.copy(framesPerPageX = 0).isUsable)
+        assertFalse(valid.copy(framesPerPageY = 0).isUsable)
+        assertFalse(valid.copy(totalFrameCount = 0).isUsable)
+        assertFalse(valid.copy(durationPerFrameMs = 0).isUsable)
+    }
+
+    @Test
+    fun negativePositionClampsToFirstFrame() {
+        assertFrame(preview().frameAt(-10_000L), page = 0, column = 0, row = 0)
+    }
+
+    @Test
+    fun positionMapsAcrossRowsAndSpritePages() {
+        val preview = preview()
+
+        // Four columns by three rows: frame 11 is the final cell on page 0.
+        assertFrame(preview.frameAt(11_999L), page = 0, column = 3, row = 2)
+        // The next millisecond bucket begins page 1 at its top-left cell.
+        assertFrame(preview.frameAt(12_000L), page = 1, column = 0, row = 0)
+        assertFrame(preview.frameAt(17_000L), page = 1, column = 1, row = 1)
+    }
+
+    @Test
+    fun exactFrameBoundarySelectsTheNewFrame() {
+        val preview = preview()
+
+        assertFrame(preview.frameAt(999L), page = 0, column = 0, row = 0)
+        assertFrame(preview.frameAt(1_000L), page = 0, column = 1, row = 0)
+    }
+
+    @Test
+    fun positionsPastDurationClampToLastDeclaredFrame() {
+        val preview = preview(totalFrameCount = 18)
+
+        assertFrame(preview.frameAt(Long.MAX_VALUE), page = 1, column = 1, row = 1)
+    }
+
+    @Test
+    fun incompleteLastPageNeverAddressesAnUndeclaredCell() {
+        val preview = preview(totalFrameCount = 14)
+
+        assertFrame(preview.frameAt(13_000L), page = 1, column = 1, row = 0)
+        assertFrame(preview.frameAt(99_000L), page = 1, column = 1, row = 0)
+    }
+
+    @Test
+    fun missingSpritePageReturnsNullInsteadOfUsingTheWrongPage() {
+        val preview = preview(pageUrls = listOf("page-0"), totalFrameCount = 18)
+
+        assertNull(preview.frameAt(12_000L))
+    }
+
+    @Test
+    fun invalidPreviewNeverProducesAFrame() {
+        assertNull(preview(durationPerFrameMs = 0).frameAt(0L))
+    }
+
+    private fun preview(
+        pageUrls: List<String> = listOf("page-0", "page-1"),
+        totalFrameCount: Int = 18,
+        durationPerFrameMs: Int = 1_000,
+    ) = VideoSeekPreview(
+        pageUrls = pageUrls,
+        frameWidthPx = 160,
+        frameHeightPx = 90,
+        framesPerPageX = 4,
+        framesPerPageY = 3,
+        totalFrameCount = totalFrameCount,
+        durationPerFrameMs = durationPerFrameMs,
+    )
+
+    private fun assertFrame(
+        actual: VideoSeekPreviewFrame?,
+        page: Int,
+        column: Int,
+        row: Int,
+    ) {
+        requireNotNull(actual)
+        assertEquals("page-$page", actual.pageUrl)
+        assertEquals(column, actual.column)
+        assertEquals(row, actual.row)
+    }
+}

--- a/app/src/test/java/com/ivor/ivormusic/ui/video/VideoPlaybackBehaviorTest.kt
+++ b/app/src/test/java/com/ivor/ivormusic/ui/video/VideoPlaybackBehaviorTest.kt
@@ -1,0 +1,85 @@
+package com.ivor.ivormusic.ui.video
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VideoPlaybackBehaviorTest {
+
+    @Test
+    fun `autoplay off always stops even when more content exists`() {
+        assertEquals(
+            VideoEndAction.STOP,
+            resolveVideoEndAction(
+                autoplayEnabled = false,
+                queueHasNext = true,
+                isInPipMode = false,
+                hasRelatedVideo = true
+            )
+        )
+    }
+
+    @Test
+    fun `playlist advances before related video`() {
+        assertEquals(
+            VideoEndAction.NEXT_IN_QUEUE,
+            resolveVideoEndAction(
+                autoplayEnabled = true,
+                queueHasNext = true,
+                isInPipMode = false,
+                hasRelatedVideo = true
+            )
+        )
+    }
+
+    @Test
+    fun `playlist may continue in picture in picture`() {
+        assertEquals(
+            VideoEndAction.NEXT_IN_QUEUE,
+            resolveVideoEndAction(
+                autoplayEnabled = true,
+                queueHasNext = true,
+                isInPipMode = true,
+                hasRelatedVideo = true
+            )
+        )
+    }
+
+    @Test
+    fun `related video is suppressed in picture in picture`() {
+        assertEquals(
+            VideoEndAction.STOP,
+            resolveVideoEndAction(
+                autoplayEnabled = true,
+                queueHasNext = false,
+                isInPipMode = true,
+                hasRelatedVideo = true
+            )
+        )
+    }
+
+    @Test
+    fun `related video plays when autoplay is on outside picture in picture`() {
+        assertEquals(
+            VideoEndAction.NEXT_RELATED,
+            resolveVideoEndAction(
+                autoplayEnabled = true,
+                queueHasNext = false,
+                isInPipMode = false,
+                hasRelatedVideo = true
+            )
+        )
+    }
+
+    @Test
+    fun `player stops when autoplay has no next item`() {
+        assertEquals(
+            VideoEndAction.STOP,
+            resolveVideoEndAction(
+                autoplayEnabled = true,
+                queueHasNext = false,
+                isInPipMode = false,
+                hasRelatedVideo = false
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add whole-playlist downloads for music and video, using the existing background queue with full playlist pagination, resumable missing-item batches, duplicate/local/live skips, and a stable per-batch video quality cap
- make music downloads portable AAC/M4A files with embedded title, artist, album, cover art and best-available lyrics, plus matching JPEG/LRC companions for Koda's offline UI
- preserve word-synced lyrics as Enhanced LRC, line timing as standard LRC and unsynchronised lyrics as plain text; missing artwork or lyrics does not discard valid audio
- add bounded storyboard seek previews, chapter-aware buffering, stable scrubbing behavior, and focused seek/end-of-playback unit coverage
- simplify the video chrome by moving secondary actions into the scroll-safe Playback settings surface
- add persistent Autoplay and coherent Loop behavior: Autoplay off stops at the current video's end and clears Loop

## Included branches

- `Develop` / `64f6c81` — video seeking and playback-control cleanup
- `feat/full-pllaylist-download` / `9d68f5b` — full playlist downloads
- `Develop` / `a7f48a3` — portable song metadata, artwork and offline lyrics

## Verification

- `./gradlew testDebugUnitTest assembleDebug`
- 33 unit tests passed, 0 failures
- debug APK assembled successfully
